### PR TITLE
fix(mga): map filter chips show only present utilities (CS2) + shock badge

### DIFF
--- a/apps/mygamingassistant/backend/app/api/games.py
+++ b/apps/mygamingassistant/backend/app/api/games.py
@@ -112,6 +112,9 @@ async def get_map(
     utility_types = await game_repo.list_utility_types_for_game(db, game.id)
     agents = await game_repo.list_agents_for_game(db, game.id)
     agent_slug_by_id = {a.id: a.slug for a in agents}
+    present_utility_type_slugs = await game_repo.list_present_utility_type_slugs_for_map(
+        db, map_obj.id
+    )
 
     return {
         "id": str(map_obj.id),
@@ -150,6 +153,7 @@ async def get_map(
             {"id": str(a.id), "slug": a.slug, "name": a.name, "role": a.role}
             for a in agents
         ],
+        "present_utility_type_slugs": present_utility_type_slugs,
     }
 
 

--- a/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import selectinload
 
 from app.models.game.agent import Agent
 from app.models.game.game import Game
+from app.models.game.lineup import Lineup
 from app.models.game.map import Map
 from app.models.game.map_zone import MapZone
 from app.models.game.site import Site
@@ -64,6 +65,25 @@ async def list_utility_types_for_game(
         select(UtilityType).where(UtilityType.game_id == game_id).order_by(UtilityType.name)
     )
     return result.scalars().all()
+
+
+async def list_present_utility_type_slugs_for_map(
+    db: AsyncSession, map_id: uuid.UUID
+) -> list[str]:
+    """Distinct utility-type slugs among *accepted* lineups on a map.
+
+    Drives the map page's utility filter chips — so the filter only offers
+    the utilities that actually have browsable lineups on this map, not the
+    whole game's ability catalog (56 for Valorant). The full catalog stays on
+    the map-detail ``utility_types`` field for the upload/review forms.
+    """
+    result = await db.execute(
+        select(UtilityType.slug)
+        .join(Lineup, Lineup.utility_type_id == UtilityType.id)
+        .where(Lineup.map_id == map_id, Lineup.status == "accepted")
+        .distinct()
+    )
+    return sorted(result.scalars().all())
 
 
 async def upsert_utility_type(

--- a/apps/mygamingassistant/frontend/src/constants/utilityDisplay.ts
+++ b/apps/mygamingassistant/frontend/src/constants/utilityDisplay.ts
@@ -3,7 +3,7 @@
  *
  * Keyed by slug (the backend fixture slug), not by display name.
  * CS2 slugs: smoke, flash, molotov, grenade
- * Valorant slugs: smoke, flash, molotov, recon (subset; unknown slugs use fallback)
+ * Valorant slugs: smoke, flash, molotov, recon, shock (subset; unknown slugs use fallback)
  *
  * sortOrder defines the LOCKED within-zone ordering:
  *   Smoke → Flash → Molotov → HE
@@ -26,6 +26,7 @@ export const UTIL_DISPLAY: Record<string, UtilDisplay> = {
   // Valorant-only slugs that share names with CS2 entries above (smoke/flash/molotov)
   // are handled by the entries already keyed above.
   recon:   { label: "Recon",   chipLabel: "Recon",   badgeBg: "bg-teal-600",   badgeText: "text-white",     sortOrder: 5 },
+  shock:   { label: "Shock",   chipLabel: "Shock",   badgeBg: "bg-purple-600", badgeText: "text-white",     sortOrder: 6 },
 };
 
 /** Safe accessor — returns a sensible fallback for any unknown slug. Never throws. */

--- a/apps/mygamingassistant/frontend/src/constants/utilityDisplay.ts
+++ b/apps/mygamingassistant/frontend/src/constants/utilityDisplay.ts
@@ -39,3 +39,41 @@ export function utilDisplay(slug: string | undefined | null): UtilDisplay {
     sortOrder: 99,
   };
 }
+
+export interface UtilChipOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * Build the map-page utility-filter chip options.
+ *
+ * - Valorant: the selected agent's abilities, labelled by their backend name;
+ *   none until an agent is picked (avoids showing ~90 catalog chips).
+ * - CS2: only utilities that actually have accepted lineups on the map
+ *   (`presentSlugs`), ordered by the locked within-zone display order
+ *   (Smoke → Flash → Molotov → HE → …).
+ *
+ * Pure + display-only so it can be unit-tested without a component.
+ */
+export function buildUtilOptions(args: {
+  isValorant: boolean;
+  hasSelectedAgent: boolean;
+  agentUtilSlugs: string[];
+  utilityTypes: { slug: string; name: string }[];
+  presentSlugs: string[];
+}): UtilChipOption[] {
+  const { isValorant, hasSelectedAgent, agentUtilSlugs, utilityTypes, presentSlugs } = args;
+  if (isValorant) {
+    if (!hasSelectedAgent) return [];
+    const scoped = new Set(agentUtilSlugs);
+    return utilityTypes
+      .filter((u) => scoped.has(u.slug))
+      .map((u) => ({ value: u.slug, label: u.name }));
+  }
+  const present = new Set(presentSlugs);
+  return utilityTypes
+    .filter((u) => present.has(u.slug))
+    .sort((a, b) => utilDisplay(a.slug).sortOrder - utilDisplay(b.slug).sortOrder)
+    .map((u) => ({ value: u.slug, label: utilDisplay(u.slug).chipLabel }));
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -163,7 +163,9 @@ export default function MapPage() {
 
   // Utility-chip options. Valorant: the selected agent's abilities labelled by
   // their backend name, or none until an agent is picked (avoids ~90 chips).
-  // CS2: every utility, slug-labelled via utilityDisplay (unchanged).
+  // CS2: only the utilities that actually have accepted lineups on this map
+  // (backend-computed present_utility_type_slugs — not the whole game catalog),
+  // ordered by the locked within-zone display order (Smoke→Flash→Molotov→HE).
   const utilOptions = useMemo(() => {
     const types = mapDetail?.utility_types ?? [];
     if (isValorant) {
@@ -173,7 +175,11 @@ export default function MapPage() {
         .filter((u) => scoped.has(u.slug))
         .map((u) => ({ value: u.slug, label: u.name }));
     }
-    return types.map((u) => ({ value: u.slug, label: utilDisplay(u.slug).chipLabel }));
+    const present = new Set(mapDetail?.present_utility_type_slugs ?? []);
+    return types
+      .filter((u) => present.has(u.slug))
+      .sort((a, b) => utilDisplay(a.slug).sortOrder - utilDisplay(b.slug).sortOrder)
+      .map((u) => ({ value: u.slug, label: utilDisplay(u.slug).chipLabel }));
   }, [mapDetail, isValorant, selectedAgent, agentUtilSlugs]);
 
   // ---------------------------------------------------------------------------

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -50,7 +50,7 @@ import { useLoadout, computeEffectiveUtilFilter } from "@/hooks/useLoadout";
 import { useAgentFilter } from "@/hooks/useAgentFilter";
 import { useMapKeyboardShortcuts } from "@/hooks/useMapKeyboardShortcuts";
 import { useIsSuperuser } from "@/hooks/useIsSuperuser";
-import { utilDisplay } from "@/constants/utilityDisplay";
+import { buildUtilOptions } from "@/constants/utilityDisplay";
 import type { ZoneDensity } from "@/types/game";
 
 export default function MapPage() {
@@ -161,26 +161,19 @@ export default function MapPage() {
     lineups:      allMapLineups,
   });
 
-  // Utility-chip options. Valorant: the selected agent's abilities labelled by
-  // their backend name, or none until an agent is picked (avoids ~90 chips).
-  // CS2: only the utilities that actually have accepted lineups on this map
-  // (backend-computed present_utility_type_slugs — not the whole game catalog),
-  // ordered by the locked within-zone display order (Smoke→Flash→Molotov→HE).
-  const utilOptions = useMemo(() => {
-    const types = mapDetail?.utility_types ?? [];
-    if (isValorant) {
-      if (!selectedAgent) return [];
-      const scoped = new Set(agentUtilSlugs);
-      return types
-        .filter((u) => scoped.has(u.slug))
-        .map((u) => ({ value: u.slug, label: u.name }));
-    }
-    const present = new Set(mapDetail?.present_utility_type_slugs ?? []);
-    return types
-      .filter((u) => present.has(u.slug))
-      .sort((a, b) => utilDisplay(a.slug).sortOrder - utilDisplay(b.slug).sortOrder)
-      .map((u) => ({ value: u.slug, label: utilDisplay(u.slug).chipLabel }));
-  }, [mapDetail, isValorant, selectedAgent, agentUtilSlugs]);
+  // Utility-chip options — see buildUtilOptions (Valorant agent-scoped chips /
+  // CS2 present-utilities-only, both display-ordered).
+  const utilOptions = useMemo(
+    () =>
+      buildUtilOptions({
+        isValorant,
+        hasSelectedAgent: Boolean(selectedAgent),
+        agentUtilSlugs,
+        utilityTypes: mapDetail?.utility_types ?? [],
+        presentSlugs: mapDetail?.present_utility_type_slugs ?? [],
+      }),
+    [mapDetail, isValorant, selectedAgent, agentUtilSlugs],
+  );
 
   // ---------------------------------------------------------------------------
   // Pin system (used by round mode)

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -54,6 +54,13 @@ export interface MapDetail {
    *  scopes the agent selector to agents that actually have lineups on the
    *  current map (intersection with the loaded lineups). */
   agents: Agent[];
+  /**
+   * Utility-type slugs that actually have accepted lineups on this map.
+   * Drives the CS2 map page's filter chips (a small subset), while
+   * `utility_types` carries the full game catalog for the upload/review forms.
+   * (Valorant scopes its chips to the selected agent's abilities instead.)
+   */
+  present_utility_type_slugs: string[];
 }
 
 export interface MinimapUploadUrlResponse {


### PR DESCRIPTION
Two small MGA map-page fixes, **reconciled onto the merged agent-dimension work (#950/#961)** rather than the older deps branch they were first authored against.

## Changes
- **CS2 utility filter chips** now derive from a backend-computed `present_utility_type_slugs` (distinct utility slugs among a map's *accepted* lineups) instead of the whole game catalog — so a CS2 map only offers chips for utilities that actually have lineups. **Valorant's agent-scoped chip behavior is untouched.**
- **`shock` badge display** — add a `shock` entry to `utilityDisplay` (Sova shock darts) so shock lineups render with a proper purple badge + correct sort order across the glance board, lists, and badges, instead of the fallback "Util" styling.

## Files
- `backend/app/repositories/game/game_repo.py` — `list_present_utility_type_slugs_for_map`
- `backend/app/api/games.py` — `get_map` returns `present_utility_type_slugs`
- `frontend/src/types/game.ts` — `MapDetail.present_utility_type_slugs`
- `frontend/src/pages/MapPage.tsx` — CS2 branch of the existing agent-aware `utilOptions` useMemo
- `frontend/src/constants/utilityDisplay.ts` — `shock` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)