### PR TITLE
fix(infra): compose env_file format: raw — stop interpolating .env.docker values

### DIFF
--- a/apps/mybookkeeper/docker-compose.yml
+++ b/apps/mybookkeeper/docker-compose.yml
@@ -41,7 +41,13 @@ services:
     mem_limit: 512m
     cpus: 1.5
     pids_limit: 128
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
     depends_on:
@@ -57,7 +63,13 @@ services:
     mem_limit: 1024m
     cpus: 1.5
     pids_limit: 256
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
       RUN_UPLOAD_WORKER: "false"
@@ -89,7 +101,13 @@ services:
     mem_limit: 512m
     cpus: 1.0
     pids_limit: 128
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
       # Workers read/write document files in MinIO (extraction downloads by
@@ -115,7 +133,13 @@ services:
     mem_limit: 512m
     cpus: 1.0
     pids_limit: 128
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
       # Workers read/write document files in MinIO (extraction downloads by

--- a/apps/mygamingassistant/docker-compose.yml
+++ b/apps/mygamingassistant/docker-compose.yml
@@ -41,7 +41,13 @@ services:
     mem_limit: 512m
     cpus: 1.5
     pids_limit: 128
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://mygamingassistant:${DB_PASSWORD}@postgres/mygamingassistant
     depends_on:
@@ -57,7 +63,13 @@ services:
     mem_limit: 1024m
     cpus: 1.5
     pids_limit: 256
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://mygamingassistant:${DB_PASSWORD}@postgres/mygamingassistant
     depends_on:

--- a/apps/myjobhunter/docker-compose.yml
+++ b/apps/myjobhunter/docker-compose.yml
@@ -41,7 +41,13 @@ services:
     mem_limit: 512m
     cpus: 1.5
     pids_limit: 128
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://myjobhunter:${DB_PASSWORD}@postgres/myjobhunter
     depends_on:
@@ -57,7 +63,13 @@ services:
     mem_limit: 1024m
     cpus: 1.5
     pids_limit: 256
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://myjobhunter:${DB_PASSWORD}@postgres/myjobhunter
     depends_on:
@@ -79,7 +91,13 @@ services:
     mem_limit: 512m
     cpus: 1.0
     pids_limit: 128
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://myjobhunter:${DB_PASSWORD}@postgres/myjobhunter
     depends_on:

--- a/apps/mypizzatracker/docker-compose.yml
+++ b/apps/mypizzatracker/docker-compose.yml
@@ -41,7 +41,13 @@ services:
     mem_limit: 512m
     cpus: 1.5
     pids_limit: 128
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://mypizzatracker:${DB_PASSWORD}@postgres/mypizzatracker
     depends_on:
@@ -57,7 +63,13 @@ services:
     mem_limit: 1024m
     cpus: 1.5
     pids_limit: 256
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://mypizzatracker:${DB_PASSWORD}@postgres/mypizzatracker
     depends_on:

--- a/apps/myrecipes/docker-compose.yml
+++ b/apps/myrecipes/docker-compose.yml
@@ -41,7 +41,13 @@ services:
     mem_limit: 512m
     cpus: 1.5
     pids_limit: 128
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://myrecipes:${DB_PASSWORD}@postgres/myrecipes
     depends_on:
@@ -57,7 +63,13 @@ services:
     mem_limit: 1024m
     cpus: 1.5
     pids_limit: 256
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://myrecipes:${DB_PASSWORD}@postgres/myrecipes
     depends_on:

--- a/infra/templates/docker-compose.yml.j2
+++ b/infra/templates/docker-compose.yml.j2
@@ -50,7 +50,13 @@ services:
     mem_limit: 512m
     cpus: 1.5
     pids_limit: 128
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://{{ app_slug }}:${DB_PASSWORD}@postgres/{{ app_slug }}
     depends_on:
@@ -72,7 +78,13 @@ services:
     mem_limit: 1024m
     cpus: 1.5
     pids_limit: 256
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://{{ app_slug }}:${DB_PASSWORD}@postgres/{{ app_slug }}
 {%- if has_minio_subdomain %}
@@ -114,7 +126,13 @@ services:
     mem_limit: 512m
     cpus: 1.0
     pids_limit: 128
