### PR TITLE
feat(myrecipes): public-read/auth-write — recipes browsable + shareable without an account

### DIFF
--- a/apps/mygamingassistant/frontend/src/RootLayout.tsx
+++ b/apps/mygamingassistant/frontend/src/RootLayout.tsx
@@ -10,14 +10,13 @@ import {
   Settings,
   Shield,
 } from "lucide-react";
-import { AppShell, StepUpModal, ThemeToggle, Toaster, useIsAuthenticated } from "@platform/ui";
+import { AppShell, GuestShell, StepUpModal, ThemeToggle, Toaster, useIsAuthenticated } from "@platform/ui";
 import { buildNav, PUBLIC_NAV_PATHS } from "@/constants/nav";
 import { signOut } from "@/lib/auth";
 import { useIsSuperuser } from "@/hooks/useIsSuperuser";
 import { useGetCurrentUserQuery } from "@/lib/userApi";
 import { isTauri } from "@/lib/tauri";
 import { isServeOnly } from "@/lib/serveOnly";
-import GuestShell from "@/components/auth/GuestShell";
 import type { CurrentUser } from "@/lib/userApi";
 
 const ANONYMOUS_USER = { name: "You", email: "" };

--- a/apps/mygamingassistant/frontend/src/__tests__/RootLayoutCompact.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/RootLayoutCompact.test.tsx
@@ -29,23 +29,21 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 const mockIsAuthenticated = vi.fn(() => false);
 
