### PR TITLE
feat(mjh): user-directed targeting — click a draft line to refine it

### DIFF
--- a/.github/workflows/ci-myjobhunter.yml
+++ b/.github/workflows/ci-myjobhunter.yml
@@ -123,6 +123,7 @@ jobs:
               tests/test_resume_refinement_preparing_flow.py
               tests/test_resume_parse_provenance.py
               tests/test_resume_mapper.py
+              tests/test_resume_refinement_user_targets.py
 
     services:
       postgres:

--- a/apps/myjobhunter/backend/alembic/versions/usertgt260702_user_created_target_role.py
+++ b/apps/myjobhunter/backend/alembic/versions/usertgt260702_user_created_target_role.py
@@ -1,0 +1,62 @@
+"""Widen the refinement turn role constraint with ``user_created_target``.
+
+User-directed targeting lets the user click a draft line to create an
+improvement target; the action is recorded as a turn so the transcript
+explains why the cursor jumped. Data-only widening — no new columns.
+
+Revision ID: usertgt260702
+Revises: iscur260702
+Create Date: 2026-07-02
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "usertgt260702"
+down_revision: Union[str, None] = "iscur260702"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_OLD_ROLES = (
+    "'ai_critique','ai_proposal','user_accept','user_accept_flagged',"
+    "'user_custom','user_request_alternative','user_skip','session_complete'"
+)
+_NEW_ROLES = (
+    "'ai_critique','ai_proposal','user_accept','user_accept_flagged',"
+    "'user_custom','user_request_alternative','user_created_target',"
+    "'user_skip','session_complete'"
+)
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "chk_refinement_turn_role",
+        "resume_refinement_turns",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_refinement_turn_role",
+        "resume_refinement_turns",
+        f"role IN ({_NEW_ROLES})",
+    )
+
+
+def downgrade() -> None:
+    # Rows in the new role would violate the narrowed constraint —
+    # resolve to the nearest old-world equivalent (a user-directed
+    # generation request) before narrowing.
+    op.execute(
+        "UPDATE resume_refinement_turns "
+        "SET role = 'user_request_alternative' WHERE role = 'user_created_target'"
+    )
+    op.drop_constraint(
+        "chk_refinement_turn_role",
+        "resume_refinement_turns",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_refinement_turn_role",
+        "resume_refinement_turns",
+        f"role IN ({_OLD_ROLES})",
+    )

--- a/apps/myjobhunter/backend/app/api/resume_refinement.py
+++ b/apps/myjobhunter/backend/app/api/resume_refinement.py
@@ -11,6 +11,8 @@ POST   /resume-refinement/sessions/{id}/accept-flagged      apply guard-held pro
 POST   /resume-refinement/sessions/{id}/custom              supply custom rewrite
 POST   /resume-refinement/sessions/{id}/alternative         regenerate same target
 POST   /resume-refinement/sessions/{id}/skip                skip current target
+POST   /resume-refinement/sessions/{id}/navigate            move the cursor next/prev
+POST   /resume-refinement/sessions/{id}/target-from-line    create/jump to a target from a clicked draft line
 POST   /resume-refinement/sessions/{id}/complete            mark session done
 GET    /resume-refinement/sessions/{id}/export?format=pdf|docx   download document
 
@@ -32,6 +34,7 @@ from app.schemas.resume_refinement.session import (
     NavigateRequest,
     SessionStartRequest,
     SessionWithTurnsRead,
+    TargetFromLineRequest,
     TurnAlternativeRequest,
     TurnCustomRequest,
 )
@@ -246,6 +249,39 @@ async def navigate(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except NoMoreTargets as exc:
         raise HTTPException(status_code=409, detail="No improvement targets to navigate") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return SessionWithTurnsRead.model_validate(session)
+
+
+@router.post(
+    "/sessions/{session_id}/target-from-line",
+    response_model=SessionWithTurnsRead,
+)
+async def create_target_from_line(
+    session_id: uuid.UUID,
+    body: TargetFromLineRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionWithTurnsRead:
+    """User clicked a draft line to get a suggestion for it.
+
+    Jumps to the matching target when the line already has one
+    (deduplicated server-side); otherwise inserts a user-origin target
+    after the cursor and generates a proposal on-demand.
+    """
+    try:
+        session = await session_service.create_target_from_line(
+            db=db,
+            user_id=user.id,
+            session_id=session_id,
+            current_text=body.current_text,
+            section=body.section,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    except SessionNotActive as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return SessionWithTurnsRead.model_validate(session)

--- a/apps/myjobhunter/backend/app/models/resume_refinement/turn.py
+++ b/apps/myjobhunter/backend/app/models/resume_refinement/turn.py
@@ -13,6 +13,8 @@ Roles:
 - ``user_custom`` — user supplies their own rewrite for the current target.
 - ``user_request_alternative`` — user asks Claude for a different proposal
   for the same target.
+- ``user_created_target`` — user clicked a draft line to create their own
+  improvement target (user-directed targeting).
 - ``user_skip`` — user skips the current target without modifying it.
 - ``session_complete`` — terminal turn; user marked the session done.
 """
@@ -94,6 +96,7 @@ class ResumeRefinementTurn(Base):
             "'user_accept_flagged',"
             "'user_custom',"
             "'user_request_alternative',"
+            "'user_created_target',"
             "'user_skip',"
             "'session_complete'"
             ")",

--- a/apps/myjobhunter/backend/app/repositories/resume_refinement/session_target_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/resume_refinement/session_target_repo.py
@@ -1,0 +1,69 @@
+"""Repository helpers for user-created improvement targets.
+
+Sibling module to ``session_repo.py`` (which sits at the 500-LOC growth
+guard). Same conventions: mutate the ORM row, reassign fresh containers
+for JSONB change detection, flush + commit + refresh.
+"""
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.resume_refinement.session import ResumeRefinementSession
+
+
+def _shift_index_keys(index_keyed: dict | None, *, insert_at: int) -> dict:
+    """Remap a ``{str(target_index): value}`` dict after a list insert.
+
+    ``proposal_cache`` and ``guard_flag_counts`` are keyed by stringified
+    target index; inserting a target mid-list shifts every later target
+    up by one, so keys >= ``insert_at`` must shift too or navigation
+    would hydrate the WRONG cached proposal for shifted targets.
+    """
+    shifted: dict = {}
+    for key, value in (index_keyed or {}).items():
+        try:
+            index = int(key)
+        except (TypeError, ValueError):
+            shifted[key] = value
+            continue
+        shifted[str(index + 1 if index >= insert_at else index)] = value
+    return shifted
+
+
+async def insert_target_at(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    target: dict,
+    insert_at: int,
+) -> ResumeRefinementSession:
+    """Insert ``target`` at ``insert_at`` and make it the active target.
+
+    Clears pending proposal state (it belonged to the previously-active
+    target) and bumps ``turn_count`` for the user turn the caller just
+    appended. The index-keyed JSONB side tables are remapped so cached
+    proposals stay attached to the right targets.
+    """
+    targets = list(session.improvement_targets or [])
+    insert_at = max(0, min(insert_at, len(targets)))
+    targets.insert(insert_at, dict(target))
+
+    session.improvement_targets = targets
+    session.proposal_cache = _shift_index_keys(
+        session.proposal_cache, insert_at=insert_at,
+    )
+    session.guard_flag_counts = _shift_index_keys(
+        session.guard_flag_counts, insert_at=insert_at,
+    )
+    session.target_index = insert_at
+    session.pending_target_section = None
+    session.pending_proposal = None
+    session.pending_rationale = None
+    session.pending_clarifying_question = None
+    session.pending_guard_flagged = None
+    session.pending_flagged_proposal = None
+    session.turn_count += 1
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session