-    env_file: backend/.env.docker
+    # format: raw (compose >= 2.30) — values are literal, never interpolated.
+    # Default env_file parsing expands $-sequences, which silently corrupts
+    # bcrypt hashes (SEED_*_PASSWORD_HASH: "$2b$12$<salt>..." loses everything
+    # after the first $<alnum-run> to a blank-variable substitution).
+    env_file:
+      - path: backend/.env.docker
+        format: raw
     environment:
       DATABASE_URL: postgresql+asyncpg://{{ app_slug }}:${DB_PASSWORD}@postgres/{{ app_slug }}
 {%- if has_minio_subdomain %}

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -1130,3 +1130,39 @@ class TestSupportPageWired:
             "not the shared MinIO, so it cannot read the shared transparency object; "
             "rendering the widget would show a persistent 'temporarily unavailable'."
         )
+
+
+@pytest.mark.parametrize("app", _APPS)
+class TestComposeEnvFileFormatRaw:
+    """Every compose env_file reference to backend/.env.docker must use the
+    long syntax with ``format: raw`` (Compose >= 2.30).
+
+    Drift trigger: compose interpolates $-sequences inside env-file values by
+    default, silently corrupting literal secrets. Real incident 2026-07-03:
+    myrecipes' SEED_ADMIN_PASSWORD_HASH ($2b$12$<salt+digest>) had its
+    $<alnum-run> substituted to blank (compose logged "variable is not set —
+    defaulting to a blank string"), the api booted with a non-bcrypt hash,
+    SeedAdminInvalidHashError crash-looped the container, and the deploy had
+    to be rolled back. ``format: raw`` declares the whole file literal,
+    protecting seeder-written AND hand-edited values.
+    """
+
+    def test_env_file_entries_use_format_raw(self, app: str) -> None:
+        compose_src = _read("apps", app, "docker-compose.yml")
+        assert "env_file: backend/.env.docker" not in compose_src, (
+            f"{app}/docker-compose.yml uses short-syntax env_file, which lets "
+            f"compose interpolate $-sequences in values (corrupts bcrypt hashes "
+            f"like SEED_ADMIN_PASSWORD_HASH). Use the long syntax with "
+            f"`format: raw` — edit infra/templates/docker-compose.yml.j2 and "
+            f"re-render via `python -m platform_shared.infra.render --all`."
+        )
+        refs = compose_src.count("backend/.env.docker")
+        raw_refs = len(
+            re.findall(r"- path: backend/\.env\.docker\n\s+format: raw", compose_src)
+        )
+        assert refs > 0 and raw_refs == refs, (
+            f"{app}/docker-compose.yml: {refs} env_file reference(s) to "
+            f"backend/.env.docker but only {raw_refs} carry `format: raw`. "
+            f"Every entry must disable interpolation — edit "
+            f"infra/templates/docker-compose.yml.j2 and re-render."
+        )


### PR DESCRIPTION
## Problem

MyRecipes' first seed-admin deploy (run 28633645537) crash-looped: docker compose interpolates `$`-sequences inside `env_file` values by default, so the bcrypt `SEED_ADMIN_PASSWORD_HASH` (`$2b$12$<salt+digest>`) had its `$<alnum-run>` substituted with a blank string (compose warning: `The JmyPK... variable is not set. Defaulting to a blank string.`). The api received a corrupted non-bcrypt hash, `SeedAdminInvalidHashError` failed the healthcheck, and prod was rolled back (run 28666526474, image 06cb4c8f).

Any literal secret containing `$` in `backend/.env.docker` is exposed to this — seeder-written or hand-edited. MBK/MJH's hand-written files just happen to be interpolation-clean today (their last deploy logs show zero such warnings).

## Fix

`env_file` long syntax with `format: raw` (Compose >= 2.30) on every `backend/.env.docker` reference — declares the whole file literal, no interpolation ever:

- `infra/templates/docker-compose.yml.j2` — all three service sites (migrate, api, workers)
- Re-rendered all five apps via `python -m platform_shared.infra.render --all` (`--check` clean, no unrelated drift)
- New conformance test `TestComposeEnvFileFormatRaw` pins the shape per app (155 conformance tests pass; full shared-backend suite 847 pass / 6 skip)

## Operational notes

No env-var changes required. VPS compose must be >= 2.30 (Oct 2024) — the same VPS already exhibits env_file interpolation, which is modern-compose behavior; if it were somehow older, `docker compose config` fails loudly at deploy preflight and the rollback branch remains available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A64Uwpo1KAxrmjMuSqAvNk