-// Minimal stubs for platform/ui components used in RootLayout.
+// Minimal stubs for platform/ui components used in RootLayout. GuestShell now
+// lives in @platform/ui (extracted from the local copy), so it's stubbed here
+// alongside AppShell — we just want to assert which shell renders, not exercise
+// its internals (those have their own tests in shared-frontend).
 vi.mock("@platform/ui", () => ({
   AppShell: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="app-shell">{children}</div>
+  ),
+  GuestShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="guest-shell">{children}</div>
   ),
   StepUpModal: () => <div data-testid="step-up-modal" />,
   ThemeToggle: () => <div data-testid="theme-toggle" />,
   Toaster: () => <div data-testid="toaster" />,
   useIsAuthenticated: () => mockIsAuthenticated(),
-}));
-
-// Mock GuestShell — we just want to assert that it renders, not exercise its
-// internals (those have their own tests).
-vi.mock("@/components/auth/GuestShell", () => ({
-  default: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="guest-shell">{children}</div>
-  ),
 }));
 
 vi.mock("@/constants/nav", () => ({

--- a/apps/mygamingassistant/frontend/src/routes.tsx
+++ b/apps/mygamingassistant/frontend/src/routes.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 import { Navigate, type RouteObject } from "react-router-dom";
-import { Support } from "@platform/ui";
+import { AuthRequired, Support } from "@platform/ui";
 import GameGrid from "@/pages/GameGrid";
 import LineupDetail from "@/pages/LineupDetail";
 import LineupPackages from "@/pages/LineupPackages";
@@ -21,7 +21,6 @@ import ResetPassword from "@/pages/ResetPassword";
 import VerifyEmail from "@/pages/VerifyEmail";
 import NotFound from "@/pages/NotFound";
 import RootLayout from "@/RootLayout";
-import AuthRequired from "@/components/auth/AuthRequired";
 import { isServeOnly } from "@/lib/serveOnly";
 
 // Serve-only mode (production public library): the backend mounts NO auth
@@ -69,7 +68,7 @@ export const routes: RouteObject[] = [
       {
         path: "/lineups/new",
         element: (
-          <AuthRequired action="upload a new lineup">
+          <AuthRequired action="upload a new lineup" unavailable={serveOnly}>
             <LineupUpload />
           </AuthRequired>
         ),
@@ -77,7 +76,7 @@ export const routes: RouteObject[] = [
       {
         path: "/sources",
         element: (
-          <AuthRequired action="manage video sources">
+          <AuthRequired action="manage video sources" unavailable={serveOnly}>
             <Sources />
           </AuthRequired>
         ),
@@ -85,7 +84,7 @@ export const routes: RouteObject[] = [
       {
         path: "/review",
         element: (
-          <AuthRequired action="review pending lineups">
+          <AuthRequired action="review pending lineups" unavailable={serveOnly}>
             <Review />
           </AuthRequired>
         ),
@@ -93,7 +92,7 @@ export const routes: RouteObject[] = [
       {
         path: "/live/cs2/setup",
         element: (
-          <AuthRequired action="install the GSI config">
+          <AuthRequired action="install the GSI config" unavailable={serveOnly}>
             <LiveCs2Setup />
           </AuthRequired>
         ),
@@ -101,7 +100,7 @@ export const routes: RouteObject[] = [
       {
         path: "/live/cs2/calibrate",
         element: (
-          <AuthRequired action="calibrate the minimap CV pipeline">
+          <AuthRequired action="calibrate the minimap CV pipeline" unavailable={serveOnly}>
             <LiveCs2Calibrate />
           </AuthRequired>
         ),
@@ -111,7 +110,7 @@ export const routes: RouteObject[] = [
         // specific path doesn't shadow the plan-mode map view.
         path: "/:gameSlug/:mapSlug/zones/edit",
         element: (
-          <AuthRequired action="edit map zones">
+          <AuthRequired action="edit map zones" unavailable={serveOnly}>
             <ZoneEditPage />
           </AuthRequired>
         ),
@@ -119,7 +118,7 @@ export const routes: RouteObject[] = [
       {
         path: "/settings",
         element: (
-          <AuthRequired action="manage your account">
+          <AuthRequired action="manage your account" unavailable={serveOnly}>
             <Settings />
           </AuthRequired>
         ),
@@ -127,7 +126,7 @@ export const routes: RouteObject[] = [
       {
         path: "/security",
         element: (
-          <AuthRequired action="manage account security">
+          <AuthRequired action="manage account security" unavailable={serveOnly}>
             <Security />
           </AuthRequired>
         ),

--- a/apps/myrecipes/backend/app/api/recipes.py
+++ b/apps/myrecipes/backend/app/api/recipes.py
@@ -1,27 +1,37 @@
 """HTTP routes for the MyRecipes domain — recipes, version history, cook logs.
 
-Every endpoint requires an authenticated user (``current_active_user``) and is
-tenant-scoped: a recipe/version/cook owned by another user yields 404 (no
-existence leak), like the canonical apps. Handlers are thin — they delegate to
-``recipe_service`` and translate ``None`` -> 404 and ``InvalidBaseVersionError``
--> 400.
+MyRecipes uses **public-read / auth-write** routing (mirrors MyGamingAssistant;
+see apps/myrecipes/CLAUDE.md and apps/mygamingassistant/CLAUDE.md → Authentication
+Model). This module exports two routers:
 
-Path map::
+    ``public_router`` — no auth dependency; anyone may browse the library:
+        GET /recipes                                  list (summaries)
+        GET /recipes/{id}                             detail (summary + latest version)
+        GET /recipes/{id}/versions                    timeline (version summaries)
+        GET /recipes/{id}/versions/{vid}              full version
+        GET /recipes/{id}/versions/{vid}/diff         diff vs parent (or ?against=)
 
-    GET    /recipes                                   list (summaries)
-    POST   /recipes                                   create recipe + v1
-    GET    /recipes/{id}                              detail (summary + latest version)
-    PATCH  /recipes/{id}                              edit metadata (title/desc/source)
-    DELETE /recipes/{id}                              soft-delete
-    GET    /recipes/{id}/versions                     timeline (version summaries)
-    POST   /recipes/{id}/versions                     tweak -> new version
-    GET    /recipes/{id}/versions/{vid}               full version
-    GET    /recipes/{id}/versions/{vid}/diff          diff vs parent (or ?against=)
-    POST   /recipes/{id}/versions/{vid}/restore       copy old version forward
-    POST   /recipes/{id}/versions/{vid}/cooks         log a cook (rating/notes)
-    GET    /recipes/{id}/versions/{vid}/cooks         cooks for a version
-    GET    /recipes/{id}/cooks                        cooks across the recipe
-    DELETE /recipes/{id}/cooks/{cook_id}              delete a cook log
+    ``auth_router`` — ``Depends(current_active_user)`` at the ROUTER level (never
+    per-handler, so a newly added write handler cannot regress to "no auth"):
+        POST   /recipes                               create recipe + v1
+        POST   /recipes/extract                       photo -> draft (Claude vision)
+        PATCH  /recipes/{id}                          edit metadata
+        DELETE /recipes/{id}                          soft-delete
+        POST   /recipes/{id}/versions                 tweak -> new version
+        POST   /recipes/{id}/versions/{vid}/restore   copy old version forward
+        POST   /recipes/{id}/versions/{vid}/cooks     log a cook (rating/notes)
+        GET    /recipes/{id}/versions/{vid}/cooks     cooks for a version (owner-only)
+        GET    /recipes/{id}/cooks                    cooks across the recipe (owner-only)
+        DELETE /recipes/{id}/cooks/{cook_id}          delete a cook log
+
+Security shape:
+- Public responses never carry ``user_id``. The service computes ``is_owner``
+  against the OPTIONAL viewer (``current_user_optional``) plus the owner's public
+  ``owner_display_name``. Cook-log rollups are owner-private (null for non-owners).
+- Cook logs are PRIVATE (owner-only) — all ``/cooks`` endpoints are auth-gated
+  and tenant-scoped; another user's cooks yield 404 (no existence leak).
+- Public reads use the service's dedicated public functions, which are NOT
+  tenant-scoped; every WRITE keeps threading ``user.id`` (cross-tenant -> 404).
 """
 from __future__ import annotations
 
@@ -30,7 +40,7 @@ import uuid
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Response, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import current_active_user
+from app.core.auth import current_active_user, current_user_optional
 from app.core.config import settings
 from app.db.session import get_db
 from app.models.user.user import User
@@ -51,28 +61,122 @@ from app.schemas.recipe.version_schemas import (
 from app.services.recipe import photo_extraction_service, recipe_service
 from app.services.recipe.recipe_service import InvalidBaseVersionError
 
-router = APIRouter(prefix="/recipes", tags=["recipes"])
+# Public read-only routes — no auth required.
+public_router = APIRouter(prefix="/recipes", tags=["recipes"])
+
+# Auth-required mutations + owner-only cook logs. Auth is enforced at the router
+# level rather than per-handler so gating cannot accidentally regress when new
+# handlers are added.
+auth_router = APIRouter(
+    prefix="/recipes",
+    tags=["recipes"],
+    dependencies=[Depends(current_active_user)],
+)
 
 _RECIPE_NOT_FOUND = "Recipe not found"
 _VERSION_NOT_FOUND = "Version not found"
 _COOK_NOT_FOUND = "Cook log not found"
 
 
-# ---------------------------------------------------------------------------
-# Recipes
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# Public routes — read-only, not tenant-scoped
+# ===========================================================================
 
 
-@router.get("", response_model=list[RecipeSummary])
+@public_router.get("", response_model=list[RecipeSummary])
 async def list_recipes(
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(current_active_user),
+    viewer: User | None = Depends(current_user_optional),
     search: str | None = Query(default=None, description="Case-insensitive title filter"),
+    owner: str | None = Query(
+        default=None,
+        description="Set to 'me' to list only your own recipes (requires auth).",
+    ),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
 ) -> list[RecipeSummary]:
-    return await recipe_service.list_recipes(db, user.id, search=search)
+    """List recipes. Public — no auth required.
+
+    ``owner=me`` scopes the list to the authenticated viewer's own recipes and
+    responds 401 if used anonymously. Rollups (best_rating/last_cooked_at) are
+    populated only on recipes the viewer owns.
+    """
+    if owner is not None and owner != "me":
+        raise HTTPException(status_code=422, detail="owner must be 'me' when provided")
+    owner_me = owner == "me"
+    if owner_me and viewer is None:
+        raise HTTPException(
+            status_code=401, detail="Authentication required for owner=me"
+        )
+    viewer_id = viewer.id if viewer is not None else None
+    return await recipe_service.list_public_recipes(
+        db, viewer_id, search=search, limit=limit, offset=offset, owner_me=owner_me,
+    )
 
 
-@router.post("", response_model=RecipeDetailResponse, status_code=201)
+@public_router.get("/{recipe_id}", response_model=RecipeDetailResponse)
+async def get_recipe(
+    recipe_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    viewer: User | None = Depends(current_user_optional),
+) -> RecipeDetailResponse:
+    viewer_id = viewer.id if viewer is not None else None
+    detail = await recipe_service.get_public_recipe_detail(db, viewer_id, recipe_id)
+    if detail is None:
+        raise HTTPException(status_code=404, detail=_RECIPE_NOT_FOUND)
+    return detail
+
+
+@public_router.get("/{recipe_id}/versions", response_model=list[VersionSummary])
+async def list_versions(
+    recipe_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    viewer: User | None = Depends(current_user_optional),
+) -> list[VersionSummary]:
+    viewer_id = viewer.id if viewer is not None else None
+    versions = await recipe_service.list_public_versions(db, viewer_id, recipe_id)
+    if versions is None:
+        raise HTTPException(status_code=404, detail=_RECIPE_NOT_FOUND)
+    return versions
+
+
+@public_router.get("/{recipe_id}/versions/{version_id}", response_model=VersionResponse)
+async def get_version(
+    recipe_id: uuid.UUID,
+    version_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> VersionResponse:
+    version = await recipe_service.get_public_version(db, recipe_id, version_id)
+    if version is None:
+        raise HTTPException(status_code=404, detail=_VERSION_NOT_FOUND)
+    return version
+
+
+@public_router.get("/{recipe_id}/versions/{version_id}/diff", response_model=DiffResponse)
+async def diff_version(
+    recipe_id: uuid.UUID,
+    version_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    against: uuid.UUID | None = Query(
+        default=None,
+        description="Version to compare against. Defaults to this version's parent.",
+    ),
+) -> DiffResponse:
+    try:
+        diff = await recipe_service.diff_public_versions(db, recipe_id, version_id, against)
+    except InvalidBaseVersionError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if diff is None:
+        raise HTTPException(status_code=404, detail=_VERSION_NOT_FOUND)
+    return diff
+
+
+# ===========================================================================
+# Auth-required routes — writes + owner-only cook logs
+# ===========================================================================
+
+
+@auth_router.post("", response_model=RecipeDetailResponse, status_code=201)
 async def create_recipe(
     payload: RecipeCreateRequest,
     db: AsyncSession = Depends(get_db),
@@ -81,7 +185,7 @@ async def create_recipe(
     return await recipe_service.create_recipe(db, user.id, payload)
 
 
-@router.post("/extract", response_model=RecipeDraftResponse)
+@auth_router.post("/extract", response_model=RecipeDraftResponse)
 async def extract_recipe_photo(
     file: UploadFile = File(...),
     user: User = Depends(current_active_user),
@@ -115,19 +219,7 @@ async def extract_recipe_photo(
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
-@router.get("/{recipe_id}", response_model=RecipeDetailResponse)
-async def get_recipe(
-    recipe_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    user: User = Depends(current_active_user),
-) -> RecipeDetailResponse:
-    detail = await recipe_service.get_recipe_detail(db, user.id, recipe_id)
-    if detail is None:
-        raise HTTPException(status_code=404, detail=_RECIPE_NOT_FOUND)
-    return detail
-
-
-@router.patch("/{recipe_id}", response_model=RecipeDetailResponse)
+@auth_router.patch("/{recipe_id}", response_model=RecipeDetailResponse)
 async def update_recipe(
     recipe_id: uuid.UUID,
     payload: RecipeUpdateRequest,
@@ -140,7 +232,7 @@ async def update_recipe(
     return detail
 
 
-@router.delete("/{recipe_id}", status_code=204)
+@auth_router.delete("/{recipe_id}", status_code=204)
 async def delete_recipe(
     recipe_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -152,24 +244,7 @@ async def delete_recipe(
     return Response(status_code=204)
 
 
-# ---------------------------------------------------------------------------
-# Versions
-# ---------------------------------------------------------------------------
-
-
-@router.get("/{recipe_id}/versions", response_model=list[VersionSummary])
-async def list_versions(
-    recipe_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    user: User = Depends(current_active_user),
-) -> list[VersionSummary]:
-    versions = await recipe_service.list_versions(db, user.id, recipe_id)
-    if versions is None:
-        raise HTTPException(status_code=404, detail=_RECIPE_NOT_FOUND)
-    return versions
-
-
-@router.post("/{recipe_id}/versions", response_model=VersionResponse, status_code=201)
+@auth_router.post("/{recipe_id}/versions", response_model=VersionResponse, status_code=201)
 async def create_version(
     recipe_id: uuid.UUID,
     payload: VersionCreateRequest,
@@ -185,40 +260,7 @@ async def create_version(
     return version
 
 
-@router.get("/{recipe_id}/versions/{version_id}", response_model=VersionResponse)
-async def get_version(
-    recipe_id: uuid.UUID,
-    version_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    user: User = Depends(current_active_user),
-) -> VersionResponse:
-    version = await recipe_service.get_version(db, user.id, recipe_id, version_id)
-    if version is None:
-        raise HTTPException(status_code=404, detail=_VERSION_NOT_FOUND)
-    return version
-
-
-@router.get("/{recipe_id}/versions/{version_id}/diff", response_model=DiffResponse)
-async def diff_version(
-    recipe_id: uuid.UUID,
-    version_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    user: User = Depends(current_active_user),
-    against: uuid.UUID | None = Query(
-        default=None,
-        description="Version to compare against. Defaults to this version's parent.",
-    ),
-) -> DiffResponse:
-    try:
-        diff = await recipe_service.diff_versions(db, user.id, recipe_id, version_id, against)
-    except InvalidBaseVersionError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if diff is None:
-        raise HTTPException(status_code=404, detail=_VERSION_NOT_FOUND)
-    return diff
-
-
-@router.post(
+@auth_router.post(
     "/{recipe_id}/versions/{version_id}/restore",
     response_model=VersionResponse,
     status_code=201,
@@ -236,11 +278,11 @@ async def restore_version(
 
 
 # ---------------------------------------------------------------------------
-# Cook logs
+# Cook logs — PRIVATE (owner-only). Never public.
 # ---------------------------------------------------------------------------
 
 
-@router.post(
+@auth_router.post(
     "/{recipe_id}/versions/{version_id}/cooks",
     response_model=CookLogResponse,
     status_code=201,
@@ -258,7 +300,7 @@ async def log_cook(
     return cook
 
 
-@router.get(
+@auth_router.get(
     "/{recipe_id}/versions/{version_id}/cooks",
     response_model=list[CookLogResponse],
 )
@@ -274,7 +316,7 @@ async def list_version_cooks(
     return cooks
 
 
-@router.get("/{recipe_id}/cooks", response_model=list[CookLogResponse])
+@auth_router.get("/{recipe_id}/cooks", response_model=list[CookLogResponse])
 async def list_recipe_cooks(
     recipe_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -286,7 +328,7 @@ async def list_recipe_cooks(
     return cooks
 
 
-@router.delete("/{recipe_id}/cooks/{cook_id}", status_code=204)
+@auth_router.delete("/{recipe_id}/cooks/{cook_id}", status_code=204)
 async def delete_cook(
     recipe_id: uuid.UUID,
     cook_id: uuid.UUID,

--- a/apps/myrecipes/backend/app/core/auth.py
+++ b/apps/myrecipes/backend/app/core/auth.py
@@ -94,3 +94,11 @@ auth_backend = _jwt.auth_backend
 
 fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend])
 current_active_user = fastapi_users.current_user(active=True, verified=True)
+
+# Optional viewer identity for public-read routes: resolves to the User when a
+# valid bearer token is present, or None for anonymous callers. Used to compute
+# ``is_owner`` and gate owner-only fields (cook-log rollups) without forcing
+# auth on public reads. See apps/myrecipes/CLAUDE.md and the recipes router.
+current_user_optional = fastapi_users.current_user(
+    active=True, verified=True, optional=True,
+)

--- a/apps/myrecipes/backend/app/main.py
+++ b/apps/myrecipes/backend/app/main.py
@@ -181,7 +181,10 @@ app.include_router(health.router, tags=["health"])
 app.include_router(admin.router)
 
 # App-specific domain routes (MyRecipes): recipes + version history + cook logs.
-app.include_router(recipes.router)
+# Public-read / auth-write split — public_router is unauthenticated (browse the
+# library), auth_router gates writes + owner-only cook logs at the router level.
+app.include_router(recipes.public_router)
+app.include_router(recipes.auth_router)
 
 # Shared platform admin router -- generic user-management endpoints
 # (list/role/activate/deactivate/superuser/stats-users).

--- a/apps/myrecipes/backend/app/repositories/recipe/recipe_repository.py
+++ b/apps/myrecipes/backend/app/repositories/recipe/recipe_repository.py
@@ -36,18 +36,69 @@ async def get_by_id(
 
 
 async def list_by_user(
-    db: AsyncSession, user_id: uuid.UUID, *, search: str | None = None,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    search: str | None = None,
+    limit: int | None = None,
+    offset: int = 0,
 ) -> list[Recipe]:
     """List a user's non-deleted recipes, most-recently-updated first.
 
+    Tenant-scoped: always filters by ``user_id``. Backs the authenticated
+    ``owner=me`` view on the public list route.
+
     Optional ``search``: case-insensitive substring on ``title``.
+    Optional ``limit``/``offset``: page the result set (offset ignored when
+    limit is None).
     """
     stmt = select(Recipe).where(Recipe.user_id == user_id, Recipe.deleted_at.is_(None))
     if search is not None and search.strip():
         stmt = stmt.where(Recipe.title.ilike(f"%{search.strip()}%"))
     stmt = stmt.order_by(Recipe.updated_at.desc())
+    if limit is not None:
+        stmt = stmt.limit(limit).offset(offset)
     result = await db.execute(stmt)
     return list(result.scalars().all())
+
+
+async def list_public(
+    db: AsyncSession,
+    *,
+    search: str | None = None,
+    limit: int,
+    offset: int = 0,
+) -> list[Recipe]:
+    """List every non-deleted recipe, most-recently-updated first.
+
+    Public read: deliberately NOT tenant-scoped — anyone may browse the
+    recipe library. Dedicated function (never a ``user_id=None`` overload of
+    :func:`list_by_user`) so a tenant-scoped write path can never accidentally
+    fall through to an unscoped query. Always paginated.
+
+    Optional ``search``: case-insensitive substring on ``title`` (bind param).
+    """
+    stmt = select(Recipe).where(Recipe.deleted_at.is_(None))
+    if search is not None and search.strip():
+        stmt = stmt.where(Recipe.title.ilike(f"%{search.strip()}%"))
+    stmt = stmt.order_by(Recipe.updated_at.desc()).limit(limit).offset(offset)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_public_by_id(db: AsyncSession, recipe_id: uuid.UUID) -> Recipe | None:
+    """Return a non-deleted recipe by id, with NO tenant filter.
+
+    Public read companion to :func:`get_by_id`. A soft-deleted or missing
+    recipe returns ``None`` (the route maps both to an identical 404).
+    """
+    result = await db.execute(
+        select(Recipe).where(
+            Recipe.id == recipe_id,
+            Recipe.deleted_at.is_(None),
+        )
+    )
+    return result.scalar_one_or_none()
 
 
 async def create(db: AsyncSession, recipe: Recipe) -> Recipe:

--- a/apps/myrecipes/backend/app/repositories/recipe/recipe_version_repository.py
+++ b/apps/myrecipes/backend/app/repositories/recipe/recipe_version_repository.py
@@ -37,6 +37,38 @@ async def list_by_recipe(
     return list(result.scalars().all())
 
 
+async def list_by_recipe_public(
+    db: AsyncSession, recipe_id: uuid.UUID,
+) -> list[RecipeVersion]:
+    """All versions of a recipe, oldest first — NO tenant filter.
+
+    Public read companion to :func:`list_by_recipe`. Every version of a recipe
+    is owned by that recipe's owner, so scoping by ``recipe_id`` alone is
+    sufficient and lets non-owners browse the timeline. Caller is responsible
+    for confirming the recipe itself is public (non-deleted) first.
+    """
+    result = await db.execute(
+        select(RecipeVersion)
+        .where(RecipeVersion.recipe_id == recipe_id)
+        .order_by(RecipeVersion.version_number.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def get_by_id_public(
+    db: AsyncSession, version_id: uuid.UUID,
+) -> RecipeVersion | None:
+    """Return a version by id with NO tenant filter.
+
+    Public read companion to :func:`get_by_id`. Caller confirms the parent
+    recipe is public and that ``recipe_id`` matches before returning it.
+    """
+    result = await db.execute(
+        select(RecipeVersion).where(RecipeVersion.id == version_id)
+    )
+    return result.scalar_one_or_none()
+
+
 async def get_latest(
     db: AsyncSession, recipe_id: uuid.UUID, user_id: uuid.UUID,
 ) -> RecipeVersion | None:

--- a/apps/myrecipes/backend/app/repositories/user/user_repo.py
+++ b/apps/myrecipes/backend/app/repositories/user/user_repo.py
@@ -3,7 +3,9 @@
 Mirrors apps/myjobhunter/backend/app/repositories/user/user_repo.py.
 """
 import uuid
+from collections.abc import Iterable
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from platform_shared.repositories.user_repo import (
@@ -17,6 +19,24 @@ from app.models.user.user import User
 
 async def get_by_id(db: AsyncSession, user_id: uuid.UUID) -> User | None:
     return await _shared_get_by_id(db, user_id, user_model=User)
+
+
+async def display_names_by_ids(
+    db: AsyncSession, user_ids: Iterable[uuid.UUID],
+) -> dict[uuid.UUID, str]:
+    """{user_id: display_name} for the given owners (one grouped query).
+
+    Backs the ``owner_display_name`` field on public recipe responses. Never
+    selects any other user column — only the id and the public display name.
+    Missing rows / null names collapse to ``""``.
+    """
+    ids = list(user_ids)
+    if not ids:
+        return {}
+    result = await db.execute(
+        select(User.id, User.display_name).where(User.id.in_(ids))
+    )
+    return {row[0]: (row[1] or "") for row in result.all()}
 
 
 async def get_by_email(db: AsyncSession, email: str) -> User | None:

--- a/apps/myrecipes/backend/app/schemas/recipe/recipe_schemas.py
+++ b/apps/myrecipes/backend/app/schemas/recipe/recipe_schemas.py
@@ -44,12 +44,18 @@ class RecipeUpdateRequest(BaseModel):
 
 
 class RecipeSummary(BaseModel):
-    """List-view recipe: identity + rollups, no version bodies."""
+    """List-view recipe: identity + rollups, no version bodies.
+
+    Public-read safe: the owner's ``user_id`` is never exposed. Instead the
+    server computes ``is_owner`` (against the OPTIONAL current viewer) and
+    surfaces the owner's public ``owner_display_name``. Cook-log rollups
+    (``best_rating`` / ``last_cooked_at``) are private — the service leaves
+    them ``None`` for any viewer who does not own the recipe.
+    """
 
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
-    user_id: uuid.UUID
     title: str
     description: str | None = None
     source: str | None = None
@@ -57,6 +63,8 @@ class RecipeSummary(BaseModel):
     updated_at: datetime
     version_count: int = 0
     latest_version_number: int | None = None
+    is_owner: bool = False
+    owner_display_name: str = ""
     best_rating: int | None = None
     last_cooked_at: datetime | None = None
 

--- a/apps/myrecipes/backend/app/schemas/recipe/version_schemas.py
+++ b/apps/myrecipes/backend/app/schemas/recipe/version_schemas.py
@@ -97,7 +97,12 @@ class VersionResponse(BaseModel):
 
 
 class VersionSummary(BaseModel):
-    """Timeline entry — lightweight, no ingredient/step bodies."""
+    """Timeline entry — lightweight, no ingredient/step bodies.
+
+    ``cook_count`` and ``best_rating`` are owner-private cook-log rollups: the
+    service populates them only when the viewer owns the recipe and leaves both
+    ``None`` for any other viewer (so cook activity never leaks publicly).
+    """
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -105,5 +110,5 @@ class VersionSummary(BaseModel):
     version_number: int
     change_note: str | None = None
     created_at: datetime
-    cook_count: int = 0
+    cook_count: int | None = None
     best_rating: int | None = None

--- a/apps/myrecipes/backend/app/services/recipe/recipe_service.py
+++ b/apps/myrecipes/backend/app/services/recipe/recipe_service.py
@@ -27,6 +27,7 @@ from app.repositories.recipe import (
     recipe_repository,
     recipe_version_repository,
 )
+from app.repositories.user import user_repo as user_repository
 from app.schemas.recipe.cook_log_schemas import CookLogCreateRequest, CookLogResponse
 from app.schemas.recipe.diff_schemas import DiffResponse
 from app.schemas.recipe.recipe_schemas import (
@@ -80,19 +81,36 @@ def _make_steps(version_id: uuid.UUID, inputs: list[StepInput]) -> list[RecipeSt
 
 
 async def _build_detail(
-    db: AsyncSession, recipe: Recipe, user_id: uuid.UUID,
+    db: AsyncSession,
+    recipe: Recipe,
+    versions: list[RecipeVersion],
+    viewer_id: uuid.UUID | None,
 ) -> RecipeDetailResponse:
     """Assemble a recipe's detail DTO (summary rollups + full latest version).
 
-    Reads see flushed-but-uncommitted rows, so callers may invoke this before
-    committing a write.
+    ``viewer_id`` is the OPTIONAL current user. ``is_owner`` is computed against
+    it; the owner's ``user_id`` is never placed on the wire. Cook-log rollups
+    (``best_rating`` / ``last_cooked_at``) are owner-private — they stay ``None``
+    for any non-owner viewer, and the rollup query is only issued when the
+    viewer owns the recipe (so another user's cook data is never even read).
+
+    ``versions`` is passed in by the caller so the right access path is used —
+    tenant-scoped for write flows, the public (recipe-scoped) listing for public
+    reads. Reads see flushed-but-uncommitted rows, so callers may invoke this
+    before committing a write.
     """
-    versions = await recipe_version_repository.list_by_recipe(db, recipe.id, user_id)
+    is_owner = viewer_id is not None and viewer_id == recipe.user_id
     latest = versions[-1] if versions else None
-    best_map = await cook_log_repository.best_rating_and_last_cooked_by_recipe(
-        db, [recipe.id]
-    )
-    best_rating, last_cooked = best_map.get(recipe.id, (None, None))
+
+    best_rating: int | None = None
+    last_cooked: datetime | None = None
+    if is_owner:
+        best_map = await cook_log_repository.best_rating_and_last_cooked_by_recipe(
+            db, [recipe.id]
+        )
+        best_rating, last_cooked = best_map.get(recipe.id, (None, None))
+
+    names = await user_repository.display_names_by_ids(db, {recipe.user_id})
 
     latest_dto: VersionResponse | None = None
     if latest is not None:
@@ -102,7 +120,6 @@ async def _build_detail(
 
     return RecipeDetailResponse(
         id=recipe.id,
-        user_id=recipe.user_id,
         title=recipe.title,
         description=recipe.description,
         source=recipe.source,
@@ -110,6 +127,8 @@ async def _build_detail(
         updated_at=recipe.updated_at,
         version_count=len(versions),
         latest_version_number=latest.version_number if latest else None,
+        is_owner=is_owner,
+        owner_display_name=names.get(recipe.user_id, ""),
         best_rating=best_rating,
         last_cooked_at=last_cooked,
         latest_version=latest_dto,
@@ -149,27 +168,59 @@ async def create_recipe(
     )
     await recipe_version_repository.add_steps(db, _make_steps(version.id, req.steps))
 
-    detail = await _build_detail(db, recipe, user_id)
+    versions = await recipe_version_repository.list_by_recipe(db, recipe.id, user_id)
+    detail = await _build_detail(db, recipe, versions, user_id)
     await db.commit()
     return detail
 
 
-async def list_recipes(
-    db: AsyncSession, user_id: uuid.UUID, *, search: str | None = None,
+async def list_public_recipes(
+    db: AsyncSession,
+    viewer_id: uuid.UUID | None,
+    *,
+    search: str | None = None,
+    limit: int,
+    offset: int = 0,
+    owner_me: bool = False,
 ) -> list[RecipeSummary]:
-    recipes = await recipe_repository.list_by_user(db, user_id, search=search)
+    """List recipes for the public library (or the viewer's own with owner_me).
+
+    ``viewer_id`` is the OPTIONAL current user. When ``owner_me`` is set the
+    result is scoped to the viewer's recipes (the route rejects anonymous
+    ``owner=me`` with 401 before we get here). Otherwise every non-deleted
+    recipe is returned, paginated.
+
+    ``is_owner`` is computed per row; ``user_id`` is never returned. Cook-log
+    rollups are populated only for recipes the viewer owns — the rollup query
+    is issued for owned ids only, so another user's cook data is never read.
+    """
+    if owner_me:
+        assert viewer_id is not None  # route guarantees this
+        recipes = await recipe_repository.list_by_user(
+            db, viewer_id, search=search, limit=limit, offset=offset,
+        )
+    else:
+        recipes = await recipe_repository.list_public(
+            db, search=search, limit=limit, offset=offset,
+        )
+
     recipe_ids = [r.id for r in recipes]
     counts = await recipe_version_repository.counts_and_latest_by_recipe(db, recipe_ids)
-    cooks = await cook_log_repository.best_rating_and_last_cooked_by_recipe(db, recipe_ids)
+    names = await user_repository.display_names_by_ids(db, {r.user_id for r in recipes})
+
+    owned_ids = [
+        r.id for r in recipes if viewer_id is not None and r.user_id == viewer_id
+    ]
+    cooks = await cook_log_repository.best_rating_and_last_cooked_by_recipe(db, owned_ids)
 
     summaries: list[RecipeSummary] = []
     for r in recipes:
+        is_owner = viewer_id is not None and r.user_id == viewer_id
         version_count, latest_number = counts.get(r.id, (0, None))
-        best_rating, last_cooked = cooks.get(r.id, (None, None))
+        best_rating, last_cooked = cooks.get(r.id, (None, None)) if is_owner else (None, None)
         summaries.append(
             RecipeSummary(
                 id=r.id,
-                user_id=r.user_id,
                 title=r.title,
                 description=r.description,
                 source=r.source,
@@ -177,6 +228,8 @@ async def list_recipes(
                 updated_at=r.updated_at,
                 version_count=version_count,
                 latest_version_number=latest_number,
+                is_owner=is_owner,
+                owner_display_name=names.get(r.user_id, ""),
                 best_rating=best_rating,
                 last_cooked_at=last_cooked,
             )
@@ -184,13 +237,17 @@ async def list_recipes(
     return summaries
 
 
-async def get_recipe_detail(
-    db: AsyncSession, user_id: uuid.UUID, recipe_id: uuid.UUID,
+async def get_public_recipe_detail(
+    db: AsyncSession, viewer_id: uuid.UUID | None, recipe_id: uuid.UUID,
 ) -> RecipeDetailResponse | None:
-    recipe = await recipe_repository.get_by_id(db, recipe_id, user_id)
+    """Public recipe detail. Returns None for a missing OR soft-deleted recipe
+    (the route maps both to an identical 404 — no soft-delete existence leak).
+    """
+    recipe = await recipe_repository.get_public_by_id(db, recipe_id)
     if recipe is None:
         return None
-    return await _build_detail(db, recipe, user_id)
+    versions = await recipe_version_repository.list_by_recipe_public(db, recipe.id)
+    return await _build_detail(db, recipe, versions, viewer_id)
 
 
 async def update_recipe(
@@ -202,7 +259,8 @@ async def update_recipe(
     updates = req.model_dump(exclude_unset=True)
     if updates:
         await recipe_repository.update(db, recipe, updates)
-    detail = await _build_detail(db, recipe, user_id)
+    versions = await recipe_version_repository.list_by_recipe(db, recipe.id, user_id)
+    detail = await _build_detail(db, recipe, versions, user_id)
     await db.commit()
     return detail
 
@@ -223,36 +281,61 @@ async def delete_recipe(
 # ---------------------------------------------------------------------------
 
 
-async def list_versions(
-    db: AsyncSession, user_id: uuid.UUID, recipe_id: uuid.UUID,
+async def list_public_versions(
+    db: AsyncSession, viewer_id: uuid.UUID | None, recipe_id: uuid.UUID,
 ) -> list[VersionSummary] | None:
-    recipe = await recipe_repository.get_by_id(db, recipe_id, user_id)
+    """Public version timeline. Returns None for a missing/soft-deleted recipe.
+
+    Per-version cook rollups (``cook_count`` / ``best_rating``) are owner-
+    private: they are populated only when the viewer owns the recipe, and stay
+    ``None`` for everyone else. The rollup query runs for owners only.
+    """
+    recipe = await recipe_repository.get_public_by_id(db, recipe_id)
     if recipe is None:
         return None
-    versions = await recipe_version_repository.list_by_recipe(db, recipe_id, user_id)
-    agg = await cook_log_repository.counts_and_best_by_version(
-        db, [v.id for v in versions]
-    )
+    versions = await recipe_version_repository.list_by_recipe_public(db, recipe_id)
+    is_owner = viewer_id is not None and viewer_id == recipe.user_id
+
+    if is_owner:
+        agg = await cook_log_repository.counts_and_best_by_version(
+            db, [v.id for v in versions]
+        )
+        return [
+            VersionSummary(
+                id=v.id,
+                version_number=v.version_number,
+                change_note=v.change_note,
+                created_at=v.created_at,
+                cook_count=agg.get(v.id, (0, None))[0],
+                best_rating=agg.get(v.id, (0, None))[1],
+            )
+            for v in versions
+        ]
+
     return [
         VersionSummary(
             id=v.id,
             version_number=v.version_number,
             change_note=v.change_note,
             created_at=v.created_at,
-            cook_count=agg.get(v.id, (0, None))[0],
-            best_rating=agg.get(v.id, (0, None))[1],
+            cook_count=None,
+            best_rating=None,
         )
         for v in versions
     ]
 
 
-async def get_version(
-    db: AsyncSession, user_id: uuid.UUID, recipe_id: uuid.UUID, version_id: uuid.UUID,
+async def get_public_version(
+    db: AsyncSession, recipe_id: uuid.UUID, version_id: uuid.UUID,
 ) -> VersionResponse | None:
-    recipe = await recipe_repository.get_by_id(db, recipe_id, user_id)
+    """Public single version. None for a missing/soft-deleted recipe or a
+    version that isn't part of it. ``VersionResponse`` carries no cook data, so
+    no viewer gating is needed here.
+    """
+    recipe = await recipe_repository.get_public_by_id(db, recipe_id)
     if recipe is None:
         return None
-    version = await recipe_version_repository.get_by_id(db, version_id, user_id)
+    version = await recipe_version_repository.get_by_id_public(db, version_id)
     if version is None or version.recipe_id != recipe_id:
         return None
     ingredients = await recipe_version_repository.get_ingredients(db, version.id)
@@ -357,28 +440,33 @@ async def restore_version(
     return dto
 
 
-async def diff_versions(
+async def diff_public_versions(
     db: AsyncSession,
-    user_id: uuid.UUID,
     recipe_id: uuid.UUID,
     version_id: uuid.UUID,
     against_id: uuid.UUID | None = None,
 ) -> DiffResponse | None:
-    """Diff ``version_id`` against ``against_id`` (default: its parent version)."""
-    recipe = await recipe_repository.get_by_id(db, recipe_id, user_id)
+    """Public diff of ``version_id`` against ``against_id`` (default: its parent).
+
+    None for a missing/soft-deleted recipe or a ``version_id`` that isn't part
+    of it. Raises InvalidBaseVersionError (route -> 400) when an explicit
+    ``against`` isn't a version of this recipe. Diffs expose only ingredient/
+    step content — no cook data — so no viewer gating is required.
+    """
+    recipe = await recipe_repository.get_public_by_id(db, recipe_id)
     if recipe is None:
         return None
-    to_version = await recipe_version_repository.get_by_id(db, version_id, user_id)
+    to_version = await recipe_version_repository.get_by_id_public(db, version_id)
     if to_version is None or to_version.recipe_id != recipe_id:
         return None
 
     if against_id is not None:
-        from_version = await recipe_version_repository.get_by_id(db, against_id, user_id)
+        from_version = await recipe_version_repository.get_by_id_public(db, against_id)
         if from_version is None or from_version.recipe_id != recipe_id:
             raise InvalidBaseVersionError("against version is not a version of this recipe")
     elif to_version.parent_version_id is not None:
-        from_version = await recipe_version_repository.get_by_id(
-            db, to_version.parent_version_id, user_id
+        from_version = await recipe_version_repository.get_by_id_public(
+            db, to_version.parent_version_id
         )
     else:
         from_version = None  # v1 — nothing precedes it; everything is "added".

--- a/apps/myrecipes/backend/tests/test_recipes.py
+++ b/apps/myrecipes/backend/tests/test_recipes.py
@@ -7,6 +7,8 @@ real Postgres in CI; the user-delete cascade cleans up all recipe rows.
 """
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from httpx import AsyncClient
 
@@ -46,7 +48,11 @@ class TestCreateRecipe:
 
         assert resp.status_code == 201, resp.text
         body = resp.json()
-        assert body["user_id"] == user["id"]
+        # Public-read safe: the owner's user_id is never on the wire; the
+        # creator sees is_owner=true and their own display name instead.
+        assert "user_id" not in body
+        assert body["is_owner"] is True
+        assert isinstance(body["owner_display_name"], str)
         assert body["title"] == "Chocolate Chip Cookies"
         assert body["version_count"] == 1
         assert body["latest_version_number"] == 1
@@ -79,35 +85,46 @@ class TestCreateRecipe:
 
 class TestReadRecipes:
     @pytest.mark.asyncio
-    async def test_list_returns_caller_recipes(self, user_factory, as_user) -> None:
+    async def test_owner_me_returns_caller_recipes(self, user_factory, as_user) -> None:
+        # owner=me is the tenant-scoped "My recipes" view (deterministic count).
         user = await user_factory()
+        title = f"Caller Recipe {uuid.uuid4().hex[:8]}"
         async with await as_user(user) as authed:
-            await authed.post("/recipes", json=_recipe_payload())
-            resp = await authed.get("/recipes")
+            await authed.post("/recipes", json=_recipe_payload(title=title))
+            resp = await authed.get("/recipes", params={"owner": "me"})
         assert resp.status_code == 200
         body = resp.json()
         assert len(body) == 1
-        assert body[0]["title"] == "Chocolate Chip Cookies"
+        assert body[0]["title"] == title
+        assert body[0]["is_owner"] is True
 
     @pytest.mark.asyncio
-    async def test_list_does_not_leak_other_users(self, user_factory, as_user) -> None:
+    async def test_owner_me_does_not_leak_other_users(self, user_factory, as_user) -> None:
         owner = await user_factory()
         attacker = await user_factory()
         async with await as_user(owner) as authed:
             await authed.post("/recipes", json=_recipe_payload())
         async with await as_user(attacker) as authed:
-            resp = await authed.get("/recipes")
+            resp = await authed.get("/recipes", params={"owner": "me"})
+        # owner=me is scoped to the caller — the attacker owns nothing.
         assert resp.json() == []
 
     @pytest.mark.asyncio
-    async def test_get_other_users_recipe_returns_404(self, user_factory, as_user) -> None:
+    async def test_other_user_can_read_but_not_own(self, user_factory, as_user) -> None:
+        # Public-read: a logged-in non-owner can fetch someone else's recipe,
+        # but is_owner is false and rollups are private (null).
         owner = await user_factory()
         attacker = await user_factory()
         async with await as_user(owner) as authed:
             recipe_id = (await authed.post("/recipes", json=_recipe_payload())).json()["id"]
         async with await as_user(attacker) as authed:
             resp = await authed.get(f"/recipes/{recipe_id}")
-        assert resp.status_code == 404
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["is_owner"] is False
+        assert "user_id" not in body
+        assert body["best_rating"] is None
+        assert body["last_cooked_at"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/myrecipes/backend/tests/test_recipes_public.py
+++ b/apps/myrecipes/backend/tests/test_recipes_public.py
@@ -1,0 +1,358 @@
+"""Public-read / auth-write behavior for the recipe library.
+
+Mirrors MyGamingAssistant's split: reads are public (anonymous callers can
+browse), writes + cook logs require auth. These tests assert the security
+contract from the design review:
+
+- Responses NEVER carry ``user_id``; the server computes ``is_owner`` +
+  ``owner_display_name`` instead.
+- Cook-log rollups (recipe best_rating/last_cooked_at, version
+  cook_count/best_rating) are owner-private — null for anyone else.
+- ``owner=me`` scopes the list to the authenticated caller (401 anonymously).
+- Soft-deleted / missing recipes 404 identically on every public route.
+- The public list is paginated (limit honored + capped).
+
+Recipes are committed to the real Postgres (the service commits) and cleaned up
+via the user-delete cascade on teardown, so count-sensitive assertions always
+scope by a unique title (``search=``) or by ``owner=me``.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+
+
+def _payload(title: str, **overrides: Any) -> dict:
+    payload = {
+        "title": title,
+        "description": "A public recipe",
+        "source": "cookbook",
+        "servings": "4",
+        "prep_minutes": 10,
+        "cook_minutes": 20,
+        "ingredients": [
+            {"name": "flour", "quantity": 2, "unit": "cup"},
+            {"name": "salt", "quantity": 1, "unit": "tsp"},
+        ],
+        "steps": [
+            {"instruction": "Mix the dry ingredients."},
+            {"instruction": "Bake until golden."},
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def _create_recipe(as_user, owner: dict, title: str) -> dict:
+    async with await as_user(owner) as authed:
+        resp = await authed.post("/recipes", json=_payload(title))
+        assert resp.status_code == 201, resp.text
+        return resp.json()
+
+
+def _assert_no_user_id(obj: Any) -> None:
+    """Recursively assert ``user_id`` appears nowhere in a response payload."""
+    if isinstance(obj, dict):
+        assert "user_id" not in obj, f"user_id leaked in keys {list(obj.keys())}"
+        for value in obj.values():
+            _assert_no_user_id(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            _assert_no_user_id(item)
+
+
+# ---------------------------------------------------------------------------
+# Anonymous reads
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymousRead:
+    @pytest.mark.asyncio
+    async def test_anon_can_list_no_user_id_rollups_null(
+        self, user_factory, as_user, client: AsyncClient,
+    ) -> None:
+        owner = await user_factory()
+        title = f"Anon List {uuid.uuid4().hex[:8]}"
+        created = await _create_recipe(as_user, owner, title)
+
+        resp = await client.get("/recipes", params={"search": title})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        row = body[0]
+        assert row["id"] == created["id"]
+        assert row["is_owner"] is False
+        assert row["best_rating"] is None
+        assert row["last_cooked_at"] is None
+        assert isinstance(row["owner_display_name"], str)
+        _assert_no_user_id(body)
+
+    @pytest.mark.asyncio
+    async def test_anon_can_read_detail_versions_diff(
+        self, user_factory, as_user, client: AsyncClient,
+    ) -> None:
+        owner = await user_factory()
+        title = f"Anon Detail {uuid.uuid4().hex[:8]}"
+        created = await _create_recipe(as_user, owner, title)
+        rid = created["id"]
+
+        async with await as_user(owner) as authed:
+            v2 = (
+                await authed.post(
+                    f"/recipes/{rid}/versions",
+                    json={
+                        "change_note": "more flour",
+                        "ingredients": [{"name": "flour", "quantity": 3, "unit": "cup"}],
+                        "steps": [{"instruction": "Mix the dry ingredients."}],
+                    },
+                )
+            ).json()
+        v2_id = v2["id"]
+
+        detail = await client.get(f"/recipes/{rid}")
+        assert detail.status_code == 200
+        detail_body = detail.json()
+        assert detail_body["is_owner"] is False
+        assert detail_body["best_rating"] is None
+        assert detail_body["last_cooked_at"] is None
+        _assert_no_user_id(detail_body)
+
+        versions = await client.get(f"/recipes/{rid}/versions")
+        assert versions.status_code == 200
+        vbody = versions.json()
+        assert [v["version_number"] for v in vbody] == [1, 2]
+        assert all(v["cook_count"] is None and v["best_rating"] is None for v in vbody)
+        _assert_no_user_id(vbody)
+
+        one = await client.get(f"/recipes/{rid}/versions/{v2_id}")
+        assert one.status_code == 200
+        _assert_no_user_id(one.json())
+
+        diff = await client.get(f"/recipes/{rid}/versions/{v2_id}/diff")
+        assert diff.status_code == 200
+        _assert_no_user_id(diff.json())
+
+
+# ---------------------------------------------------------------------------
+# Anonymous writes are blocked
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymousWritesBlocked:
+    @pytest.mark.asyncio
+    async def test_all_write_and_cook_endpoints_401(
+        self, user_factory, as_user, client: AsyncClient,
+    ) -> None:
+        owner = await user_factory()
+        created = await _create_recipe(as_user, owner, f"Guard {uuid.uuid4().hex[:8]}")
+        rid = created["id"]
+        vid = created["latest_version"]["id"]
+
+        assert (await client.post("/recipes", json=_payload("x"))).status_code == 401
+        assert (await client.patch(f"/recipes/{rid}", json={"title": "z"})).status_code == 401
+        assert (await client.delete(f"/recipes/{rid}")).status_code == 401
+        assert (
+            await client.post(
+                f"/recipes/{rid}/versions", json={"ingredients": [], "steps": []}
+            )
+        ).status_code == 401
+        assert (
+            await client.post(f"/recipes/{rid}/versions/{vid}/restore")
+        ).status_code == 401
+        assert (
+            await client.post(f"/recipes/extract", files={"file": ("x.png", b"x", "image/png")})
+        ).status_code == 401
+        # Cook logs are private — every /cooks endpoint requires auth.
+        assert (
+            await client.post(
+                f"/recipes/{rid}/versions/{vid}/cooks", json={"rating": 5}
+            )
+        ).status_code == 401
+        assert (
+            await client.get(f"/recipes/{rid}/versions/{vid}/cooks")
+        ).status_code == 401
+        assert (await client.get(f"/recipes/{rid}/cooks")).status_code == 401
+        assert (
+            await client.delete(f"/recipes/{rid}/cooks/{uuid.uuid4()}")
+        ).status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Logged-in non-owner
+# ---------------------------------------------------------------------------
+
+
+class TestNonOwner:
+    @pytest.mark.asyncio
+    async def test_non_owner_cannot_mutate_or_read_cooks(
+        self, user_factory, as_user,
+    ) -> None:
+        owner = await user_factory()
+        attacker = await user_factory()
+        created = await _create_recipe(as_user, owner, f"Iso {uuid.uuid4().hex[:8]}")
+        rid = created["id"]
+        vid = created["latest_version"]["id"]
+
+        async with await as_user(attacker) as authed:
+            assert (
+                await authed.patch(f"/recipes/{rid}", json={"title": "hax"})
+            ).status_code == 404
+            assert (await authed.delete(f"/recipes/{rid}")).status_code == 404
+            assert (
+                await authed.post(
+                    f"/recipes/{rid}/versions", json={"ingredients": [], "steps": []}
+                )
+            ).status_code == 404
+            assert (
+                await authed.post(f"/recipes/{rid}/versions/{vid}/restore")
+            ).status_code == 404
+            # Cook logs are owner-only; another user's recipe 404s (no leak).
+            assert (await authed.get(f"/recipes/{rid}/cooks")).status_code == 404
+            assert (
+                await authed.get(f"/recipes/{rid}/versions/{vid}/cooks")
+            ).status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_non_owner_version_rollups_hidden_even_with_cooks(
+        self, user_factory, as_user, client: AsyncClient,
+    ) -> None:
+        owner = await user_factory()
+        created = await _create_recipe(as_user, owner, f"Priv {uuid.uuid4().hex[:8]}")
+        rid = created["id"]
+        vid = created["latest_version"]["id"]
+        async with await as_user(owner) as authed:
+            await authed.post(f"/recipes/{rid}/versions/{vid}/cooks", json={"rating": 5})
+
+        # Anonymous / non-owner must never see cook activity.
+        versions = (await client.get(f"/recipes/{rid}/versions")).json()
+        assert all(v["cook_count"] is None and v["best_rating"] is None for v in versions)
+        detail = (await client.get(f"/recipes/{rid}")).json()
+        assert detail["best_rating"] is None
+        assert detail["last_cooked_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Owner sees their own rollups
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerRollups:
+    @pytest.mark.asyncio
+    async def test_owner_sees_populated_rollups(self, user_factory, as_user) -> None:
+        owner = await user_factory()
+        created = await _create_recipe(as_user, owner, f"Roll {uuid.uuid4().hex[:8]}")
+        rid = created["id"]
+        vid = created["latest_version"]["id"]
+
+        async with await as_user(owner) as authed:
+            await authed.post(f"/recipes/{rid}/versions/{vid}/cooks", json={"rating": 4})
+            detail = (await authed.get(f"/recipes/{rid}")).json()
+            versions = (await authed.get(f"/recipes/{rid}/versions")).json()
+            listed = (await authed.get("/recipes", params={"owner": "me"})).json()
+
+        assert detail["is_owner"] is True
+        assert detail["best_rating"] == 4
+        assert detail["last_cooked_at"] is not None
+        assert versions[0]["cook_count"] == 1
+        assert versions[0]["best_rating"] == 4
+        mine = next(r for r in listed if r["id"] == rid)
+        assert mine["is_owner"] is True
+        assert mine["best_rating"] == 4
+
+
+# ---------------------------------------------------------------------------
+# owner=me
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerMeParam:
+    @pytest.mark.asyncio
+    async def test_owner_me_anonymous_401(self, client: AsyncClient) -> None:
+        resp = await client.get("/recipes", params={"owner": "me"})
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_owner_me_returns_only_own(self, user_factory, as_user) -> None:
+        owner = await user_factory()
+        other = await user_factory()
+        mine_title = f"Mine {uuid.uuid4().hex[:8]}"
+        await _create_recipe(as_user, owner, mine_title)
+        await _create_recipe(as_user, other, f"Theirs {uuid.uuid4().hex[:8]}")
+
+        async with await as_user(owner) as authed:
+            mine = (await authed.get("/recipes", params={"owner": "me"})).json()
+
+        assert len(mine) == 1
+        assert mine[0]["title"] == mine_title
+        assert mine[0]["is_owner"] is True
+
+    @pytest.mark.asyncio
+    async def test_owner_invalid_value_422(self, user_factory, as_user) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.get("/recipes", params={"owner": "everyone"})
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Soft-delete is invisible on every public route
+# ---------------------------------------------------------------------------
+
+
+class TestSoftDeletePublic:
+    @pytest.mark.asyncio
+    async def test_deleted_recipe_404_on_all_public_routes(
+        self, user_factory, as_user, client: AsyncClient,
+    ) -> None:
+        owner = await user_factory()
+        created = await _create_recipe(as_user, owner, f"Del {uuid.uuid4().hex[:8]}")
+        rid = created["id"]
+        vid = created["latest_version"]["id"]
+
+        async with await as_user(owner) as authed:
+            assert (await authed.delete(f"/recipes/{rid}")).status_code == 204
+
+        assert (await client.get(f"/recipes/{rid}")).status_code == 404
+        assert (await client.get(f"/recipes/{rid}/versions")).status_code == 404
+        assert (await client.get(f"/recipes/{rid}/versions/{vid}")).status_code == 404
+        assert (await client.get(f"/recipes/{rid}/versions/{vid}/diff")).status_code == 404
+
+        # Identical body whether soft-deleted or never existed (no leak).
+        deleted = await client.get(f"/recipes/{rid}")
+        missing = await client.get(f"/recipes/{uuid.uuid4()}")
+        assert deleted.json() == missing.json()
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+class TestPagination:
+    @pytest.mark.asyncio
+    async def test_limit_honored_offset_and_capped(self, user_factory, as_user) -> None:
+        owner = await user_factory()
+        tag = uuid.uuid4().hex[:8]
+        async with await as_user(owner) as authed:
+            for i in range(3):
+                await authed.post("/recipes", json=_payload(f"Page {tag} {i}"))
+
+            page1 = await authed.get(
+                "/recipes",
+                params={"owner": "me", "search": f"Page {tag}", "limit": 2},
+            )
+            assert page1.status_code == 200
+            assert len(page1.json()) == 2
+
+            page2 = await authed.get(
+                "/recipes",
+                params={"owner": "me", "search": f"Page {tag}", "limit": 2, "offset": 2},
+            )
+            assert len(page2.json()) == 1
+
+            # Over the cap (le=200) and under the floor (ge=1) → 422.
+            assert (await authed.get("/recipes", params={"limit": 999})).status_code == 422
+            assert (await authed.get("/recipes", params={"limit": 0})).status_code == 422

--- a/apps/myrecipes/frontend/e2e/public-recipes.spec.ts
+++ b/apps/myrecipes/frontend/e2e/public-recipes.spec.ts
@@ -1,0 +1,185 @@
+import {
+  test,
+  expect,
+  request as playwrightRequest,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+/**
+ * E2E coverage for the public-read / auth-write conversion.
+ *
+ * Layout/gating tests are unconditional (no data required). The seeded-recipe
+ * suite logs in via the API, creates one recipe, asserts the guest and owner
+ * views against it, and soft-deletes it afterwards — so it runs green on an
+ * empty local library. It requires E2E_USER_EMAIL / E2E_USER_PASSWORD to
+ * point at a verified local account (never hardcode credentials here — this
+ * file is committed).
+ *
+ * Run against a local stack (backend :8008 + `npm run dev`), or point
+ * BASE_URL at an already-running frontend whose /api proxies to the backend.
+ */
+
+const MISSING_ID = "00000000-0000-0000-0000-000000000000";
+const OWNER_EMAIL = process.env.E2E_USER_EMAIL ?? "";
+const OWNER_PASSWORD = process.env.E2E_USER_PASSWORD ?? "";
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:5180";
+// Unique per run so a probe leaked by an aborted earlier run can't collide.
+const SEEDED_TITLE = `E2E Public Browsing Probe ${Date.now()}`;
+
+/** The AuthRequired card's button — scoped to <main> because the guest shell
+ * renders its own "Sign in" CTAs in the sidebar and topbar. */
+function cardSignIn(page: Page) {
+  return page.getByRole("main").getByRole("button", { name: "Sign in" });
+}
+
+test.describe("Public browsing — guest layout & gating", () => {
+  test("recipes list renders in the guest shell with a sign-in CTA", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText("Sign in").first()).toBeVisible();
+    // The public library UI renders — search box is available to guests.
+    await expect(
+      page.getByPlaceholder("Search recipes by title")
+    ).toBeVisible();
+    // Owner-scoped filter is an authenticated-only affordance.
+    await expect(page.getByText("My recipes")).toHaveCount(0);
+  });
+
+  test("guest hitting /recipes/new gets the inline sign-in card", async ({
+    page,
+  }) => {
+    await page.goto("/recipes/new");
+    await expect(
+      page.getByRole("heading", { name: "Sign in to create a new recipe" })
+    ).toBeVisible();
+    await cardSignIn(page).click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("guest hitting gated account pages gets the sign-in card", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await expect(
+      page.getByRole("heading", { name: "Sign in to manage your settings" })
+    ).toBeVisible();
+
+    await page.goto("/security");
+    await expect(
+      page.getByRole("heading", {
+        name: "Sign in to manage account security",
+      })
+    ).toBeVisible();
+  });
+
+  test("guest hitting the tweak editor gets the sign-in card", async ({
+    page,
+  }) => {
+    await page.goto(`/recipes/${MISSING_ID}/tweak`);
+    await expect(
+      page.getByRole("heading", { name: "Sign in to tweak this recipe" })
+    ).toBeVisible();
+  });
+
+  test("missing recipe shows the public 404 copy", async ({ page }) => {
+    await page.goto(`/recipes/${MISSING_ID}`);
+    await expect(
+      page.getByText("This recipe doesn't exist. It may have been deleted.")
+    ).toBeVisible();
+  });
+});
+
+test.describe("Seeded recipe — guest vs owner", () => {
+  // Serial: one worker → one beforeAll → exactly one seeded probe. Parallel
+  // workers would each run beforeAll and seed duplicate probe recipes.
+  test.describe.configure({ mode: "serial" });
+  test.skip(
+    !OWNER_EMAIL || !OWNER_PASSWORD,
+    "set E2E_USER_EMAIL + E2E_USER_PASSWORD (verified local account) to run"
+  );
+
+  let api: APIRequestContext;
+  let recipeId = "";
+
+  test.beforeAll(async () => {
+    // API login + seed one recipe so these tests pass on an empty library.
+    const anon = await playwrightRequest.newContext({ baseURL: BASE_URL });
+    const login = await anon.post("/api/auth/jwt/login", {
+      form: { username: OWNER_EMAIL, password: OWNER_PASSWORD },
+    });
+    expect(login.ok(), "API login failed — check E2E_USER_* env").toBe(true);
+    const { access_token } = await login.json();
+    await anon.dispose();
+
+    api = await playwrightRequest.newContext({
+      baseURL: BASE_URL,
+      extraHTTPHeaders: { Authorization: `Bearer ${access_token}` },
+    });
+    const created = await api.post("/api/recipes", {
+      data: { title: SEEDED_TITLE, ingredients: [], steps: [] },
+    });
+    expect(created.status(), "seeding the probe recipe failed").toBe(201);
+    recipeId = (await created.json()).id;
+  });
+
+  test.afterAll(async () => {
+    if (recipeId) {
+      await api.delete(`/api/recipes/${recipeId}`); // soft-delete the probe
+    }
+    await api?.dispose();
+  });
+
+  test("guest sees the recipe read-only — no write or cook-log UI", async ({
+    page,
+  }) => {
+    await page.goto(`/recipes/${recipeId}`);
+    await expect(
+      page.getByRole("heading", { name: SEEDED_TITLE })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Tweak this recipe" })
+    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "I made it" })).toHaveCount(
+      0
+    );
+    await expect(page.getByRole("heading", { name: "Cook log" })).toHaveCount(
+      0
+    );
+  });
+
+  test("guest sees the recipe on the public list", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("link", { name: new RegExp(SEEDED_TITLE) })
+    ).toBeVisible();
+  });
+
+  test("owner signs in, filters to My recipes, and sees owner controls", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+    await page.getByLabel("Email").fill(OWNER_EMAIL);
+    await page.getByLabel("Password").fill(OWNER_PASSWORD);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await expect(page).toHaveURL(/^(?!.*\/login).*$/, { timeout: 10_000 });
+
+    await page.goto("/");
+    const mineChip = page.getByText("My recipes");
+    await expect(mineChip).toBeVisible();
+    await mineChip.click();
+    await expect(page).toHaveURL(/owner=me/);
+
+    await page
+      .getByRole("link", { name: new RegExp(SEEDED_TITLE) })
+      .click();
+    await expect(page).toHaveURL(new RegExp(`/recipes/${recipeId}$`));
+    await expect(
+      page.getByRole("button", { name: "I made it" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Cook log" })
+    ).toBeVisible();
+  });
+});

--- a/apps/myrecipes/frontend/src/RootLayout.tsx
+++ b/apps/myrecipes/frontend/src/RootLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, ScrollRestoration } from "react-router-dom";
 import { ChefHat, Settings, Shield } from "lucide-react";
-import { AppShell, RequireAuth, StepUpModal, Toaster, useIsAuthenticated } from "@platform/ui";
-import { buildNav } from "@/constants/nav";
+import { AppShell, GuestShell, StepUpModal, Toaster, useIsAuthenticated } from "@platform/ui";
+import { buildNav, PUBLIC_NAV_PATHS } from "@/constants/nav";
 import { signOut } from "@/lib/auth";
 import { useIsSuperuser } from "@/hooks/useIsSuperuser";
 import { useGetCurrentUserQuery } from "@/lib/userApi";
@@ -25,6 +25,32 @@ const ICONS: Record<string, React.ReactNode> = {
   Shield: <Shield className="w-5 h-5" />,
 };
 
+const LOGO = (
+  <div className="flex items-center gap-2">
+    <div className="w-7 h-7 rounded-lg bg-primary/10 flex items-center justify-center shrink-0 text-primary">
+      <ChefHat className="w-4 h-4" aria-hidden="true" />
+    </div>
+    <span className="font-semibold text-sm">MyRecipes</span>
+  </div>
+);
+
+/**
+ * RootLayout — top-level layout wrapper.
+ *
+ * MyRecipes uses a public-read / auth-write model: the recipe library is
+ * publicly browsable, and only writes (create / tweak / cook / account pages)
+ * require an account. The layout reflects that:
+ *
+ *   - Authenticated             → full AppShell with all nav items.
+ *   - Unauthenticated (default) → GuestShell — public nav items only, with a
+ *     "Sign in" CTA where the user dropdown would be. The CTA carries the
+ *     current pathname via ``state.from`` so Login can return the visitor here
+ *     after they sign in.
+ *
+ * Per-route gating for write surfaces is handled by ``<AuthRequired>`` (see
+ * routes.tsx), not at the layout level, so the layout stays decoupled from
+ * individual page auth requirements.
+ */
 export default function RootLayout() {
   const isAuthenticated = useIsAuthenticated();
   const { isSuperuser: _isSuperuser } = useIsSuperuser();
@@ -32,25 +58,34 @@ export default function RootLayout() {
     skip: !isAuthenticated,
   });
 
-  const nav = buildNav(ICONS);
+  // Guests see only the public paths so the sidebar doesn't dangle dead links
+  // to pages that require an account.
+  const fullNav = buildNav(ICONS);
+  const nav = isAuthenticated
+    ? fullNav
+    : fullNav.filter((n) => PUBLIC_NAV_PATHS.has(n.path));
   const user = isAuthenticated ? projectUser(currentUser) : ANONYMOUS_USER;
 
-  const logo = (
-    <div className="flex items-center gap-2">
-      <div className="w-7 h-7 rounded-lg bg-primary/10 flex items-center justify-center shrink-0 text-primary">
-        <ChefHat className="w-4 h-4" aria-hidden="true" />
-      </div>
-      <span className="font-semibold text-sm">MyRecipes</span>
-    </div>
-  );
+  if (!isAuthenticated) {
+    return (
+      <>
+        <ScrollRestoration />
+        <Toaster />
+        <StepUpModal />
+        <GuestShell logo={LOGO} nav={nav}>
+          <Outlet />
+        </GuestShell>
+      </>
+    );
+  }
 
   return (
-    <RequireAuth>
+    <>
       <ScrollRestoration />
       <Toaster />
       <StepUpModal />
       <AppShell
-        logo={logo}
+        logo={LOGO}
         nav={nav}
         user={user}
         onSignOut={signOut}
@@ -58,6 +93,6 @@ export default function RootLayout() {
       >
         <Outlet />
       </AppShell>
-    </RequireAuth>
+    </>
   );
 }

--- a/apps/myrecipes/frontend/src/constants/nav.ts
+++ b/apps/myrecipes/frontend/src/constants/nav.ts
@@ -19,6 +19,18 @@ const NAV_DESCRIPTORS: NavDescriptor[] = [
 ];
 
 /**
+ * Paths that appear in the unauthenticated GuestShell sidebar.
+ *
+ * MyRecipes uses a public-read / auth-write model: anyone can browse the recipe
+ * library, but only the owner can create / tweak / cook. Guests see just the
+ * recipes list; /settings and /security are account pages, kept out of the
+ * guest nav so unauthenticated visitors don't see dead links to gated pages.
+ */
+export const PUBLIC_NAV_PATHS: ReadonlySet<string> = new Set([
+  "/", // Recipes (public library)
+]);
+
+/**
  * Build the full NavItem array -- called once in RootLayout.tsx with injected
  * icon nodes.
  */

--- a/apps/myrecipes/frontend/src/features/recipes/RecipeCard.test.tsx
+++ b/apps/myrecipes/frontend/src/features/recipes/RecipeCard.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for RecipeCard — the recipe list tile.
+ *
+ * MyRecipes is public-read / auth-write: recipe cards render for everyone, but
+ * the star-rating and last-cooked block is owner-private. These tests pin the
+ * guest-vs-owner rendering rules:
+ *   - owner     → rating + last-cooked block shown
+ *   - non-owner → that block omitted entirely (not dashed), attribution shown
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import RecipeCard from "@/features/recipes/RecipeCard";
+import type { RecipeSummary } from "@/types/recipe/recipe";
+
+function makeRecipe(overrides: Partial<RecipeSummary> = {}): RecipeSummary {
+  return {
+    id: "r1",
+    title: "Sourdough Loaf",
+    description: "A tangy overnight bake",
+    source: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    version_count: 3,
+    latest_version_number: 3,
+    best_rating: 4,
+    last_cooked_at: "2026-02-01T00:00:00Z",
+    is_owner: true,
+    owner_display_name: "Alice",
+    ...overrides,
+  };
+}
+
+function renderCard(recipe: RecipeSummary) {
+  return render(
+    <MemoryRouter>
+      <RecipeCard recipe={recipe} />
+    </MemoryRouter>,
+  );
+}
+
+describe("RecipeCard", () => {
+  it("shows the rating and last-cooked block for the owner", () => {
+    renderCard(makeRecipe({ is_owner: true, best_rating: 4 }));
+    expect(screen.getByRole("img", { name: /4 out of 5 stars/i })).toBeInTheDocument();
+    expect(screen.getByText(/last cooked/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Not cooked yet' for an owner who hasn't cooked", () => {
+    renderCard(makeRecipe({ is_owner: true, best_rating: null, last_cooked_at: null }));
+    expect(screen.getByText(/not cooked yet/i)).toBeInTheDocument();
+  });
+
+  it("omits the rating and last-cooked block entirely for non-owners", () => {
+    renderCard(makeRecipe({ is_owner: false, best_rating: null, last_cooked_at: null }));
+    // No star rating rendered (not even a dash) and no cook status line.
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.queryByText(/last cooked/i)).toBeNull();
+    expect(screen.queryByText(/not cooked yet/i)).toBeNull();
+  });
+
+  it("renders attribution when owner_display_name is present", () => {
+    renderCard(makeRecipe({ is_owner: false, owner_display_name: "Bob" }));
+    expect(screen.getByText(/by Bob/i)).toBeInTheDocument();
+  });
+
+  it("omits attribution when owner_display_name is empty", () => {
+    renderCard(makeRecipe({ is_owner: true, owner_display_name: "" }));
+    expect(screen.queryByText(/^by /i)).toBeNull();
+  });
+
+  it("always shows the version count for everyone", () => {
+    renderCard(makeRecipe({ is_owner: false, version_count: 2 }));
+    expect(screen.getByText(/2 versions/i)).toBeInTheDocument();
+  });
+});

--- a/apps/myrecipes/frontend/src/features/recipes/RecipeCard.tsx
+++ b/apps/myrecipes/frontend/src/features/recipes/RecipeCard.tsx
@@ -9,9 +9,15 @@ interface Props {
 }
 
 /**
- * A single recipe in the list grid. Surfaces the four data points that answer
+ * A single recipe in the list grid. Surfaces the data points that answer
  * "which recipe, how evolved, how good, how recently cooked": title, latest
- * version number, best rating (as stars), version count, and last-cooked date.
+ * version number, and version count for everyone; plus best rating and
+ * last-cooked date for the owner only.
+ *
+ * Public-read / auth-write: the recipe library is public, so cards render for
+ * every visitor. The star-rating and last-cooked block is owner-private — it's
+ * omitted entirely (not dashed) for other people's recipes, and cards show a
+ * "by {owner}" attribution when the owner's display name is known.
  */
 export default function RecipeCard({ recipe }: Props) {
   const versionLabel =
@@ -42,14 +48,22 @@ export default function RecipeCard({ recipe }: Props) {
           <GitBranch className="w-4 h-4" aria-hidden />
           {recipe.version_count} version{recipe.version_count === 1 ? "" : "s"}
         </span>
-        <StarRating value={recipe.best_rating} showEmptyDash />
+        {recipe.is_owner && <StarRating value={recipe.best_rating} showEmptyDash />}
       </div>
 
-      <div className="text-xs text-muted-foreground">
-        {recipe.last_cooked_at
-          ? `Last cooked ${formatDate(recipe.last_cooked_at)}`
-          : "Not cooked yet"}
-      </div>
+      {recipe.is_owner && (
+        <div className="text-xs text-muted-foreground">
+          {recipe.last_cooked_at
+            ? `Last cooked ${formatDate(recipe.last_cooked_at)}`
+            : "Not cooked yet"}
+        </div>
+      )}
+
+      {recipe.owner_display_name ? (
+        <div className="text-xs text-muted-foreground/80">
+          by {recipe.owner_display_name}
+        </div>
+      ) : null}
     </Link>
   );
 }

--- a/apps/myrecipes/frontend/src/features/recipes/VersionTimeline.tsx
+++ b/apps/myrecipes/frontend/src/features/recipes/VersionTimeline.tsx
@@ -108,10 +108,14 @@ export default function VersionTimeline({
                     </p>
                     <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
                       <span>{formatDate(version.created_at)}</span>
-                      <span>
-                        {version.cook_count} cook
-                        {version.cook_count === 1 ? "" : "s"}
-                      </span>
+                      {/* cook_count is owner-only — null for non-owners, so the
+                          count is omitted rather than rendered as a bare "cooks". */}
+                      {version.cook_count !== null ? (
+                        <span>
+                          {version.cook_count} cook
+                          {version.cook_count === 1 ? "" : "s"}
+                        </span>
+                      ) : null}
                     </div>
                   </button>
                 </div>

--- a/apps/myrecipes/frontend/src/pages/RecipeDetail.tsx
+++ b/apps/myrecipes/frontend/src/pages/RecipeDetail.tsx
@@ -29,8 +29,16 @@ export default function RecipeDetail() {
   const navigate = useNavigate();
 
   const recipeQuery = useGetRecipeQuery(recipeId, { skip: !recipeId });
+  // Public-read / auth-write: reads are public, but cook logs, write buttons,
+  // and the cook-log section are owner-only. is_owner comes from the recipe
+  // response and gates all of those below.
+  const isOwner = recipeQuery.data?.is_owner ?? false;
   const versionsQuery = useListVersionsQuery(recipeId, { skip: !recipeId });
-  const cooksQuery = useListRecipeCooksQuery(recipeId, { skip: !recipeId });
+  // The cook-logs endpoint 404s for non-owners, so skip it entirely unless the
+  // viewer owns this recipe.
+  const cooksQuery = useListRecipeCooksQuery(recipeId, {
+    skip: !recipeId || !isOwner,
+  });
 
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
   const [compareIds, setCompareIds] = useState<string[]>([]);
@@ -99,7 +107,7 @@ export default function RecipeDetail() {
         <EmptyState
           icon={<ChefHat className="w-12 h-12 text-destructive" />}
           heading="Recipe not found"
-          body="This recipe doesn't exist or you don't have access to it."
+          body="This recipe doesn't exist. It may have been deleted."
           action={{ label: "Back to recipes", onClick: () => navigate("/") }}
         />
       </main>
@@ -133,45 +141,47 @@ export default function RecipeDetail() {
             </p>
           ) : null}
         </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <LoadingButton
-            variant="primary"
-            size="sm"
-            onClick={() => navigate(`/recipes/${recipeId}/tweak`)}
-          >
-            <span className="inline-flex items-center gap-1.5">
-              <GitBranch className="w-4 h-4" />
-              Tweak this recipe
-            </span>
-          </LoadingButton>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => setCookOpen(true)}
-            disabled={!effectiveVersionId}
-          >
-            <span className="inline-flex items-center gap-1.5">
-              <UtensilsCrossed className="w-4 h-4" />
-              I made it
-            </span>
-          </Button>
-          <Button variant="secondary" size="sm" onClick={() => setEditOpen(true)}>
-            <span className="inline-flex items-center gap-1.5">
-              <Pencil className="w-4 h-4" />
-              Edit
-            </span>
-          </Button>
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={() => setDeleteOpen(true)}
-          >
-            <span className="inline-flex items-center gap-1.5">
-              <Trash2 className="w-4 h-4" />
-              Delete
-            </span>
-          </Button>
-        </div>
+        {isOwner && (
+          <div className="flex flex-wrap items-center gap-2">
+            <LoadingButton
+              variant="primary"
+              size="sm"
+              onClick={() => navigate(`/recipes/${recipeId}/tweak`)}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <GitBranch className="w-4 h-4" />
+                Tweak this recipe
+              </span>
+            </LoadingButton>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setCookOpen(true)}
+              disabled={!effectiveVersionId}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <UtensilsCrossed className="w-4 h-4" />
+                I made it
+              </span>
+            </Button>
+            <Button variant="secondary" size="sm" onClick={() => setEditOpen(true)}>
+              <span className="inline-flex items-center gap-1.5">
+                <Pencil className="w-4 h-4" />
+                Edit
+              </span>
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setDeleteOpen(true)}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Trash2 className="w-4 h-4" />
+                Delete
+              </span>
+            </Button>
+          </div>
+        )}
       </header>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
@@ -195,14 +205,16 @@ export default function RecipeDetail() {
             </>
           )}
 
-          <section className="bg-card border rounded-lg p-6">
-            <h2 className="text-base font-medium mb-4">Cook log</h2>
-            <CookLogHistory
-              recipeId={recipeId}
-              cooks={cooksQuery.data ?? []}
-              versionNumberById={versionNumberById}
-            />
-          </section>
+          {isOwner && (
+            <section className="bg-card border rounded-lg p-6">
+              <h2 className="text-base font-medium mb-4">Cook log</h2>
+              <CookLogHistory
+                recipeId={recipeId}
+                cooks={cooksQuery.data ?? []}
+                versionNumberById={versionNumberById}
+              />
+            </section>
+          )}
         </div>
 
         <div className="lg:col-span-1">
@@ -217,7 +229,7 @@ export default function RecipeDetail() {
         </div>
       </div>
 
-      {effectiveVersionId && versionQuery.data ? (
+      {isOwner && effectiveVersionId && versionQuery.data ? (
         <CookLogModal
           open={cookOpen}
           onClose={() => setCookOpen(false)}
@@ -227,22 +239,26 @@ export default function RecipeDetail() {
         />
       ) : null}
 
-      <EditRecipeMetaModal
-        open={editOpen}
-        onClose={() => setEditOpen(false)}
-        recipe={recipe}
-      />
+      {isOwner && (
+        <EditRecipeMetaModal
+          open={editOpen}
+          onClose={() => setEditOpen(false)}
+          recipe={recipe}
+        />
+      )}
 
-      <ConfirmDialog
-        open={deleteOpen}
-        title="Delete this recipe?"
-        description="This removes the recipe and its whole version history from your list. This can't be undone here."
-        confirmLabel="Delete recipe"
-        variant="destructive"
-        isLoading={isDeleting}
-        onConfirm={handleDelete}
-        onCancel={() => setDeleteOpen(false)}
-      />
+      {isOwner && (
+        <ConfirmDialog
+          open={deleteOpen}
+          title="Delete this recipe?"
+          description="This removes the recipe and its whole version history from your list. This can't be undone here."
+          confirmLabel="Delete recipe"
+          variant="destructive"
+          isLoading={isDeleting}
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteOpen(false)}
+        />
+      )}
     </main>
   );
 }

--- a/apps/myrecipes/frontend/src/pages/RecipeEditor.tsx
+++ b/apps/myrecipes/frontend/src/pages/RecipeEditor.tsx
@@ -1,16 +1,14 @@
 import { useNavigate, useParams } from "react-router-dom";
-import { ChefHat } from "lucide-react";
-import { EmptyState, Skeleton } from "@platform/ui";
-import { useGetRecipeQuery } from "@/store/recipesApi";
 import EditorHeader from "@/features/recipes/EditorHeader";
 import RecipeEditorForm from "@/features/recipes/RecipeEditorForm";
+import TweakEditor from "@/pages/TweakEditor";
 
 /**
  * Recipe editor route. Two modes, distinguished by the presence of a recipe id
  * in the path:
  *   - /recipes/new      -> create a brand-new recipe (its first version)
  *   - /recipes/:id/tweak -> create a new version of an existing recipe,
- *     prefilled from its latest version (lineage keys carried for the diff)
+ *     prefilled from its latest version (see TweakEditor)
  */
 export default function RecipeEditor() {
   const { id } = useParams<{ id: string }>();
@@ -27,85 +25,4 @@ export default function RecipeEditor() {
   }
 
   return <TweakEditor recipeId={id as string} onMissing={() => navigate("/")} />;
-}
-
-interface TweakEditorProps {
-  recipeId: string;
-  onMissing: () => void;
-}
-
-function TweakEditor({ recipeId, onMissing }: TweakEditorProps) {
-  const navigate = useNavigate();
-  const { data, isLoading, isError } = useGetRecipeQuery(recipeId);
-
-  if (isLoading) {
-    return (
-      <main className="p-4 sm:p-8 space-y-6">
-        <EditorHeader
-          backTo={`/recipes/${recipeId}`}
-          backLabel="Back to recipe"
-          title="Tweak recipe"
-        />
-        <div className="space-y-4">
-          <Skeleton className="h-32 w-full" />
-          <Skeleton className="h-48 w-full" />
-          <Skeleton className="h-48 w-full" />
-        </div>
-      </main>
-    );
-  }
-
-  if (isError || !data || !data.latest_version) {
-    return (
-      <main className="p-4 sm:p-8 space-y-6">
-        <EmptyState
-          icon={<ChefHat className="w-12 h-12 text-destructive" />}
-          heading="Recipe not found"
-          body="This recipe doesn't exist or has no version to tweak."
-          action={{ label: "Back to recipes", onClick: onMissing }}
-        />
-      </main>
-    );
-  }
-
-  // Public-read / auth-write: anyone can view a recipe, but tweaking creates a
-  // new version on the owner's recipe — only they can do that. A non-owner who
-  // deep-links to /tweak must NOT get a fillable form that would 404 on submit;
-  // show a clear message with a way back to the recipe instead.
-  if (!data.is_owner) {
-    return (
-      <main className="p-4 sm:p-8 space-y-6">
-        <EditorHeader
-          backTo={`/recipes/${recipeId}`}
-          backLabel="Back to recipe"
-          title="Tweak recipe"
-        />
-        <EmptyState
-          icon={<ChefHat className="w-12 h-12" />}
-          heading="You can only tweak your own recipes"
-          body="This recipe belongs to someone else. You can view it, but tweaking creates a new version that only the owner can make."
-          action={{
-            label: "Back to recipe",
-            onClick: () => navigate(`/recipes/${recipeId}`),
-          }}
-        />
-      </main>
-    );
-  }
-
-  return (
-    <main className="p-4 sm:p-8 space-y-6">
-      <EditorHeader
-        backTo={`/recipes/${recipeId}`}
-        backLabel="Back to recipe"
-        title={`Tweak "${data.title}"`}
-        subtitle={`Starting from v${data.latest_version.version_number}. Saving creates a new version and the diff shows exactly what changed.`}
-      />
-      <RecipeEditorForm
-        mode="tweak"
-        recipeId={recipeId}
-        baseVersion={data.latest_version}
-      />
-    </main>
-  );
 }

--- a/apps/myrecipes/frontend/src/pages/RecipeEditor.tsx
+++ b/apps/myrecipes/frontend/src/pages/RecipeEditor.tsx
@@ -35,6 +35,7 @@ interface TweakEditorProps {
 }
 
 function TweakEditor({ recipeId, onMissing }: TweakEditorProps) {
+  const navigate = useNavigate();
   const { data, isLoading, isError } = useGetRecipeQuery(recipeId);
 
   if (isLoading) {
@@ -62,6 +63,31 @@ function TweakEditor({ recipeId, onMissing }: TweakEditorProps) {
           heading="Recipe not found"
           body="This recipe doesn't exist or has no version to tweak."
           action={{ label: "Back to recipes", onClick: onMissing }}
+        />
+      </main>
+    );
+  }
+
+  // Public-read / auth-write: anyone can view a recipe, but tweaking creates a
+  // new version on the owner's recipe — only they can do that. A non-owner who
+  // deep-links to /tweak must NOT get a fillable form that would 404 on submit;
+  // show a clear message with a way back to the recipe instead.
+  if (!data.is_owner) {
+    return (
+      <main className="p-4 sm:p-8 space-y-6">
+        <EditorHeader
+          backTo={`/recipes/${recipeId}`}
+          backLabel="Back to recipe"
+          title="Tweak recipe"
+        />
+        <EmptyState
+          icon={<ChefHat className="w-12 h-12" />}
+          heading="You can only tweak your own recipes"
+          body="This recipe belongs to someone else. You can view it, but tweaking creates a new version that only the owner can make."
+          action={{
+            label: "Back to recipe",
+            onClick: () => navigate(`/recipes/${recipeId}`),
+          }}
         />
       </main>
     );

--- a/apps/myrecipes/frontend/src/pages/Recipes.tsx
+++ b/apps/myrecipes/frontend/src/pages/Recipes.tsx
@@ -1,20 +1,53 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useState, type ReactNode } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { Camera, ChefHat, Plus, Search } from "lucide-react";
-import { EmptyState } from "@platform/ui";
+import { EmptyState, cn, useIsAuthenticated } from "@platform/ui";
 import { useListRecipesQuery } from "@/store/recipesApi";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import RecipeCard from "@/features/recipes/RecipeCard";
 import RecipesListSkeleton from "@/features/recipes/RecipesListSkeleton";
 import { RECIPES_EMPTY_STATE, RECIPES_SEARCH_EMPTY } from "@/constants/empty-states";
+import type { RecipeSummary } from "@/types/recipe/recipe";
+
+function errorBody(error: unknown): string {
+  if (error && typeof error === "object" && "status" in error) {
+    return `The server returned ${(error as { status?: number }).status}. Try refreshing.`;
+  }
+  return "Try refreshing the page.";
+}
 
 export default function Recipes() {
   const navigate = useNavigate();
-  const [search, setSearch] = useState("");
-  const debouncedSearch = useDebouncedValue(search.trim(), 300);
-  const { data, isLoading, isError, error, isFetching } = useListRecipesQuery(
-    debouncedSearch || undefined,
-  );
+  const isAuthenticated = useIsAuthenticated();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // The URL is the source of truth: ?q= drives the free-text search and
+  // ?owner=me narrows to the signed-in user's own recipes.
+  const query = searchParams.get("q") ?? "";
+  const ownerMe = searchParams.get("owner") === "me";
+
+  // Local input keeps typing responsive; the debounced value is what gets
+  // written back to ?q= so each keystroke neither stacks a history entry nor
+  // fires a request.
+  const [input, setInput] = useState(query);
+  const debouncedInput = useDebouncedValue(input.trim(), 300);
+
+  useEffect(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (debouncedInput) next.set("q", debouncedInput);
+        else next.delete("q");
+        return next;
+      },
+      { replace: true },
+    );
+  }, [debouncedInput, setSearchParams]);
+
+  const { data, isLoading, isError, error, isFetching } = useListRecipesQuery({
+    search: query || undefined,
+    owner: ownerMe ? "me" : undefined,
+  });
 
   function goToNew() {
     navigate("/recipes/new");
@@ -24,8 +57,61 @@ export default function Recipes() {
     navigate("/recipes/import");
   }
 
+  function toggleOwnerMe() {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (next.get("owner") === "me") next.delete("owner");
+        else next.set("owner", "me");
+        return next;
+      },
+      { replace: true },
+    );
+  }
+
   const recipes = data ?? [];
-  const hasSearch = debouncedSearch.length > 0;
+  const hasSearch = query.length > 0;
+
+  let content: ReactNode;
+  if (isLoading) {
+    content = <RecipesListSkeleton />;
+  } else if (isError) {
+    content = (
+      <EmptyState
+        icon={<ChefHat className="w-12 h-12 text-destructive" />}
+        heading="Couldn't load recipes"
+        body={errorBody(error)}
+      />
+    );
+  } else if (recipes.length === 0 && hasSearch) {
+    content = (
+      <EmptyState
+        icon={<Search className="w-12 h-12" />}
+        heading={RECIPES_SEARCH_EMPTY.heading}
+        body={RECIPES_SEARCH_EMPTY.body}
+      />
+    );
+  } else if (recipes.length === 0) {
+    content = (
+      <EmptyState
+        icon={<ChefHat className="w-12 h-12" />}
+        heading={RECIPES_EMPTY_STATE.heading}
+        body={RECIPES_EMPTY_STATE.body}
+        action={{ label: RECIPES_EMPTY_STATE.actionLabel, onClick: goToNew }}
+      />
+    );
+  } else {
+    content = (
+      <div
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        aria-busy={isFetching}
+      >
+        {recipes.map((recipe: RecipeSummary) => (
+          <RecipeCard key={recipe.id} recipe={recipe} />
+        ))}
+      </div>
+    );
+  }
 
   return (
     <main className="p-4 sm:p-8 space-y-6">
@@ -49,55 +135,37 @@ export default function Recipes() {
         </div>
       </header>
 
-      <div className="relative max-w-md">
-        <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-        <input
-          type="search"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search recipes by title"
-          aria-label="Search recipes by title"
-          className="w-full rounded-md border bg-background pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary min-h-[44px]"
-        />
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative max-w-md flex-1 min-w-[220px]">
+          <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <input
+            type="search"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Search recipes by title"
+            aria-label="Search recipes by title"
+            className="w-full rounded-md border bg-background pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary min-h-[44px]"
+          />
+        </div>
+        {isAuthenticated ? (
+          <button
+            type="button"
+            onClick={toggleOwnerMe}
+            aria-pressed={ownerMe}
+            className={cn(
+              "inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-colors min-h-[44px]",
+              ownerMe
+                ? "border-primary bg-primary/10 text-primary"
+                : "bg-background text-muted-foreground hover:bg-muted",
+            )}
+          >
+            <ChefHat className="w-4 h-4" />
+            My recipes
+          </button>
+        ) : null}
       </div>
 
-      {isLoading ? (
-        <RecipesListSkeleton />
-      ) : isError ? (
-        <EmptyState
-          icon={<ChefHat className="w-12 h-12 text-destructive" />}
-          heading="Couldn't load recipes"
-          body={
-            error && typeof error === "object" && "status" in error
-              ? `The server returned ${(error as { status?: number }).status}. Try refreshing.`
-              : "Try refreshing the page."
-          }
-        />
-      ) : recipes.length === 0 ? (
-        hasSearch ? (
-          <EmptyState
-            icon={<Search className="w-12 h-12" />}
-            heading={RECIPES_SEARCH_EMPTY.heading}
-            body={RECIPES_SEARCH_EMPTY.body}
-          />
-        ) : (
-          <EmptyState
-            icon={<ChefHat className="w-12 h-12" />}
-            heading={RECIPES_EMPTY_STATE.heading}
-            body={RECIPES_EMPTY_STATE.body}
-            action={{ label: RECIPES_EMPTY_STATE.actionLabel, onClick: goToNew }}
-          />
-        )
-      ) : (
-        <div
-          className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
-          aria-busy={isFetching}
-        >
-          {recipes.map((recipe) => (
-            <RecipeCard key={recipe.id} recipe={recipe} />
-          ))}
-        </div>
-      )}
+      {content}
     </main>
   );
 }

--- a/apps/myrecipes/frontend/src/pages/TweakEditor.tsx
+++ b/apps/myrecipes/frontend/src/pages/TweakEditor.tsx
@@ -1,0 +1,93 @@
+import { useNavigate } from "react-router-dom";
+import { ChefHat } from "lucide-react";
+import { EmptyState, Skeleton } from "@platform/ui";
+import { useGetRecipeQuery } from "@/store/recipesApi";
+import EditorHeader from "@/features/recipes/EditorHeader";
+import RecipeEditorForm from "@/features/recipes/RecipeEditorForm";
+
+interface TweakEditorProps {
+  recipeId: string;
+  onMissing: () => void;
+}
+
+/**
+ * Tweak mode of the recipe editor (/recipes/:id/tweak) — creates a new
+ * version of an existing recipe, prefilled from its latest version (lineage
+ * keys carried for the diff). Rendered by RecipeEditor when the path has an
+ * id.
+ */
+export default function TweakEditor({ recipeId, onMissing }: TweakEditorProps) {
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useGetRecipeQuery(recipeId);
+
+  if (isLoading) {
+    return (
+      <main className="p-4 sm:p-8 space-y-6">
+        <EditorHeader
+          backTo={`/recipes/${recipeId}`}
+          backLabel="Back to recipe"
+          title="Tweak recipe"
+        />
+        <div className="space-y-4">
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-48 w-full" />
+          <Skeleton className="h-48 w-full" />
+        </div>
+      </main>
+    );
+  }
+
+  if (isError || !data || !data.latest_version) {
+    return (
+      <main className="p-4 sm:p-8 space-y-6">
+        <EmptyState
+          icon={<ChefHat className="w-12 h-12 text-destructive" />}
+          heading="Recipe not found"
+          body="This recipe doesn't exist or has no version to tweak."
+          action={{ label: "Back to recipes", onClick: onMissing }}
+        />
+      </main>
+    );
+  }
+
+  // Public-read / auth-write: anyone can view a recipe, but tweaking creates a
+  // new version on the owner's recipe — only they can do that. A non-owner who
+  // deep-links to /tweak must NOT get a fillable form that would 404 on submit;
+  // show a clear message with a way back to the recipe instead.
+  if (!data.is_owner) {
+    return (
+      <main className="p-4 sm:p-8 space-y-6">
+        <EditorHeader
+          backTo={`/recipes/${recipeId}`}
+          backLabel="Back to recipe"
+          title="Tweak recipe"
+        />
+        <EmptyState
+          icon={<ChefHat className="w-12 h-12" />}
+          heading="You can only tweak your own recipes"
+          body="This recipe belongs to someone else. You can view it, but tweaking creates a new version that only the owner can make."
+          action={{
+            label: "Back to recipe",
+            onClick: () => navigate(`/recipes/${recipeId}`),
+          }}
+        />
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6">
+      <EditorHeader
+        backTo={`/recipes/${recipeId}`}
+        backLabel="Back to recipe"
+        title={`Tweak "${data.title}"`}
+        subtitle={`Starting from v${data.latest_version.version_number}. Saving creates a new version and the diff shows exactly what changed.`}
+      />
+      <RecipeEditorForm
+        mode="tweak"
+        recipeId={recipeId}
+        baseVersion={data.latest_version}
+      />
+    </main>
+  );
+}

--- a/apps/myrecipes/frontend/src/pages/VersionDiff.tsx
+++ b/apps/myrecipes/frontend/src/pages/VersionDiff.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useNavigate, useParams, useSearchParams, Link } from "react-router-dom";
 import { ArrowLeft, GitCompare } from "lucide-react";
 import { EmptyState, LoadingButton, Skeleton } from "@platform/ui";
-import { useGetDiffQuery } from "@/store/recipesApi";
+import { useGetDiffQuery, useGetRecipeQuery } from "@/store/recipesApi";
 import DiffRow from "@/features/recipes/DiffRow";
 import { formatIngredientLine } from "@/features/recipes/IngredientLine";
 import type { IngredientChange } from "@/types/recipe/diff";
@@ -30,6 +30,11 @@ export default function VersionDiff() {
     { recipeId, versionId, against },
     { skip: !recipeId || !versionId },
   );
+
+  // The diff is public, but "Tweak this recipe" is a write action gated to the
+  // owner. Fetch the recipe to read is_owner (cached from the detail page).
+  const recipeQuery = useGetRecipeQuery(recipeId, { skip: !recipeId });
+  const isOwner = recipeQuery.data?.is_owner ?? false;
 
   const totalChanges = useMemo(
     () => (data ? data.ingredient_changes.length + data.step_changes.length : 0),
@@ -142,14 +147,16 @@ export default function VersionDiff() {
         </div>
       )}
 
-      <div className="flex justify-end">
-        <LoadingButton
-          variant="secondary"
-          onClick={() => navigate(`/recipes/${recipeId}/tweak`)}
-        >
-          Tweak this recipe
-        </LoadingButton>
-      </div>
+      {isOwner ? (
+        <div className="flex justify-end">
+          <LoadingButton
+            variant="secondary"
+            onClick={() => navigate(`/recipes/${recipeId}/tweak`)}
+          >
+            Tweak this recipe
+          </LoadingButton>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/apps/myrecipes/frontend/src/routes.tsx
+++ b/apps/myrecipes/frontend/src/routes.tsx
@@ -1,5 +1,5 @@
 import { type RouteObject } from "react-router-dom";
-import { Support } from "@platform/ui";
+import { AuthRequired, Support } from "@platform/ui";
 import Recipes from "@/pages/Recipes";
 import RecipeDetail from "@/pages/RecipeDetail";
 import RecipeEditor from "@/pages/RecipeEditor";
@@ -16,22 +16,69 @@ import NotFound from "@/pages/NotFound";
 import RootLayout from "@/RootLayout";
 
 // Multi-user app — self-serve /register route enabled (mirrors MJH/MBK).
+//
+// MyRecipes uses public-read / auth-write: anyone can browse the recipe
+// library (list, detail, version diffs), but write surfaces (create / import /
+// tweak) and account pages (settings / security) are wrapped in <AuthRequired>,
+// which shows a Sign-in CTA carrying the current path when unauthenticated.
+// See apps/myrecipes/CLAUDE.md and apps/mygamingassistant CLAUDE.md →
+// Authentication Model for the shared pattern.
 
 export const routes: RouteObject[] = [
   {
     element: <RootLayout />,
     children: [
+      // Public routes — anyone can browse.
       { index: true, element: <Recipes /> },
-      { path: "/recipes/new", element: <RecipeEditor /> },
-      { path: "/recipes/import", element: <RecipeImport /> },
       { path: "/recipes/:id", element: <RecipeDetail /> },
-      { path: "/recipes/:id/tweak", element: <RecipeEditor /> },
       {
         path: "/recipes/:id/versions/:vid/diff",
         element: <VersionDiff />,
       },
-      { path: "/settings", element: <Settings /> },
-      { path: "/security", element: <Security /> },
+
+      // Auth-required — write surfaces + account pages. Each is wrapped in
+      // <AuthRequired> with a tailored ``action`` so the sign-in card explains
+      // exactly what signing in unlocks.
+      {
+        path: "/recipes/new",
+        element: (
+          <AuthRequired action="create a new recipe">
+            <RecipeEditor />
+          </AuthRequired>
+        ),
+      },
+      {
+        path: "/recipes/import",
+        element: (
+          <AuthRequired action="import a recipe from a photo">
+            <RecipeImport />
+          </AuthRequired>
+        ),
+      },
+      {
+        path: "/recipes/:id/tweak",
+        element: (
+          <AuthRequired action="tweak this recipe">
+            <RecipeEditor />
+          </AuthRequired>
+        ),
+      },
+      {
+        path: "/settings",
+        element: (
+          <AuthRequired action="manage your settings">
+            <Settings />
+          </AuthRequired>
+        ),
+      },
+      {
+        path: "/security",
+        element: (
+          <AuthRequired action="manage account security">
+            <Security />
+          </AuthRequired>
+        ),
+      },
     ],
   },
   // Public support / donation page — standalone (no shell, no auth).

--- a/apps/myrecipes/frontend/src/store/recipesApi.ts
+++ b/apps/myrecipes/frontend/src/store/recipesApi.ts
@@ -28,15 +28,33 @@ const apiWithTags = baseApi.enhanceEndpoints({
   addTagTypes: ["Recipe", "Version", "CookLog"],
 });
 
+/**
+ * Arguments for the recipes list query.
+ *
+ * Public-read / auth-write: ``search`` free-text filters the public library;
+ * ``owner: "me"`` narrows to the signed-in user's own recipes (the "My recipes"
+ * filter chip, rendered only when authenticated).
+ */
+export interface ListRecipesArgs {
+  search?: string;
+  owner?: "me";
+}
+
 const recipesApi = apiWithTags.injectEndpoints({
   endpoints: (build) => ({
     // ---- Recipes -------------------------------------------------------
-    listRecipes: build.query<RecipeSummary[], string | undefined>({
-      query: (search) => ({
-        url: "/recipes",
-        method: "GET",
-        params: search ? { search } : undefined,
-      }),
+    listRecipes: build.query<RecipeSummary[], ListRecipesArgs | void>({
+      query: (args) => {
+        const { search, owner } = args ?? {};
+        const params: Record<string, string> = {};
+        if (search) params.search = search;
+        if (owner) params.owner = owner;
+        return {
+          url: "/recipes",
+          method: "GET",
+          params: Object.keys(params).length > 0 ? params : undefined,
+        };
+      },
       providesTags: (result) =>
         result
           ? [

--- a/apps/myrecipes/frontend/src/types/recipe/recipe.ts
+++ b/apps/myrecipes/frontend/src/types/recipe/recipe.ts
@@ -1,9 +1,17 @@
 import type { VersionResponse } from "@/types/recipe/version";
 
-/** List-view recipe: identity plus rollups, no version bodies. */
+/**
+ * List-view recipe: identity plus rollups, no version bodies.
+ *
+ * Public-read / auth-write: recipe reads are public, so the response no longer
+ * carries the owner's ``user_id``. Instead it carries ``is_owner`` (whether the
+ * current viewer owns this recipe) and ``owner_display_name`` (attribution for
+ * everyone else). The owner-only rollups ``best_rating`` and ``last_cooked_at``
+ * are ``null`` for non-owners — the backend omits them so private cook history
+ * never leaks.
+ */
 export interface RecipeSummary {
   id: string;
-  user_id: string;
   title: string;
   description: string | null;
   source: string | null;
@@ -11,8 +19,14 @@ export interface RecipeSummary {
   updated_at: string;
   version_count: number;
   latest_version_number: number | null;
+  /** Best cook rating across versions — ``null`` for non-owners (private). */
   best_rating: number | null;
+  /** When this recipe was last cooked — ``null`` for non-owners (private). */
   last_cooked_at: string | null;
+  /** True when the current viewer owns this recipe (drives write affordances). */
+  is_owner: boolean;
+  /** Display name of the owner, for "by {name}" attribution. Empty when unknown. */
+  owner_display_name: string;
 }
 
 /** Detail-view recipe: the summary plus the full latest version. */

--- a/apps/myrecipes/frontend/src/types/recipe/version.ts
+++ b/apps/myrecipes/frontend/src/types/recipe/version.ts
@@ -16,12 +16,21 @@ export interface VersionResponse {
   steps: StepResponse[];
 }
 
-/** Timeline entry — lightweight, no ingredient/step bodies. */
+/**
+ * Timeline entry — lightweight, no ingredient/step bodies.
+ *
+ * Public-read / auth-write: the per-version cook rollups ``cook_count`` and
+ * ``best_rating`` are owner-only, so the backend returns ``null`` for both to
+ * non-owners. The timeline renders for everyone (version history is public) but
+ * omits these rollups when they're ``null``.
+ */
 export interface VersionSummary {
   id: string;
   version_number: number;
   change_note: string | null;
   created_at: string;
-  cook_count: number;
+  /** Number of logged cooks — ``null`` for non-owners (private). */
+  cook_count: number | null;
+  /** Best cook rating for this version — ``null`` for non-owners (private). */
   best_rating: number | null;
 }

--- a/packages/shared-frontend/src/__tests__/AuthRequired.test.tsx
+++ b/packages/shared-frontend/src/__tests__/AuthRequired.test.tsx
@@ -1,30 +1,21 @@
 /**
- * Unit tests for AuthRequired.
+ * Unit tests for AuthRequired — the frontend gate for public-read / auth-write
+ * apps.
  *
  * Verifies the gate behaviour:
- *   - authenticated   → renders children
- *   - unauthenticated → renders the sign-in fallback (heading + Sign in button)
- *
- * Public-read / auth-write model: see apps/mygamingassistant/CLAUDE.md →
- * Authentication Model.
+ *   - authenticated       → renders children
+ *   - unauthenticated     → renders the sign-in fallback (heading + Sign in button)
+ *   - unavailable={true}  → redirects home, renders neither children nor card
  */
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 
-const mockIsAuthenticated = vi.fn(() => false);
 const mockNavigate = vi.fn();
-const mockIsServeOnly = vi.fn(() => false);
 
-vi.mock("@platform/ui", () => ({
-  Button: ({ children, ...props }: { children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button {...props}>{children}</button>
-  ),
-  useIsAuthenticated: () => mockIsAuthenticated(),
-}));
-
-vi.mock("@/lib/serveOnly", () => ({
-  isServeOnly: () => mockIsServeOnly(),
+vi.mock("../lib/auth-store", () => ({
+  useIsAuthenticated: vi.fn(),
+  notifyAuthChange: vi.fn(),
 }));
 
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -35,7 +26,10 @@ vi.mock("react-router-dom", async (importOriginal) => {
   };
 });
 
-import AuthRequired from "@/components/auth/AuthRequired";
+import { useIsAuthenticated } from "../lib/auth-store";
+import AuthRequired from "../components/auth/AuthRequired";
+
+const mockUseIsAuthenticated = vi.mocked(useIsAuthenticated);
 
 function renderWithRouter(ui: React.ReactNode, initialPath = "/sources") {
   return render(<MemoryRouter initialEntries={[initialPath]}>{ui}</MemoryRouter>);
@@ -43,33 +37,30 @@ function renderWithRouter(ui: React.ReactNode, initialPath = "/sources") {
 
 describe("AuthRequired", () => {
   it("renders children when authenticated", () => {
-    mockIsServeOnly.mockReturnValue(false);
-    mockIsAuthenticated.mockReturnValue(true);
+    mockUseIsAuthenticated.mockReturnValue(true);
     renderWithRouter(
       <AuthRequired action="manage sources">
         <div data-testid="protected">protected content</div>
       </AuthRequired>,
     );
-    expect(screen.getByTestId("protected")).toBeDefined();
+    expect(screen.getByTestId("protected")).toBeInTheDocument();
   });
 
-  it("in serve-only mode, redirects home and renders neither children nor sign-in card", () => {
-    mockIsServeOnly.mockReturnValue(true);
-    // Even with a valid auth token, serve-only must NOT render gated content —
+  it("when unavailable, redirects home and renders neither children nor sign-in card", () => {
+    // Even with a valid auth token, unavailable must NOT render gated content —
     // it redirects to the public home (fail closed).
-    mockIsAuthenticated.mockReturnValue(true);
+    mockUseIsAuthenticated.mockReturnValue(true);
     renderWithRouter(
-      <AuthRequired action="manage sources">
+      <AuthRequired action="manage sources" unavailable>
         <div data-testid="protected">protected content</div>
       </AuthRequired>,
     );
     expect(screen.queryByTestId("protected")).toBeNull();
     expect(screen.queryByRole("heading", { name: /sign in to/i })).toBeNull();
-    mockIsServeOnly.mockReturnValue(false);
   });
 
   it("renders sign-in fallback when not authenticated", () => {
-    mockIsAuthenticated.mockReturnValue(false);
+    mockUseIsAuthenticated.mockReturnValue(false);
     renderWithRouter(
       <AuthRequired action="manage sources">
         <div data-testid="protected">protected content</div>
@@ -77,22 +68,22 @@ describe("AuthRequired", () => {
     );
     expect(screen.queryByTestId("protected")).toBeNull();
     // Heading uses the action string
-    expect(screen.getByRole("heading", { name: /sign in to manage sources/i })).toBeDefined();
-    expect(screen.getByRole("button", { name: /sign in/i })).toBeDefined();
+    expect(screen.getByRole("heading", { name: /sign in to manage sources/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
   });
 
   it("falls back to generic heading when no action is provided", () => {
-    mockIsAuthenticated.mockReturnValue(false);
+    mockUseIsAuthenticated.mockReturnValue(false);
     renderWithRouter(
       <AuthRequired>
         <div>protected</div>
       </AuthRequired>,
     );
-    expect(screen.getByRole("heading", { name: /sign in to continue/i })).toBeDefined();
+    expect(screen.getByRole("heading", { name: /sign in to continue/i })).toBeInTheDocument();
   });
 
   it("navigates to /login with the current path as state.from on click", () => {
-    mockIsAuthenticated.mockReturnValue(false);
+    mockUseIsAuthenticated.mockReturnValue(false);
     mockNavigate.mockClear();
     renderWithRouter(
       <AuthRequired action="manage sources">
@@ -110,12 +101,12 @@ describe("AuthRequired", () => {
   });
 
   it("renders the custom description when supplied", () => {
-    mockIsAuthenticated.mockReturnValue(false);
+    mockUseIsAuthenticated.mockReturnValue(false);
     renderWithRouter(
       <AuthRequired action="upload a lineup" description="Only the operator can add lineups.">
         <div>protected</div>
       </AuthRequired>,
     );
-    expect(screen.getByText(/only the operator can add lineups/i)).toBeDefined();
+    expect(screen.getByText(/only the operator can add lineups/i)).toBeInTheDocument();
   });
 });

--- a/packages/shared-frontend/src/__tests__/GuestShell.test.tsx
+++ b/packages/shared-frontend/src/__tests__/GuestShell.test.tsx
@@ -1,13 +1,12 @@
 /**
- * Unit tests for GuestShell — the layout shown to unauthenticated visitors.
+ * Unit tests for GuestShell — the layout shown to unauthenticated visitors of
+ * a public-read / auth-write app.
  *
  * Verifies:
  *   - the top-bar Sign in button is present
  *   - navigation items render
  *   - clicking Sign in routes to /login with the current location captured
- *
- * Public-read / auth-write model: see apps/mygamingassistant/CLAUDE.md →
- * Authentication Model.
+ *   - hideSignIn suppresses the Sign in CTAs
  */
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -15,12 +14,10 @@ import { MemoryRouter } from "react-router-dom";
 
 const mockNavigate = vi.fn();
 
-vi.mock("@platform/ui", () => ({
-  Button: ({ children, ...props }: { children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button {...props}>{children}</button>
-  ),
-  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
-  useMediaQuery: () => false, // desktop view
+// GuestShell reads useMediaQuery to switch between desktop sidebar and mobile
+// bottom nav. jsdom has no matchMedia, so mock the hook to desktop (false).
+vi.mock("../hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
 }));
 
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -31,10 +28,10 @@ vi.mock("react-router-dom", async (importOriginal) => {
   };
 });
 
-import GuestShell from "@/components/auth/GuestShell";
+import GuestShell from "../components/layout/GuestShell";
 
 const SAMPLE_NAV = [
-  { path: "/", label: "Games", icon: <span data-testid="icon-games" />, exact: true },
+  { path: "/", label: "Recipes", icon: <span data-testid="icon-recipes" />, exact: true },
   { path: "/packages", label: "Packages", icon: <span data-testid="icon-packages" /> },
 ];
 
@@ -49,7 +46,7 @@ describe("GuestShell", () => {
         <div>content</div>
       </GuestShell>,
     );
-    expect(screen.getByTestId("topbar-sign-in")).toBeDefined();
+    expect(screen.getByTestId("topbar-sign-in")).toBeInTheDocument();
   });
 
   it("renders the supplied nav items", () => {
@@ -58,8 +55,8 @@ describe("GuestShell", () => {
         <div>content</div>
       </GuestShell>,
     );
-    expect(screen.getByText("Games")).toBeDefined();
-    expect(screen.getByText("Packages")).toBeDefined();
+    expect(screen.getByText("Recipes")).toBeInTheDocument();
+    expect(screen.getByText("Packages")).toBeInTheDocument();
   });
 
   it("renders content", () => {
@@ -68,7 +65,7 @@ describe("GuestShell", () => {
         <div data-testid="content">inner</div>
       </GuestShell>,
     );
-    expect(screen.getByTestId("content")).toBeDefined();
+    expect(screen.getByTestId("content")).toBeInTheDocument();
   });
 
   it("routes to /login with the current location captured on Sign in click", () => {
@@ -98,6 +95,15 @@ describe("GuestShell", () => {
         <div>content</div>
       </GuestShell>,
     );
-    expect(screen.getByTestId("theme-toggle")).toBeDefined();
+    expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
+  });
+
+  it("hides the Sign in CTAs when hideSignIn is set", () => {
+    renderWithRouter(
+      <GuestShell logo={<div>logo</div>} nav={SAMPLE_NAV} hideSignIn>
+        <div>content</div>
+      </GuestShell>,
+    );
+    expect(screen.queryByTestId("topbar-sign-in")).toBeNull();
   });
 });

--- a/packages/shared-frontend/src/components/auth/AuthRequired.tsx
+++ b/packages/shared-frontend/src/components/auth/AuthRequired.tsx
@@ -1,14 +1,23 @@
 import type { ReactNode } from "react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { Lock } from "lucide-react";
-import { Button, useIsAuthenticated } from "@platform/ui";
-import { isServeOnly } from "@/lib/serveOnly";
+import Button from "../ui/Button";
+import { useIsAuthenticated } from "../../lib/auth-store";
 
-interface AuthRequiredProps {
+export interface AuthRequiredProps {
   /** What the user is trying to do, e.g., "manage sources". Shown in the fallback. */
   action?: string;
   /** Optional longer description rendered below the primary CTA copy. */
   description?: string;
+  /**
+   * When true, the gated route can never be satisfied in this deployment (e.g.
+   * a serve-only / no-auth build where the backend mounts no login route).
+   * Rather than showing a Sign-in card that points at a /login route that
+   * would 404, redirect to the public home. Fail closed: gated content is
+   * never rendered when ``unavailable`` is set, even if a stale token is
+   * present.
+   */
+  unavailable?: boolean;
   /** The gated content. */
   children: ReactNode;
 }
@@ -16,33 +25,32 @@ interface AuthRequiredProps {
 /**
  * AuthRequired — gate a write-surface route or sub-tree behind authentication.
  *
- * MGA uses a public-read / auth-write model: anyone can browse lineups, but
- * mutations and operational pages are operator-only. This component is the
- * one and only frontend gate — every gated route should wrap its top-level
- * component with `<AuthRequired action="...">`.
+ * For a public-read / auth-write app: anyone can browse, but mutations and
+ * operational pages are auth-only. This component is the one and only frontend
+ * gate — every gated route should wrap its top-level component with
+ * `<AuthRequired action="...">`.
  *
  * When unauthenticated, renders a centered card explaining what auth would
  * unlock and a "Sign in" button that routes to /login, passing the current
- * pathname so Login.tsx can return the user here on success.
+ * pathname so Login can return the user here on success.
  *
  * When authenticated, renders ``children`` unchanged.
- *
- * See apps/mygamingassistant/CLAUDE.md → Authentication Model.
  */
 export default function AuthRequired({
   action,
   description,
+  unavailable = false,
   children,
 }: AuthRequiredProps) {
   const isAuthenticated = useIsAuthenticated();
   const location = useLocation();
   const navigate = useNavigate();
 
-  // Serve-only mode: there is no auth and no operator surface — these gated
+  // Unavailable mode: there is no auth surface in this deployment — these gated
   // routes can never be satisfied. Redirect to the public home rather than
-  // showing a Sign-in card that points at a /login route the backend does
-  // not mount (it would 404). Fail closed: gated content is never rendered.
-  if (isServeOnly()) {
+  // showing a Sign-in card that points at a /login route the backend does not
+  // mount (it would 404). Fail closed: gated content is never rendered.
+  if (unavailable) {
     return <Navigate to="/" replace />;
   }
 
@@ -55,7 +63,7 @@ export default function AuthRequired({
     : "Sign in to continue";
   const body =
     description ??
-    "This page is for the site operator. Browsing lineups doesn't require an account — only managing content does.";
+    "This page is for signed-in users. Browsing doesn't require an account — only managing content does.";
 
   function onSignIn() {
     navigate("/login", {

--- a/packages/shared-frontend/src/components/layout/GuestShell.tsx
+++ b/packages/shared-frontend/src/components/layout/GuestShell.tsx
@@ -1,26 +1,26 @@
 import type { ReactNode } from "react";
 import { NavLink, useLocation, useNavigate, type NavLinkRenderProps } from "react-router-dom";
 import { LogIn } from "lucide-react";
-import { Button } from "@platform/ui";
-import { cn } from "@platform/ui";
-import { useMediaQuery } from "@platform/ui";
-import type { NavItem } from "@platform/ui";
+import Button from "../ui/Button";
+import { cn } from "../../utils/cn";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
+import type { NavItem } from "./AppShell";
 
-interface GuestShellProps {
+export interface GuestShellProps {
   logo: ReactNode;
   /** Nav items visible to unauthenticated visitors (public surfaces only). */
   nav: NavItem[];
   /**
-   * Optional right-aligned topbar slot — mirrors @platform/ui AppShell's
-   * ``headerActions`` so the same node (e.g. ``<ThemeToggle />``) can be
-   * passed to either shell without conditional plumbing in RootLayout.
+   * Optional right-aligned topbar slot — mirrors AppShell's ``headerActions``
+   * so the same node (e.g. ``<ThemeToggle />``) can be passed to either shell
+   * without conditional plumbing in RootLayout.
    */
   headerActions?: ReactNode;
   /**
    * When true, the "Sign in" CTAs (sidebar + topbar) are hidden entirely.
-   * Used by the serve-only deployment, where there is NO auth at all — the
-   * backend mounts no login route, so a Sign-in button would dead-end on a
-   * 404. The shell then reads as a plain public site with no account concept.
+   * Used by a serve-only / no-auth deployment, where the backend mounts no
+   * login route so a Sign-in button would dead-end on a 404. The shell then
+   * reads as a plain public site with no account concept.
    */
   hideSignIn?: boolean;
   /** Page content. */
@@ -28,21 +28,19 @@ interface GuestShellProps {
 }
 
 /**
- * GuestShell — app layout for unauthenticated visitors.
+ * GuestShell — app layout for unauthenticated visitors of a public-read /
+ * auth-write app.
  *
- * Mirrors the @platform/ui AppShell visually (same sidebar + topbar
- * structure) but:
- *   - Sidebar shows only public nav items (no Sources / Review / Settings).
+ * Mirrors the AppShell visually (same sidebar + topbar structure) but:
+ *   - Sidebar shows only the public nav items passed in ``nav``.
  *   - User dropdown is replaced with a "Sign in" CTA button.
  *   - Bottom mobile nav reflects the same public-only nav.
  *
- * This is an MGA-specific Tier 3 component — MBK / MJH stay fully auth-gated
- * and don't have an unauthenticated layout state to render.
- *
- * Why not extend @platform/ui AppShell directly: AppShell requires a
- * ``user: { name, email? }`` prop and renders a "Sign out" item. Bending
- * its API to handle the guest case would break parity with MBK / MJH.
- * A small local component keeps the shared layer clean.
+ * Why not extend AppShell directly: AppShell requires a
+ * ``user: { name, email? }`` prop and renders a "Sign out" item. Bending its
+ * API to handle the guest case would break parity for fully auth-gated apps.
+ * A small dedicated component keeps the shared layer clean and lets each app
+ * pick the shell in its RootLayout based on auth state.
  */
 export default function GuestShell({
   logo,

--- a/packages/shared-frontend/src/index.ts
+++ b/packages/shared-frontend/src/index.ts
@@ -48,10 +48,14 @@ export { default as ThemeToggle } from "./components/ui/ThemeToggle";
 // Layout components
 export { default as AppShell } from "./components/layout/AppShell";
 export type { AppShellProps, NavItem, BottomNavItem } from "./components/layout/AppShell";
+export { default as GuestShell } from "./components/layout/GuestShell";
+export type { GuestShellProps } from "./components/layout/GuestShell";
 export { default as AuthPageFooter } from "./components/layout/AuthPageFooter";
 
 // Auth components
 export { default as RequireAuth } from "./components/auth/RequireAuth";
+export { default as AuthRequired } from "./components/auth/AuthRequired";
+export type { AuthRequiredProps } from "./components/auth/AuthRequired";
 export { default as LoginForm } from "./components/auth/LoginForm";
 export type { LoginFormProps } from "./components/auth/LoginForm";
 export { default as PasswordPair } from "./components/auth/PasswordPair";


### PR DESCRIPTION
## What

All recipes become publicly readable and shareable by URL — no account needed. Login gates every write (create/edit/tweak/restore/delete/photo-import) and everything cook-log related. Mirrors MGA's proven `public_router`/`auth_router` split and GuestShell pattern. **Cook logs are private, owner-only** (operator decision), including their rollups.

Product sign-off note: MyRecipes has no production users yet (not deployed), so flipping reads public retroactively exposes nothing.

## Backend

- `recipes.py` exports `public_router` (no auth: list/detail/versions/version/diff) + `auth_router` (router-level `Depends(current_active_user)`: all writes, `/extract`, all `/cooks`).
- **No `user_id` anywhere in responses.** Server computes `is_owner` (against an optional viewer identity, `current_user_optional`) and `owner_display_name` instead.
- **Cook-log rollups are private on the wire**: recipe `best_rating`/`last_cooked_at` and version `cook_count`/`best_rating` are `null` unless the viewer owns the recipe — other users' cook data is never even queried, let alone sent and hidden client-side.
- Dedicated public repo functions (`list_public`, `get_public_by_id`, version equivalents) filter `deleted_at IS NULL` with no `user_id` param — the tenant-scoped write path is byte-unchanged (cross-tenant → 404, no existence leak).
- Public list: pagination (`limit` default 50, cap 200, 422 above), existing `search` ilike, new `owner=me` (401 for anonymous, 422 for other values).
- Soft-deleted and never-existed recipes return identical 404s on every public route.
- No DB migration.

## Frontend

- **`GuestShell` + `AuthRequired` extracted from MGA to `@platform/ui`** (second consumer → auto-promote rule). `AuthRequired` generalized with an `unavailable?: boolean` prop replacing the internal `isServeOnly()` call; MGA passes `unavailable={isServeOnly()}` — behavior identical, local copies + tests moved, MGA stays green.
- MyRecipes: root-level `RequireAuth` removed. Guests get `GuestShell` (nav = recipes list only, sign-in CTA carries `state.from` into the existing Login redirect); authed users keep `AppShell`. `/recipes/new`, `/recipes/import`, `/recipes/:id/tweak`, `/settings`, `/security` wrapped in `<AuthRequired action="…">` (inline sign-in card, no redirect loop).
- Recipes list: search now URL-backed (`?q=`), authed-only "My recipes" chip (`?owner=me`). Cards show the rating/last-cooked block only for `is_owner` (omitted, not dashed — absence of data ≠ never cooked) and "by {display name}" attribution.
- RecipeDetail: non-owners see a clean read-only page — write controls and the entire cook-log section hidden, cook-log query skipped (no doomed 404 request). 404 copy updated for the public model.
- RecipeEditor (tweak, extracted to `TweakEditor.tsx`) and VersionDiff guard non-owners *before* rendering a form that would 404 on submit.

## Tests

- Backend: **39 passed** — 11 new public-matrix tests (no `user_id` key in any payload, rollups null for guests and non-owners, anonymous writes/cooks/extract → 401, non-owner isolation → 404, `owner=me` scoping + anon 401, soft-delete 404 on all public routes, pagination honored/capped).
- **E2E (Playwright): 8/8 passed locally** against a live worktree stack — guest shell + AuthRequired gating on all write surfaces, public 404 copy, and a self-seeding suite (API-seeded probe recipe → guest read-only view, public list visibility, owner sign-in → `My recipes` filter → owner controls + cook log). Credential-gated via `E2E_USER_*` env; self-skips when unset.
- myrecipes frontend: typecheck / lint / test / build all pass (+ new guest-vs-owner RecipeCard tests).
- MGA frontend + shared-frontend: typecheck/build/tests pass except 3 **pre-existing** failures verified byte-identical on `origin/main` (`InlineBoldText.test.tsx` ×2, `MicroClipShiftOverlay.test.tsx` ×1) — unrelated to the extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A64Uwpo1KAxrmjMuSqAvNk