--- a/apps/myjobhunter/backend/app/schemas/resume_refinement/session.py
+++ b/apps/myjobhunter/backend/app/schemas/resume_refinement/session.py
@@ -35,6 +35,11 @@ class ImprovementTarget(BaseModel):
         default=None,
         description="Critique pass's free-form notes about why this target matters.",
     )
+    origin: Literal["ai", "user"] = Field(
+        default="ai",
+        description="'ai' for critique-chosen targets; 'user' when the user "
+        "clicked a draft line to create the target themselves.",
+    )
 
 
 class TurnRead(BaseModel):
@@ -140,3 +145,16 @@ class NavigateRequest(BaseModel):
         ...,
         description="Move to the next or previous improvement target.",
     )
+
+
+class TargetFromLineRequest(BaseModel):
+    """User clicked a draft line to get a suggestion for it.
+
+    ``current_text`` must be the raw markdown line content (minus any
+    ``- `` bullet marker) so the rewrite's verbatim substring replace
+    still matches the draft. ``section`` is the nearest preceding
+    ``##`` heading — used for the target label and transcript grouping.
+    """
+
+    current_text: str = Field(..., min_length=1, max_length=2000)
+    section: str = Field(default="", max_length=200)

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
@@ -34,6 +34,7 @@ from app.services.resume_refinement.session_turn_service import (
     accept_custom,
     accept_flagged,
     accept_pending,
+    create_target_from_line,
     navigate,
     request_alternative,
     skip_target,
@@ -67,7 +68,11 @@ from app.repositories.profile import (
     skill_repository,
     work_history_repository,
 )
-from app.repositories.resume_refinement import session_repo, turn_repo
+from app.repositories.resume_refinement import (
+    session_repo,
+    session_target_repo,
+    turn_repo,
+)
 from app.services.resume_refinement import critique_service, rewrite_service
 
 __all__ = [
@@ -84,6 +89,7 @@ __all__ = [
     "request_alternative",
     "skip_target",
     "navigate",
+    "create_target_from_line",
     # Private helpers (tests import these directly)
     "_PREFETCH_CONCURRENCY",
     "_apply_rewrite",
@@ -96,6 +102,7 @@ __all__ = [
     "_with_turns",
     # Module refs (tests use patch / patch.object against these)
     "session_repo",
+    "session_target_repo",
     "turn_repo",
     "rewrite_service",
     "critique_service",

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_turn_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_turn_service.py
@@ -9,6 +9,9 @@ Public entry points (called from ``app.api.resume_refinement``):
 - ``request_alternative`` — regenerate the proposal for the same target.
 - ``skip_target`` — move to the next target without modifying.
 - ``navigate`` — move the iteration cursor without consuming the active proposal.
+- ``create_target_from_line`` — user clicked a draft line: jump to the
+  matching target if one exists, otherwise insert a user-origin target
+  after the cursor and generate a proposal for it.
 
 Each "advance" entry point has the same shape:
 1. Apply the user's resolution to the draft (or skip).
@@ -19,12 +22,17 @@ Each "advance" entry point has the same shape:
 """
 from __future__ import annotations
 
+import re
 import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.resume_refinement.session import ResumeRefinementSession
-from app.repositories.resume_refinement import session_repo, turn_repo
+from app.repositories.resume_refinement import (
+    session_repo,
+    session_target_repo,
+    turn_repo,
+)
 from app.services.resume_refinement.errors import (
     NoMoreTargets,
     NoPendingProposal,
@@ -293,5 +301,83 @@ async def navigate(
 
     # Cache miss: fall through to generation. ``_generate_next_proposal``
     # writes the result back to the cache for future navigations.
+    session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    return await _with_turns(db, session)
+
+
+# Markdown decoration stripped before comparing a clicked line against
+# stored target text — mirrors the frontend's plainText() normalization.
+_MD_DECORATION = re.compile(r"\*\*|\*")
+
+
+def _normalize_line(text: str) -> str:
+    return _MD_DECORATION.sub("", text).strip()
+
+
+async def create_target_from_line(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+    current_text: str,
+    section: str,
+) -> ResumeRefinementSession:
+    """Create (or jump to) an improvement target from a clicked draft line.
+
+    Dedup first: if the line matches an existing target's ``current_text``
+    (markdown decoration stripped), jump to that target instead of
+    duplicating — re-clicking a previously-skipped line is a legitimate
+    "let me reconsider" gesture and should surface its cached proposal.
+
+    Otherwise a user-origin target is inserted immediately AFTER the
+    cursor (not appended) so the progress bar's "resolved" count stays
+    accurate, the cursor moves to it, and a proposal is generated
+    on-demand (user targets are never prefetched).
+    """
+    session = await _load_active(db, session_id, user_id)
+    normalized = _normalize_line(current_text)
+    if not normalized:
+        raise ValueError("The selected line is empty.")
+
+    targets = session.improvement_targets or []
+    for idx, existing in enumerate(targets):
+        if _normalize_line(str(existing.get("current_text") or "")) != normalized:
+            continue
+        if idx == session.target_index:
+            # Already the active target — nothing to do.
+            return await _with_turns(db, session)
+        session = await session_repo.set_target_index(db, session, new_index=idx)
+        cached = await session_repo.hydrate_pending_from_cache(
+            db, session, target_index=idx,
+        )
+        if cached is not None:
+            return await _with_turns(db, cached)
+        session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+        return await _with_turns(db, session)
+
+    new_target = {
+        "section": section.strip() or "Your selection",
+        # Raw line text — must remain a verbatim substring of the draft
+        # so _apply_rewrite's replace still matches on accept.
+        "current_text": current_text.strip(),
+        "improvement_type": "other",
+        "severity": "low",
+        "notes": None,
+        "origin": "user",
+    }
+    insert_at = min(session.target_index + 1, len(targets))
+
+    await turn_repo.append(
+        db,
+        session_id=session.id,
+        turn_index=session.turn_count,
+        role="user_created_target",
+        target_section=new_target["section"],
+        user_text=normalized,
+    )
+    session = await session_target_repo.insert_target_at(
+        db, session, target=new_target, insert_at=insert_at,
+    )
+
     session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
     return await _with_turns(db, session)

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_user_targets.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_user_targets.py
@@ -1,0 +1,292 @@
+"""Tests for user-directed targeting (create_target_from_line).
+
+Pure-mock tests in the style of test_resume_refinement_proposal_cache:
+no DB, every repo/helper call patched at the session_turn_service
+namespace. Plus direct tests of session_target_repo's index-key remap,
+which is the load-bearing piece — inserting a target mid-list shifts
+later targets, so the index-keyed proposal_cache/guard_flag_counts
+must shift too or navigation would hydrate the WRONG cached proposal.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.repositories.resume_refinement.session_target_repo import (
+    _shift_index_keys,
+    insert_target_at,
+)
+from app.services.resume_refinement.session_turn_service import (
+    _normalize_line,
+    create_target_from_line,
+)
+
+_USER_ID = uuid.uuid4()
+_SESSION_ID = uuid.uuid4()
+
+_SVC = "app.services.resume_refinement.session_turn_service"
+
+
+def _fake_session(
+    *,
+    targets: list[dict] | None = None,
+    target_index: int = 0,
+    turn_count: int = 3,
+) -> MagicMock:
+    session = MagicMock()
+    session.id = _SESSION_ID
+    session.improvement_targets = targets
+    session.target_index = target_index
+    session.turn_count = turn_count
+    return session
+
+
+def _ai_target(current_text: str, section: str = "Experience") -> dict:
+    return {
+        "section": section,
+        "current_text": current_text,
+        "improvement_type": "add_metric",
+        "severity": "high",
+        "notes": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _normalize_line
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_line_strips_decoration_and_whitespace():
+    assert _normalize_line("  **Led** the *team*  ") == "Led the team"
+
+
+# ---------------------------------------------------------------------------
+# _shift_index_keys — the cache-remap invariant
+# ---------------------------------------------------------------------------
+
+
+def test_shift_index_keys_shifts_at_and_after_insert_point():
+    cache = {"0": "a", "1": "b", "2": "c"}
+    assert _shift_index_keys(cache, insert_at=1) == {"0": "a", "2": "b", "3": "c"}
+
+
+def test_shift_index_keys_handles_none_and_non_numeric():
+    assert _shift_index_keys(None, insert_at=0) == {}
+    assert _shift_index_keys({"weird": 1, "0": 2}, insert_at=0) == {"weird": 1, "1": 2}
+
+
+# ---------------------------------------------------------------------------
+# insert_target_at — real repo function against a mock session/db
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insert_target_at_inserts_activates_and_remaps():
+    session = _fake_session(
+        targets=[_ai_target("one"), _ai_target("two")], target_index=0,
+    )
+    session.proposal_cache = {"0": {"proposal": "p0"}, "1": {"proposal": "p1"}}
+    session.guard_flag_counts = {"1": 2}
+    db = AsyncMock()
+
+    new_target = {"section": "S", "current_text": "clicked", "origin": "user"}
+    result = await insert_target_at(db, session, target=new_target, insert_at=1)
+
+    assert [t["current_text"] for t in result.improvement_targets] == [
+        "one", "clicked", "two",
+    ]
+    assert result.target_index == 1
+    # Old target "two" moved 1 -> 2; its cache + flag count must follow.
+    assert result.proposal_cache == {"0": {"proposal": "p0"}, "2": {"proposal": "p1"}}
+    assert result.guard_flag_counts == {"2": 2}
+    assert result.pending_proposal is None
+    assert result.turn_count == 4
+
+
+@pytest.mark.asyncio
+async def test_insert_target_at_clamps_out_of_bounds_index():
+    session = _fake_session(targets=[_ai_target("one")], target_index=5)
+    session.proposal_cache = {}
+    session.guard_flag_counts = {}
+    db = AsyncMock()
+
+    result = await insert_target_at(
+        db, session, target={"current_text": "x"}, insert_at=99,
+    )
+    assert result.target_index == 1
+    assert len(result.improvement_targets) == 2
+
+
+# ---------------------------------------------------------------------------
+# create_target_from_line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_line_raises_value_error():
+    session = _fake_session(targets=[])
+    with (
+        patch(f"{_SVC}._load_active", new_callable=AsyncMock, return_value=session),
+    ):
+        with pytest.raises(ValueError):
+            await create_target_from_line(
+                db=AsyncMock(),
+                user_id=_USER_ID,
+                session_id=_SESSION_ID,
+                current_text="  ** **  ",
+                section="Experience",
+            )
+
+
+@pytest.mark.asyncio
+async def test_click_on_active_target_is_a_noop():
+    session = _fake_session(targets=[_ai_target("Led the team")], target_index=0)
+    with (
+        patch(f"{_SVC}._load_active", new_callable=AsyncMock, return_value=session),
+        patch(
+            f"{_SVC}._with_turns", new_callable=AsyncMock, return_value=session,
+        ) as with_turns,
+        patch(f"{_SVC}.session_repo") as repo,
+        patch(f"{_SVC}.session_target_repo") as target_repo,
+    ):
+        result = await create_target_from_line(
+            db=AsyncMock(),
+            user_id=_USER_ID,
+            session_id=_SESSION_ID,
+            current_text="**Led** the team",
+            section="Experience",
+        )
+    assert result is session
+    with_turns.assert_awaited_once()
+    repo.set_target_index.assert_not_called()
+    target_repo.insert_target_at.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_click_matching_existing_target_jumps_with_cache_hit():
+    session = _fake_session(
+        targets=[_ai_target("first"), _ai_target("second")], target_index=0,
+    )
+    with (
+        patch(f"{_SVC}._load_active", new_callable=AsyncMock, return_value=session),
+        patch(f"{_SVC}._with_turns", new_callable=AsyncMock, side_effect=lambda db, s: s),
+        patch(f"{_SVC}.session_repo") as repo,
+        patch(
+            f"{_SVC}._generate_next_proposal", new_callable=AsyncMock,
+        ) as generate,
+    ):
+        repo.set_target_index = AsyncMock(return_value=session)
+        repo.hydrate_pending_from_cache = AsyncMock(return_value=session)
+        await create_target_from_line(
+            db=AsyncMock(),
+            user_id=_USER_ID,
+            session_id=_SESSION_ID,
+            current_text="second",
+            section="Experience",
+        )
+    repo.set_target_index.assert_awaited_once()
+    assert repo.set_target_index.await_args.kwargs["new_index"] == 1
+    generate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_click_matching_existing_target_generates_on_cache_miss():
+    session = _fake_session(
+        targets=[_ai_target("first"), _ai_target("second")], target_index=0,
+    )
+    with (
+        patch(f"{_SVC}._load_active", new_callable=AsyncMock, return_value=session),
+        patch(f"{_SVC}._with_turns", new_callable=AsyncMock, side_effect=lambda db, s: s),
+        patch(f"{_SVC}.session_repo") as repo,
+        patch(
+            f"{_SVC}._generate_next_proposal",
+            new_callable=AsyncMock,
+            return_value=session,
+        ) as generate,
+    ):
+        repo.set_target_index = AsyncMock(return_value=session)
+        repo.hydrate_pending_from_cache = AsyncMock(return_value=None)
+        await create_target_from_line(
+            db=AsyncMock(),
+            user_id=_USER_ID,
+            session_id=_SESSION_ID,
+            current_text="second",
+            section="Experience",
+        )
+    generate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_new_line_inserts_user_target_after_cursor():
+    session = _fake_session(
+        targets=[_ai_target("first"), _ai_target("second")],
+        target_index=0,
+        turn_count=7,
+    )
+    with (
+        patch(f"{_SVC}._load_active", new_callable=AsyncMock, return_value=session),
+        patch(f"{_SVC}._with_turns", new_callable=AsyncMock, side_effect=lambda db, s: s),
+        patch(f"{_SVC}.turn_repo") as turns,
+        patch(f"{_SVC}.session_target_repo") as target_repo,
+        patch(
+            f"{_SVC}._generate_next_proposal",
+            new_callable=AsyncMock,
+            return_value=session,
+        ) as generate,
+    ):
+        turns.append = AsyncMock()
+        target_repo.insert_target_at = AsyncMock(return_value=session)
+        await create_target_from_line(
+            db=AsyncMock(),
+            user_id=_USER_ID,
+            session_id=_SESSION_ID,
+            current_text="**A brand new** line",
+            section="Projects",
+        )
+
+    turns.append.assert_awaited_once()
+    turn_kwargs = turns.append.await_args.kwargs
+    assert turn_kwargs["role"] == "user_created_target"
+    assert turn_kwargs["turn_index"] == 7
+    assert turn_kwargs["user_text"] == "A brand new line"
+
+    target_repo.insert_target_at.assert_awaited_once()
+    kwargs = target_repo.insert_target_at.await_args.kwargs
+    assert kwargs["insert_at"] == 1
+    new_target = kwargs["target"]
+    assert new_target["origin"] == "user"
+    assert new_target["current_text"] == "**A brand new** line"
+    assert new_target["section"] == "Projects"
+    assert new_target["improvement_type"] == "other"
+    assert new_target["severity"] == "low"
+    generate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_new_line_with_blank_section_falls_back():
+    session = _fake_session(targets=[], target_index=0)
+    with (
+        patch(f"{_SVC}._load_active", new_callable=AsyncMock, return_value=session),
+        patch(f"{_SVC}._with_turns", new_callable=AsyncMock, side_effect=lambda db, s: s),
+        patch(f"{_SVC}.turn_repo") as turns,
+        patch(f"{_SVC}.session_target_repo") as target_repo,
+        patch(
+            f"{_SVC}._generate_next_proposal",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+    ):
+        turns.append = AsyncMock()
+        target_repo.insert_target_at = AsyncMock(return_value=session)
+        await create_target_from_line(
+            db=AsyncMock(),
+            user_id=_USER_ID,
+            session_id=_SESSION_ID,
+            current_text="orphan line",
+            section="   ",
+        )
+    kwargs = target_repo.insert_target_at.await_args.kwargs
+    assert kwargs["target"]["section"] == "Your selection"
+    assert kwargs["insert_at"] == 0

--- a/apps/myjobhunter/frontend/e2e/resume-refinement.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/resume-refinement.spec.ts
@@ -291,3 +291,143 @@ test.describe("Resume Refinement — chat composer (mocked active session)", () 
     }
   });
 });
+
+test.describe("Resume Refinement — click-to-target (mocked active session)", () => {
+  const SESSION_ID = "22222222-3333-4444-8555-666666666666";
+
+  const AI_TARGET = {
+    section: "Experience — bullet 1",
+    current_text: "Built the payments system",
+    improvement_type: "stronger_verb",
+    severity: "medium",
+    notes: null,
+    origin: "ai",
+  };
+
+  function clickableSession(overrides: Record<string, unknown> = {}) {
+    return {
+      id: SESSION_ID,
+      source_resume_job_id: null,
+      status: "active",
+      current_draft:
+        "# Jane Doe\n\n## Experience\n\n- Built the payments system\n- Shipped the mobile app",
+      improvement_targets: [AI_TARGET],
+      target_index: 0,
+      pending_target_section: "Experience — bullet 1",
+      pending_proposal: "Architected the payments system",
+      pending_rationale: null,
+      pending_clarifying_question: null,
+      pending_guard_flagged: null,
+      guard_can_force: false,
+      turn_count: 2,
+      total_tokens_in: 0,
+      total_tokens_out: 0,
+      total_cost_usd: "0",
+      error_message: null,
+      proposals_ready_count: 1,
+      completed_at: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      turns: [],
+      ...overrides,
+    };
+  }
+
+  function afterClickSession() {
+    return clickableSession({
+      improvement_targets: [
+        AI_TARGET,
+        {
+          section: "Experience",
+          current_text: "Shipped the mobile app",
+          improvement_type: "other",
+          severity: "low",
+          notes: null,
+          origin: "user",
+        },
+      ],
+      target_index: 1,
+      pending_target_section: "Experience",
+      pending_proposal: "Delivered the mobile app to 1M users",
+      turn_count: 4,
+    });
+  }
+
+  test("clicking a draft line creates a user target and shows its suggestion", async ({
+    page,
+    request,
+  }) => {
+    const user = await createTestUser(request);
+
+    try {
+      await loginViaUI(page, user, request);
+
+      // Mutable payload: the target-from-line POST swaps it so the
+      // poll/invalidation refetch returns the post-click state.
+      let sessionPayload = clickableSession();
+      await page.route(
+        `**/api/resume-refinement/sessions/${SESSION_ID}`,
+        (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(sessionPayload),
+          }),
+      );
+      let capturedBody: { current_text?: string; section?: string } | null = null;
+      await page.route(
+        `**/api/resume-refinement/sessions/${SESSION_ID}/target-from-line`,
+        async (route) => {
+          capturedBody = route.request().postDataJSON();
+          sessionPayload = afterClickSession();
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(sessionPayload),
+          });
+        },
+      );
+
+      await page.addInitScript((id) => {
+        localStorage.removeItem("mjh:resumeRefinementClickTipDismissed");
+        localStorage.setItem("mjh:resumeRefinementSessionId", id);
+      }, SESSION_ID);
+
+      await page.goto("/resume");
+      await page.waitForURL("**/resume");
+
+      // Discovery tip is visible on a fresh browser.
+      await expect(
+        page.getByText(/click any line to get a fresh suggestion/i),
+      ).toBeVisible();
+
+      // The non-active bullet is a real button with an action-stating label…
+      const line = page.getByRole("button", {
+        name: /get a suggestion for this line: Shipped the mobile app/i,
+      });
+      await expect(line).toBeVisible();
+
+      // …while the ACTIVE (highlighted) line is never clickable.
+      await expect(
+        page.getByRole("button", {
+          name: /get a suggestion for this line: Built the payments system/i,
+        }),
+      ).toHaveCount(0);
+
+      await line.click();
+
+      // The backend receives the raw line + its nearest ## section.
+      await expect.poll(() => capturedBody).not.toBeNull();
+      expect(capturedBody?.current_text).toBe("Shipped the mobile app");
+      expect(capturedBody?.section).toBe("Experience");
+
+      // The user-origin target is active: "Your pick" badge + its proposal.
+      await expect(page.getByText("Your pick")).toBeVisible();
+      await expect(
+        page.getByText("Delivered the mobile app to 1M users"),
+      ).toBeVisible();
+    } finally {
+      await deleteTestUser(request, user);
+    }
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ActiveSessionView.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ActiveSessionView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { showError, extractErrorMessage } from "@platform/ui";
 import CurrentDraftPanel from "@/features/resume_refinement/CurrentDraftPanel";
 import PendingProposalCard from "@/features/resume_refinement/PendingProposalCard";
 import CompletePanel from "@/features/resume_refinement/CompletePanel";
@@ -6,11 +7,16 @@ import SessionPreparingPanel from "@/features/resume_refinement/SessionPreparing
 import ConversationHistory from "@/features/resume_refinement/ConversationHistory";
 import ActiveSessionLayout from "@/features/resume_refinement/ActiveSessionLayout";
 import ResumeRefinementHeader from "@/features/resume_refinement/ResumeRefinementHeader";
+import { useCreateTargetFromLineMutation } from "@/lib/resumeRefinementApi";
 import type { RefinementSession } from "@/types/resume-refinement/refinement-session";
 
 interface ActiveSessionViewProps {
   session: RefinementSession;
   onStartNew: () => void;
+}
+
+function normalizeLine(text: string): string {
+  return text.replace(/\*\*?/g, "").trim();
 }
 
 export default function ActiveSessionView({ session, onStartNew }: ActiveSessionViewProps) {
@@ -40,12 +46,52 @@ export default function ActiveSessionView({ session, onStartNew }: ActiveSession
     session.target_index < session.improvement_targets.length
       ? session.improvement_targets[session.target_index]
       : null;
-  const highlightText = activeTarget?.current_text ?? null;
+
+  // Click-to-target: the clicked line becomes the highlight IMMEDIATELY
+  // (before the 2-10s generation resolves); the override clears once
+  // the refetched session's active target matches the clicked line.
+  const [createTargetFromLine, createTarget] = useCreateTargetFromLineMutation();
+  const [pendingLine, setPendingLine] = useState<string | null>(null);
+  const controlsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (
+      pendingLine &&
+      activeTarget &&
+      normalizeLine(activeTarget.current_text) === normalizeLine(pendingLine)
+    ) {
+      setPendingLine(null);
+    }
+  }, [activeTarget, pendingLine]);
+
+  async function handleLineSelected({ text, section }: { text: string; section: string }) {
+    if (createTarget.isLoading) return;
+    setPendingLine(text);
+    try {
+      await createTargetFromLine({
+        id: session.id,
+        current_text: text,
+        section,
+      }).unwrap();
+      // On narrow viewports the suggestion card sits below the draft —
+      // bring it into view so the generated proposal isn't off-screen.
+      if (window.innerWidth < 1024) {
+        controlsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    } catch (err) {
+      setPendingLine(null);
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  const highlightText = pendingLine ?? activeTarget?.current_text ?? null;
 
   const draft = (
     <CurrentDraftPanel
       markdown={session.current_draft}
       highlightText={highlightText}
+      onLineClick={session.status === "active" ? handleLineSelected : undefined}
+      clickDisabled={createTarget.isLoading}
     />
   );
 
@@ -59,7 +105,7 @@ export default function ActiveSessionView({ session, onStartNew }: ActiveSession
   // On desktop (lg+) rendered second in visual flow (order-2).
   // On mobile rendered first (order-1).
   const controls = (
-    <div className="flex flex-col gap-2 min-h-0 h-full">
+    <div className="flex flex-col gap-2 min-h-0 h-full" ref={controlsRef}>
       {/* History zone */}
       <div className="order-2 lg:order-1 lg:flex-1 lg:overflow-y-auto lg:min-h-0 pr-1">
         <ConversationHistory
@@ -77,6 +123,7 @@ export default function ActiveSessionView({ session, onStartNew }: ActiveSession
           <PendingProposalCard
             session={session}
             onPendingEchoChange={setPendingEcho}
+            externalPending={createTarget.isLoading}
           />
         )}
         {/* Gated: CompletePanel's reached-end math treats a null

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ClickToTargetTip.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ClickToTargetTip.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+
+const DISMISS_KEY = "mjh:resumeRefinementClickTipDismissed";
+
+/**
+ * One-time dismissible discovery tip for click-to-target. Also states
+ * the fact-vs-phrasing boundary up front so users don't discover it by
+ * bouncing off the hallucination guard.
+ */
+export default function ClickToTargetTip() {
+  const [dismissed, setDismissed] = useState(
+    () => localStorage.getItem(DISMISS_KEY) === "1",
+  );
+  if (dismissed) return null;
+
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-border bg-muted/40 px-2.5 py-1.5 text-xs text-muted-foreground">
+      <p className="flex-1">
+        Tip: click any line to get a fresh suggestion for it. To fix a wrong
+        fact (title, dates, employer), edit it on your Profile page — I can
+        only adjust phrasing.
+      </p>
+      <button
+        type="button"
+        aria-label="Dismiss tip"
+        onClick={() => {
+          localStorage.setItem(DISMISS_KEY, "1");
+          setDismissed(true);
+        }}
+        className="shrink-0 hover:text-foreground"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/CurrentDraftPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/CurrentDraftPanel.tsx
@@ -1,9 +1,13 @@
 import MarkdownPreview from "@/features/resume_refinement/markdown-preview";
+import ClickToTargetTip from "@/features/resume_refinement/ClickToTargetTip";
 
 interface CurrentDraftPanelProps {
   markdown: string;
   /** When set, the matching block in the preview gets a yellow band + auto-scroll. */
   highlightText?: string | null;
+  /** When set, draft lines become clickable to create/jump to a target. */
+  onLineClick?: (payload: { text: string; section: string }) => void;
+  clickDisabled?: boolean;
 }
 
 /**
@@ -17,10 +21,15 @@ interface CurrentDraftPanelProps {
  * internally — the operator always sees the full resume while
  * working through suggestions on the right.
  */
-export default function CurrentDraftPanel({ markdown, highlightText }: CurrentDraftPanelProps) {
+export default function CurrentDraftPanel({
+  markdown,
+  highlightText,
+  onLineClick,
+  clickDisabled = false,
+}: CurrentDraftPanelProps) {
   return (
     <section className="rounded-lg border border-border bg-card p-4 flex flex-col min-h-0 flex-1 gap-2">
-      <header className="shrink-0">
+      <header className="shrink-0 space-y-1.5">
         <h2 className="text-sm font-semibold">Current draft</h2>
         <p className="text-xs text-muted-foreground mt-0.5">
           Your live working copy.{" "}
@@ -28,10 +37,16 @@ export default function CurrentDraftPanel({ markdown, highlightText }: CurrentDr
             ? "The highlighted line is what we're refining now."
             : "Changes apply as you accept rewrites."}
         </p>
+        {onLineClick && <ClickToTargetTip />}
       </header>
       <div className="rounded-md border border-border bg-background p-4 overflow-y-auto flex-1 min-h-0">
         {markdown.trim() ? (
-          <MarkdownPreview source={markdown} highlightText={highlightText} />
+          <MarkdownPreview
+            source={markdown}
+            highlightText={highlightText}
+            onLineClick={onLineClick}
+            clickDisabled={clickDisabled}
+          />
         ) : (
           <p className="text-sm text-muted-foreground">Your draft is empty.</p>
         )}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/DraftLine.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/DraftLine.tsx
@@ -1,0 +1,47 @@
+import { Pencil } from "lucide-react";
+import InlineText from "@/features/resume_refinement/InlineText";
+
+interface DraftLineProps {
+  /** Raw markdown line content (bullet marker already stripped) —
+   *  sent verbatim so the backend's substring replace still matches. */
+  text: string;
+  /** Nearest preceding ## heading — the new target's section label. */
+  section: string;
+  disabled: boolean;
+  onSelect: (payload: { text: string; section: string }) => void;
+}
+
+/**
+ * A clickable draft block: click to create (or jump to) an improvement
+ * target for this line. Native button for free keyboard + SR semantics.
+ * The trailing pencil renders at low opacity always (the only discovery
+ * affordance on touch) and intensifies on hover.
+ */
+export default function DraftLine({ text, section, disabled, onSelect }: DraftLineProps) {
+  const plain = text.replace(/\*\*?/g, "").trim();
+
+  function handleClick() {
+    // Users drag-select bullets to copy them constantly — a click at
+    // the end of a selection drag is not a "get suggestion" gesture.
+    if (window.getSelection()?.toString()) return;
+    onSelect({ text, section });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      title="Get a suggestion for this line"
+      aria-label={`Get a suggestion for this line: ${plain}`}
+      className="group w-full text-left rounded-sm cursor-pointer hover:bg-muted/60 hover:ring-1 hover:ring-border disabled:opacity-40 disabled:cursor-not-allowed"
+    >
+      <InlineText source={text} />
+      <Pencil
+        size={12}
+        aria-hidden="true"
+        className="inline-block ml-1.5 align-baseline text-muted-foreground/40 group-hover:text-muted-foreground"
+      />
+    </button>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
@@ -31,6 +31,9 @@ interface PendingProposalCardProps {
   /** Surface for the composer's optimistic echo — the parent renders
    *  it inside ConversationHistory (which lives outside this card). */
   onPendingEchoChange?: (echo: { text: string } | null) => void;
+  /** A sibling mutation is in flight (click-to-target generation owned
+   *  by ActiveSessionView) — folds into the unified pending gate. */
+  externalPending?: boolean;
 }
 
 // Top-level orchestrator for the suggestion area. Owns the
@@ -40,6 +43,7 @@ interface PendingProposalCardProps {
 export default function PendingProposalCard({
   session,
   onPendingEchoChange,
+  externalPending = false,
 }: PendingProposalCardProps) {
   const [mode, setMode] = useState<SuggestionMode>(SuggestionMode.VIEW);
   // Dedicated states: customText belongs to "Write my own" (replaces
@@ -91,7 +95,9 @@ export default function PendingProposalCard({
     flaggedAccept.isLoading ||
     custom.isLoading ||
     alternative.isLoading ||
-    skip.isLoading;
+    skip.isLoading ||
+    externalPending;
+  const isUserTarget = activeTarget?.origin === "user";
 
   // Bail when every target is consumed — AND for the zero-target
   // session, where there is nothing to suggest (CompletePanel's
@@ -186,7 +192,12 @@ export default function PendingProposalCard({
           <span className="truncate">
             Suggestion {session.target_index + 1} / {totalTargets}
           </span>
-          {activeTarget && (
+          {activeTarget && isUserTarget && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium shrink-0 bg-primary/10 text-primary">
+              Your pick
+            </span>
+          )}
+          {activeTarget && !isUserTarget && (
             <span
               className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium shrink-0 ${SEVERITY_BADGE_CLASS[activeTarget.severity]}`}
             >
@@ -209,8 +220,10 @@ export default function PendingProposalCard({
         total={totalTargets}
       />
 
-      {/* Improvement type pill as subtitle */}
-      {activeTarget && (
+      {/* Improvement type pill as subtitle — suppressed for user-created
+          targets, whose placeholder "other" type explains nothing next
+          to the "Your pick" badge. */}
+      {activeTarget && !isUserTarget && (
         <p className="text-xs">
           <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-primary/10 text-primary">
             {IMPROVEMENT_TYPE_LABEL[activeTarget.improvement_type]}
@@ -218,16 +231,20 @@ export default function PendingProposalCard({
         </p>
       )}
 
-      <SuggestionBody
-        clarifyingQuestion={clarifyingQuestion}
-        proposal={proposal}
-        rationale={rationale}
-        isPending={isPending}
-        isRegenerating={alternative.isLoading}
-        canForce={session.guard_can_force}
-        onForce={handleForceAccept}
-        forceIsLoading={flaggedAccept.isLoading}
-      />
+      {/* aria-live: focus never moves when a proposal lands (passive
+          transitions by convention here) — this is the SR signal. */}
+      <div aria-live="polite">
+        <SuggestionBody
+          clarifyingQuestion={clarifyingQuestion}
+          proposal={proposal}
+          rationale={rationale}
+          isPending={isPending}
+          isRegenerating={alternative.isLoading || externalPending}
+          canForce={session.guard_can_force}
+          onForce={handleForceAccept}
+          forceIsLoading={flaggedAccept.isLoading}
+        />
+      </div>
 
       {mode === SuggestionMode.VIEW && (
         <SuggestionActions

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SuggestionBody.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SuggestionBody.tsx
@@ -53,6 +53,21 @@ export default function SuggestionBody({
             </LoadingButton>
           </div>
         )}
+        {/* The recovery path when the flagged detail is a genuinely
+            wrong FACT: facts are edited in Profile, not here. Opens a
+            new tab so the in-progress session isn't lost. */}
+        <p className="text-xs text-muted-foreground">
+          Is a fact wrong here (title, dates, employer)? I can't edit facts —{" "}
+          <a
+            href="/profile"
+            target="_blank"
+            rel="noopener"
+            className="underline hover:text-foreground"
+          >
+            head to Profile
+          </a>{" "}
+          to fix it, then come back.
+        </p>
       </div>
     );
   }

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/conversation-turn-render.ts
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/conversation-turn-render.ts
@@ -16,6 +16,7 @@ export function isUserRole(role: RefinementTurn["role"]): boolean {
     role === "user_accept_flagged" ||
     role === "user_custom" ||
     role === "user_request_alternative" ||
+    role === "user_created_target" ||
     role === "user_skip"
   );
 }
@@ -58,6 +59,10 @@ export function renderTurnBody(turn: RefinementTurn): string | null {
       // "Try something with: …" prefix mislabeled clarify answers as
       // reroll hints (operator complaint, 2026-07-02).
       return turn.user_text ?? "Asked for another take.";
+    case "user_created_target":
+      return turn.user_text
+        ? `Picked from the draft: ${turn.user_text}`
+        : "Picked a line from the draft.";
     case "user_skip":
       return "Skipped.";
     case "session_complete":

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/markdown-preview.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/markdown-preview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import InlineText from "@/features/resume_refinement/InlineText";
+import DraftLine from "@/features/resume_refinement/DraftLine";
 
 // Tiny in-page markdown preview. Handles only the constrained subset
 // emitted by the backend's render/rewrite pipeline (headings, bullet
@@ -11,10 +12,18 @@ import InlineText from "@/features/resume_refinement/InlineText";
 // highlight band. The first matching block becomes the auto-scroll
 // target so users immediately see where the active refinement target
 // lives in the full draft.
+//
+// `onLineClick`: when provided, bullet and paragraph blocks AFTER the
+// first ## heading become clickable (user-directed targeting). Blocks
+// before the first section heading are name/contact preamble — pure
+// facts that should never look actionable. The currently-highlighted
+// block is never clickable (it's already the active target).
 
 interface MarkdownPreviewProps {
   source: string;
   highlightText?: string | null;
+  onLineClick?: (payload: { text: string; section: string }) => void;
+  clickDisabled?: boolean;
 }
 
 // Strip markdown decoration so a heading like "**Staff Engineer** — Acme"
@@ -33,11 +42,28 @@ function shouldHighlight(line: string, highlightText: string | null | undefined)
 const HIGHLIGHT_CLASS =
   "rounded-md border-l-4 border-amber-400 bg-amber-50/60 dark:bg-amber-500/10 -ml-2 pl-3 py-1";
 
-export default function MarkdownPreview({ source, highlightText }: MarkdownPreviewProps) {
+// Screen-reader marker for the amber band — the highlight is otherwise
+// color-only.
+function activeMarker(highlight: boolean): React.ReactNode {
+  if (!highlight) return null;
+  return <span className="sr-only">(this is the suggestion you're working on)</span>;
+}
+
+export default function MarkdownPreview({
+  source,
+  highlightText,
+  onLineClick,
+  clickDisabled = false,
+}: MarkdownPreviewProps) {
   const lines = source.split("\n");
   const blocks: React.ReactNode[] = [];
-  let listBuffer: { text: string; highlight: boolean }[] = [];
+  let listBuffer: { text: string; highlight: boolean; clickable: boolean; section: string }[] = [];
   let key = 0;
+  // Section tracking for click-to-target: the nearest preceding ##
+  // heading labels the new target; blocks before the first ## are
+  // never clickable.
+  let currentSection = "";
+  let seenFirstSection = false;
   const firstHighlightRef = useRef<HTMLElement | null>(null);
   let firstHighlightAssigned = false;
 
@@ -61,7 +87,17 @@ export default function MarkdownPreview({ source, highlightText }: MarkdownPrevi
               ref={(node) => attachIfFirst(node, item.highlight)}
               className={item.highlight ? HIGHLIGHT_CLASS : undefined}
             >
-              <InlineText source={item.text} />
+              {item.clickable && onLineClick ? (
+                <DraftLine
+                  text={item.text}
+                  section={item.section}
+                  disabled={clickDisabled}
+                  onSelect={onLineClick}
+                />
+              ) : (
+                <InlineText source={item.text} />
+              )}
+              {activeMarker(item.highlight)}
             </li>
           ))}
         </ul>
@@ -75,7 +111,13 @@ export default function MarkdownPreview({ source, highlightText }: MarkdownPrevi
 
     if (line.startsWith("- ")) {
       const text = line.slice(2);
-      listBuffer.push({ text, highlight: shouldHighlight(text, highlightText) });
+      const hl = shouldHighlight(text, highlightText);
+      listBuffer.push({
+        text,
+        highlight: hl,
+        clickable: seenFirstSection && !!onLineClick && !hl,
+        section: currentSection,
+      });
       continue;
     }
 
@@ -93,12 +135,15 @@ export default function MarkdownPreview({ source, highlightText }: MarkdownPrevi
           className={`text-xl font-bold border-b border-border pb-1 ${hl ? HIGHLIGHT_CLASS : ""}`}
         >
           <InlineText source={text} />
+          {activeMarker(hl)}
         </h1>
       );
       continue;
     }
     if (line.startsWith("## ")) {
       const text = line.slice(3);
+      currentSection = plainText(text);
+      seenFirstSection = true;
       const hl = shouldHighlight(text, highlightText);
       blocks.push(
         <h2
@@ -107,6 +152,7 @@ export default function MarkdownPreview({ source, highlightText }: MarkdownPrevi
           className={`text-base font-bold uppercase tracking-wide mt-4 ${hl ? HIGHLIGHT_CLASS : ""}`}
         >
           <InlineText source={text} />
+          {activeMarker(hl)}
         </h2>
       );
       continue;
@@ -121,19 +167,31 @@ export default function MarkdownPreview({ source, highlightText }: MarkdownPrevi
           className={`text-sm font-bold mt-2 ${hl ? HIGHLIGHT_CLASS : ""}`}
         >
           <InlineText source={text} />
+          {activeMarker(hl)}
         </h3>
       );
       continue;
     }
 
     const hl = shouldHighlight(line, highlightText);
+    const clickable = seenFirstSection && !!onLineClick && !hl;
     blocks.push(
       <p
         key={`p-${key++}`}
         ref={(node) => attachIfFirst(node, hl)}
         className={`text-sm ${hl ? HIGHLIGHT_CLASS : ""}`}
       >
-        <InlineText source={line} />
+        {clickable && onLineClick ? (
+          <DraftLine
+            text={line}
+            section={currentSection}
+            disabled={clickDisabled}
+            onSelect={onLineClick}
+          />
+        ) : (
+          <InlineText source={line} />
+        )}
+        {activeMarker(hl)}
       </p>
     );
   }

--- a/apps/myjobhunter/frontend/src/lib/resumeRefinementApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/resumeRefinementApi.ts
@@ -79,6 +79,18 @@ const resumeRefinementApi = baseApi
         invalidatesTags: (_result, _err, { id }) => [{ type: REFINEMENT_TAG, id }],
       }),
 
+      createTargetFromLine: build.mutation<
+        RefinementSession,
+        { id: string; current_text: string; section: string }
+      >({
+        query: ({ id, current_text, section }) => ({
+          url: `/resume-refinement/sessions/${id}/target-from-line`,
+          method: "POST",
+          data: { current_text, section },
+        }),
+        invalidatesTags: (_result, _err, { id }) => [{ type: REFINEMENT_TAG, id }],
+      }),
+
       retryPreparation: build.mutation<RefinementSession, string>({
         query: (id) => ({
           url: `/resume-refinement/sessions/${id}/retry-preparation`,
@@ -108,6 +120,7 @@ export const {
   useRequestAlternativeMutation,
   useSkipTargetMutation,
   useNavigateRefinementMutation,
+  useCreateTargetFromLineMutation,
   useRetryPreparationMutation,
   useCompleteRefinementSessionMutation,
 } = resumeRefinementApi;

--- a/apps/myjobhunter/frontend/src/types/resume-refinement/improvement-target.ts
+++ b/apps/myjobhunter/frontend/src/types/resume-refinement/improvement-target.ts
@@ -10,10 +10,15 @@ export type ImprovementType =
 
 export type ImprovementSeverity = "critical" | "high" | "medium" | "low";
 
+export type ImprovementTargetOrigin = "ai" | "user";
+
 export interface ImprovementTarget {
   section: string;
   current_text: string;
   improvement_type: ImprovementType;
   severity: ImprovementSeverity;
   notes: string | null;
+  /** "ai" for critique-chosen targets; "user" when the user clicked a
+   *  draft line. Optional for tolerance of pre-migration payloads. */
+  origin?: ImprovementTargetOrigin;
 }

--- a/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-turn.ts
+++ b/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-turn.ts
@@ -5,6 +5,7 @@ export type RefinementTurnRole =
   | "user_accept_flagged"
   | "user_custom"
   | "user_request_alternative"
+  | "user_created_target"
   | "user_skip"
   | "session_complete";
 


### PR DESCRIPTION
## What

PR 5 (final) of the /resume walkthrough fix-all (follows #960/#963/#964/#965/#966). Users can now click any bullet or paragraph after the first section heading in the draft panel to create their own improvement target — instead of only walking the AI critique's list.

## How

**Backend** — `POST /resume-refinement/sessions/{id}/target-from-line`:
- Dedups server-side by decoration-stripped text: clicking a line that already has a target jumps to it (cached proposal = instant); clicking the active line is a no-op.
- Otherwise inserts a **user-origin target immediately after the cursor** (not appended — the progress bar's "resolved" count stays accurate) and generates a proposal on-demand (user targets are never prefetched).
- New sibling `session_target_repo` module (session_repo sits at the 500-LOC growth guard) **remaps the index-keyed `proposal_cache` / `guard_flag_counts`** — without this, inserting mid-list would make navigation hydrate the WRONG cached proposal for every shifted target.
- New `user_created_target` turn role (migration `usertgt260702` widens the check constraint) so the transcript explains why the cursor jumped; `origin: "ai"|"user"` field on `ImprovementTarget` (JSONB — no column migration).

**Frontend** (g-design-ux spec applied):
- Clickable blocks are native buttons (`DraftLine`) — keyboard + SR semantics free, selection-drag guard so copy-dragging bullets never fires, hover tint + pencil affordance (always faintly visible for touch), `aria-label` states the action.
- Highlight moves to the clicked line **at click time**; the suggestion card shows the existing regenerating skeleton via the unified pending gate (`externalPending`) during the 2–10s generation; all other actions disabled meanwhile.
- One-time dismissible tip states discoverability + the fact-vs-phrasing boundary; the guard clarify state gains a "facts are edited in Profile" recovery link (new tab — preserves the in-progress session).
- "Your pick" badge replaces the severity/type pills for user-origin targets; new transcript case ("Picked from the draft: …").
- A11y gap fixes ridden along: `aria-live` on the suggestion body (focus never moves by convention here) and an sr-only marker on the amber active block (was color-only).

## Tests

- New `tests/test_resume_refinement_user_targets.py` (refinement CI shard): index-key remap invariant, insert-after-cursor + user-origin defaults, dedup jump (cache hit/miss), active-target no-op, empty-line rejection, section fallback.
- E2E (`resume-refinement.spec.ts`, mocked session): tip visible, non-active lines are labeled buttons / active line is not clickable, click sends raw line + nearest `##` section, user target lands with "Your pick" badge + its proposal.
- Frontend typecheck + build green; refinement suites 24 passed locally.

## Notes

- Failure handling matches the existing navigate cache-miss semantics: if generation fails the target stays with pending cleared and the card's existing regenerate affordance retries — dedup guarantees a re-click never duplicates the target.
- No operational migration: the turn-role migration is a data-free constraint widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHo57XAZpGMGwtvp8w1fQY