### PR TITLE
fix(mga): serve prod clips via presigned R2 URLs + fail-loud media guard

### DIFF
--- a/.github/workflows/deploy-mygamingassistant.yml
+++ b/.github/workflows/deploy-mygamingassistant.yml
@@ -218,6 +218,32 @@ jobs:
               echo "Bundle freshness OK: $DEPLOYED_JS present in caddy"
             fi
 
+            echo "--- Media serving tripwire ---"
+            # Regression guard for the 2026-07-10 incident: MINIO_PUBLIC_BASE_URL
+            # was set to an unbound custom domain (NXDOMAIN), so EVERY lineup clip
+            # 404'd in the browser while the API + /health check stayed green and
+            # the deploy reported success. Fetch one accepted lineup's clip_url
+            # from the live API and confirm the media actually serves. A range GET
+            # (not HEAD — presigned R2 URLs are signed for GET only) keeps it to
+            # ~1MB. See apps/mygamingassistant/backend/.env.docker.example.
+            CLIP_URL=$(curl -sS http://127.0.0.1:8096/api/lineups \
+              | grep -oE '"clip_url":"[^"]+"' | head -1 \
+              | sed -E 's/"clip_url":"//; s/"$//')
+            if [ -z "$CLIP_URL" ] || [ "$CLIP_URL" = "null" ]; then
+              echo "::warning::Media tripwire: no accepted lineup with a clip_url yet — nothing to verify, skipping"
+            else
+              MEDIA_STATUS=$(curl -s -o /dev/null -w '%{http_code}' -L --max-time 20 -r 0-1048575 "$CLIP_URL")
+              case "$MEDIA_STATUS" in
+                200|206)
+                  echo "Media serving OK: clip_url returned $MEDIA_STATUS ($CLIP_URL)"
+                  ;;
+                *)
+                  echo "::error::Media serving tripwire: clip_url returned HTTP $MEDIA_STATUS (expected 200/206) for $CLIP_URL. MINIO_PUBLIC_BASE_URL is likely misconfigured — every clip is a dead link. Leave it empty for presigned R2 URLs, or bind the custom domain. See apps/mygamingassistant/backend/.env.docker.example."
+                  exit 1
+                  ;;
+              esac
+            fi
+
             echo "--- Reclaim disk: prune images + build cache superseded by this deploy ---"
             # Registry-pull deploys (registry_images) fetch a fresh SHA-tagged
             # image from GHCR every time but never remove the prior one, so

--- a/.github/workflows/deploy-mygamingassistant.yml
+++ b/.github/workflows/deploy-mygamingassistant.yml
@@ -218,14 +218,11 @@ jobs:
               echo "Bundle freshness OK: $DEPLOYED_JS present in caddy"
             fi
 
-            echo "--- Media serving tripwire ---"
-            # Regression guard for the 2026-07-10 incident: MINIO_PUBLIC_BASE_URL
-            # was set to an unbound custom domain (NXDOMAIN), so EVERY lineup clip
-            # 404'd in the browser while the API + /health check stayed green and
-            # the deploy reported success. Fetch one accepted lineup's clip_url
-            # from the live API and confirm the media actually serves. A range GET
-            # (not HEAD — presigned R2 URLs are signed for GET only) keeps it to
-            # ~1MB. See apps/mygamingassistant/backend/.env.docker.example.
+            echo "--- Post-deploy verification: Media serving tripwire ---"
+            # Fetch one accepted lineup's clip_url from the live API and confirm the
+            # media actually serves. Range GET (not HEAD — presigned R2 URLs are signed
+            # for GET only) caps the transfer at ~1MB. See
+            # apps/mygamingassistant/backend/.env.docker.example (MINIO_PUBLIC_BASE_URL).
             CLIP_URL=$(curl -sS http://127.0.0.1:8096/api/lineups \
               | grep -oE '"clip_url":"[^"]+"' | head -1 \
               | sed -E 's/"clip_url":"//; s/"$//')
@@ -243,6 +240,7 @@ jobs:
                   ;;
               esac
             fi
+
 
             echo "--- Reclaim disk: prune images + build cache superseded by this deploy ---"
             # Registry-pull deploys (registry_images) fetch a fresh SHA-tagged

--- a/apps/mygamingassistant/TECH_DEBT.md
+++ b/apps/mygamingassistant/TECH_DEBT.md
@@ -192,6 +192,16 @@ backend/app/services/ingestion/chapter_post_processors.py
 
 ## Medium
 
+### [Infra] Unify media routing — migrate myfreeapps.org zone to Cloudflare + bind mga-clips as an R2 custom domain
+
+- **Severity:** Medium
+- **Effort:** L (operator-driven: Cloudflare + Porkbun dashboards; risk touches all apps)
+- **Category:** infra / serving
+- **Location:** apps/mygamingassistant/backend/.env.docker (MINIO_PUBLIC_BASE_URL); apps/mygamingassistant/app.yaml (CSP already allows both hosts)
+- **Deferred:** 2026-07-10, by operator ("defer the work to unify routing to the backlog").
+- **Problem:** Prod currently serves lineup clips via PRESIGNED R2 URLs (`*.r2.cloudflarestorage.com`) because `MINIO_PUBLIC_BASE_URL` is empty. This is correct and works, but bypasses Cloudflare's edge cache — the original reason R2 was chosen for a public read-heavy library. The intended CDN mode (plain `{base}/{key}` via `mga-clips.myfreeapps.org`) needs that domain bound as an R2 custom domain, which needs the `myfreeapps.org` DNS zone on Cloudflare. It is on **Porkbun** (`*.ns.porkbun.com`), so binding is impossible without migrating the whole zone. Setting `MINIO_PUBLIC_BASE_URL` to the unbound domain is what caused the 2026-07-10 incident (every clip NXDOMAIN while /health stayed green).
+- **Recommendation:** When/if edge caching is wanted: repoint `myfreeapps.org` nameservers Porkbun → Cloudflare, re-create every existing DNS record (all app subdomains + MX/email — one miss = downtime), bind `mga-clips.myfreeapps.org` as an R2 custom domain, then set `MINIO_PUBLIC_BASE_URL=https://mga-clips.myfreeapps.org` on the VPS. The boot guard (`app/main.py _check_media_public_base_url_resolvable`) and deploy media tripwire will then verify the CDN host serves before the deploy is declared green. Low urgency: presigned mode is fully functional and R2 egress is free regardless; this only buys edge caching, marginal for a low-traffic app.
+
 ### [Size] LiveCs2Calibrate - 658-line page mixes URL state, dirty-leave guard, keyboard shortcuts, screen capture, three sub-panels
 
 - **Severity:** Medium

--- a/apps/mygamingassistant/app.yaml
+++ b/apps/mygamingassistant/app.yaml
@@ -50,3 +50,34 @@ workers: []
 post_deploy_commands:
   - python -m app.cli load-fixtures
   - python -m app.cli import-lineups
+
+# Host-side smoke checks run AFTER the health check + bundle tripwire (see the
+# deploy template's post_deploy_verifications block). Each entry is a name + a
+# shell snippet; a snippet that `exit 1`s fails the deploy. Other apps omit this
+# key. MGA's media tripwire is the gate that was missing on 2026-07-10, when
+# MINIO_PUBLIC_BASE_URL pointed at an unbound custom domain (NXDOMAIN) and every
+# clip 404'd while /health stayed green and the deploy reported success.
+post_deploy_verifications:
+  - name: Media serving tripwire
+    script: |
+      # Fetch one accepted lineup's clip_url from the live API and confirm the
+      # media actually serves. Range GET (not HEAD — presigned R2 URLs are signed
+      # for GET only) caps the transfer at ~1MB. See
+      # apps/mygamingassistant/backend/.env.docker.example (MINIO_PUBLIC_BASE_URL).
+      CLIP_URL=$(curl -sS http://127.0.0.1:8096/api/lineups \
+        | grep -oE '"clip_url":"[^"]+"' | head -1 \
+        | sed -E 's/"clip_url":"//; s/"$//')
+      if [ -z "$CLIP_URL" ] || [ "$CLIP_URL" = "null" ]; then
+        echo "::warning::Media tripwire: no accepted lineup with a clip_url yet — nothing to verify, skipping"
+      else
+        MEDIA_STATUS=$(curl -s -o /dev/null -w '%{http_code}' -L --max-time 20 -r 0-1048575 "$CLIP_URL")
+        case "$MEDIA_STATUS" in
+          200|206)
+            echo "Media serving OK: clip_url returned $MEDIA_STATUS ($CLIP_URL)"
+            ;;
+          *)
+            echo "::error::Media serving tripwire: clip_url returned HTTP $MEDIA_STATUS (expected 200/206) for $CLIP_URL. MINIO_PUBLIC_BASE_URL is likely misconfigured — every clip is a dead link. Leave it empty for presigned R2 URLs, or bind the custom domain. See apps/mygamingassistant/backend/.env.docker.example."
+            exit 1
+            ;;
+        esac
+      fi

--- a/apps/mygamingassistant/backend/.env.docker.example
+++ b/apps/mygamingassistant/backend/.env.docker.example
@@ -139,13 +139,27 @@ SMTP_PASSWORD=
 #   MINIO_ACCESS_KEY      R2 API-token Access Key ID.
 #   MINIO_SECRET_KEY      R2 API-token Secret Access Key.
 #   MINIO_BUCKET          R2 bucket name (keep == local so object keys match).
-#   MINIO_PUBLIC_BASE_URL R2 bucket's PUBLIC custom domain, no trailing slash.
-#                         Public read URLs become {base}/{key} — plain CDN URLs,
-#                         no presigning (only accepted/public clips reach prod).
-#                         MUST match the host allowed in app.yaml's CSP
-#                         (mga-clips.myfreeapps.org) AND the domain the operator
-#                         binds to the R2 bucket. Create the bucket BEFORE first
-#                         boot (the lifespan bucket-check verifies, never creates).
+#   MINIO_PUBLIC_BASE_URL Two serving modes — LEAVE EMPTY unless you have bound
+#                         a real R2 custom domain (see below). Empty is the
+#                         current production shape.
+#
+#     * EMPTY (default, current prod):  clip/screenshot read URLs are PRESIGNED
+#       against the R2 S3 endpoint (https://<ACCOUNT_ID>.r2.cloudflarestorage.com,
+#       already allowed in app.yaml's CSP). Works with the DNS zone anywhere.
+#       Only accepted/public clips reach prod, and the API presigns each URL per
+#       request. No edge caching, but R2 egress is free — fine for this app.
+#
+#     * SET to an R2 custom domain (e.g. https://mga-clips.myfreeapps.org):
+#       read URLs become plain {base}/{key} CDN URLs (edge-cached, unsigned).
+#       This REQUIRES the domain to be bound as an R2 custom domain, which
+#       REQUIRES the myfreeapps.org DNS zone to live on Cloudflare. It is
+#       currently on Porkbun, so this cannot be bound without a zone migration
+#       (tracked in apps/mygamingassistant/TECH_DEBT.md → "Unify media routing").
+#       DO NOT set this to an unbound domain: every clip URL becomes a dead host
+#       (NXDOMAIN) while /health stays green — the 2026-07-10 incident. The
+#       lifespan now FAILS LOUD at boot if this host does not resolve (see
+#       app/main.py _check_media_public_base_url_resolvable), so a misconfig
+#       crashes the deploy instead of silently serving broken <video>s.
 #
 # Local dev does NOT use this file — it uses backend/.env with standalone MinIO:
 #   MINIO_ENDPOINT=localhost:9000  MINIO_SECURE=false  MINIO_PUBLIC_BASE_URL= (empty → presigned)
@@ -154,7 +168,9 @@ MINIO_SECURE=true
 MINIO_ACCESS_KEY=
 MINIO_SECRET_KEY=
 MINIO_BUCKET=mygamingassistant-screenshots
-MINIO_PUBLIC_BASE_URL=https://mga-clips.myfreeapps.org
+# Empty → presigned R2 URLs (current prod mode). Only set to a BOUND R2 custom
+# domain; an unbound value dead-links every clip. See the block above.
+MINIO_PUBLIC_BASE_URL=
 
 # YouTube ingestion pipeline (PR 4+)
 # Directory where yt-dlp downloads videos before ffmpeg frame extraction.

--- a/apps/mygamingassistant/backend/app/core/config.py
+++ b/apps/mygamingassistant/backend/app/core/config.py
@@ -55,16 +55,20 @@ class Settings(BaseAppSettings):
     email_from_name: str = "MyGamingAssistant"
 
     # ------------------------------------------------------------------
-    # Public object base URL for the lineup library (R2 prod serving).
-    # When set (production: the R2 bucket's public custom domain, e.g.
-    # https://clips.mygamingassistant.myfreeapps.org), public read URLs for
-    # lineup clips/screenshots are emitted as plain CDN URLs ``{base}/{key}``
-    # instead of presigned MinIO URLs. Accepted lineups are public and prod R2
-    # holds ONLY accepted clips, so no signing is needed and Cloudflare's CDN
-    # can edge-cache them (R2's free-egress + cache win — why R2 was chosen).
-    # Leave EMPTY in local dev / CI, where storage is MinIO, reads are
-    # presigned, and pending screenshots are gated by the API 404 on
-    # non-accepted lineups. See lineup_service._sign_screenshot_url.
+    # Public object base URL for the lineup library (R2 read serving).
+    # EMPTY is the current production mode: clip/screenshot read URLs are
+    # PRESIGNED against the R2 S3 endpoint (always reachable; CSP already allows
+    # *.r2.cloudflarestorage.com). Only accepted/public clips reach prod and the
+    # API presigns each URL per request — no edge cache, but R2 egress is free.
+    #
+    # Set this ONLY to a BOUND R2 custom domain (e.g. https://mga-clips.myfreeapps.org):
+    # read URLs then become plain CDN URLs ``{base}/{key}`` (unsigned, edge-cached).
+    # Binding requires the myfreeapps.org DNS zone on Cloudflare, which it is not
+    # (Porkbun) — so this stays empty until the zone migration tracked in
+    # apps/mygamingassistant/TECH_DEBT.md. An unbound value dead-links every clip;
+    # the lifespan now fails loud at boot if the host does not resolve (see
+    # app/main.py _check_media_public_base_url_resolvable). Also empty in local
+    # dev / CI, where storage is MinIO. See lineup_url_signing._sign_screenshot_url.
     # ------------------------------------------------------------------
     minio_public_base_url: str = ""
 

--- a/apps/mygamingassistant/backend/app/main.py
+++ b/apps/mygamingassistant/backend/app/main.py
@@ -10,8 +10,10 @@ TOTP routes, admin router, version endpoint). MGA-specific divergences
 are called out inline.
 """
 import logging
+import socket
 import time
 from datetime import datetime, timezone
+from urllib.parse import urlsplit
 
 import jwt
 from fastapi import Depends, FastAPI, Request
@@ -66,6 +68,60 @@ class SchedulerStartupError(RuntimeError):
     """Raised at startup when SCHEDULER_ENABLED=true but the scheduler fails to start."""
 
 
+class MediaPublicBaseUrlUnresolvableError(RuntimeError):
+    """Raised at startup when MINIO_PUBLIC_BASE_URL is set but its host does not resolve.
+
+    Guards against the 2026-07-10 incident: MINIO_PUBLIC_BASE_URL was set to a
+    custom domain (mga-clips.myfreeapps.org) that was never bound as an R2 custom
+    domain — the myfreeapps.org zone is on Porkbun, not Cloudflare, so binding is
+    impossible without a zone migration. The host was NXDOMAIN, so EVERY lineup
+    clip/screenshot URL 404'd in the browser while the API and /health stayed
+    green. Fail loud at boot instead of silently serving a library of dead media.
+    """
+
+
+def _check_media_public_base_url_resolvable() -> None:
+    """Fail loud in prod if the configured public media host does not resolve.
+
+    ``minio_public_base_url`` drives clip/screenshot read URLs (see
+    ``lineup_url_signing._sign_screenshot_url``):
+
+    - **Empty (default prod mode):** URLs are presigned against the R2 S3
+      endpoint, which is always reachable — there is no separate public host to
+      check, so this guard is a no-op.
+    - **Set:** URLs become plain ``{base}/{key}`` against that host. If the host
+      does not resolve, every clip is a dead link while /health stays green.
+      That is the exact silent failure this guard converts into a loud boot
+      crash (prod) or a warning (dev/CI).
+    """
+    base = settings.minio_public_base_url
+    if not base:
+        return  # presigned mode — no separate public host to verify
+    host = urlsplit(base).hostname
+    if not host:
+        raise MediaPublicBaseUrlUnresolvableError(
+            f"MINIO_PUBLIC_BASE_URL={base!r} is not a valid absolute URL (no host). "
+            "Set it to the full https URL of a BOUND R2 custom domain, or leave it "
+            "empty to serve presigned R2 URLs (the default prod mode). See "
+            "apps/mygamingassistant/backend/.env.docker.example."
+        )
+    try:
+        socket.getaddrinfo(host, 443)
+    except socket.gaierror as exc:
+        msg = (
+            f"MINIO_PUBLIC_BASE_URL host {host!r} does not resolve ({exc}). Every "
+            "lineup clip/screenshot URL would point at a dead host while /health "
+            "stays green (the 2026-07-10 incident). Either bind that domain as an "
+            "R2 custom domain (requires the DNS zone on Cloudflare — see "
+            "apps/mygamingassistant/TECH_DEBT.md), or leave MINIO_PUBLIC_BASE_URL "
+            "empty to serve presigned R2 URLs (the default prod mode). See "
+            "apps/mygamingassistant/backend/.env.docker.example."
+        )
+        if settings.environment == "production":
+            raise MediaPublicBaseUrlUnresolvableError(msg) from exc
+        logger.warning("_on_startup: %s (non-production — continuing)", msg)
+
+
 async def _on_startup() -> None:
     """MGA-specific startup: seed the single operator user + classifier boot guard.
 
@@ -91,6 +147,12 @@ async def _on_startup() -> None:
         )
     else:
         await _seed_operator_if_configured()
+
+    # Media serving boot guard — runs in BOTH modes. If a public media base URL
+    # is configured, its host MUST resolve, or the whole public clip library
+    # dead-links while /health stays green. No-op in the default presigned mode
+    # (empty base). See _check_media_public_base_url_resolvable.
+    _check_media_public_base_url_resolvable()
 
     # Classifier boot guard: fail loud in production if classifier is enabled
     # but ANTHROPIC_API_KEY is not set.

--- a/apps/mygamingassistant/backend/tests/test_media_public_base_url_guard.py
+++ b/apps/mygamingassistant/backend/tests/test_media_public_base_url_guard.py
@@ -1,0 +1,94 @@
+"""Boot guard + config-default regression for MINIO_PUBLIC_BASE_URL.
+
+Regression tests for the 2026-07-10 incident: MINIO_PUBLIC_BASE_URL was set to
+an unbound custom domain (mga-clips.myfreeapps.org, NXDOMAIN), so every lineup
+clip/screenshot dead-linked in the browser while the API and /health stayed
+green and the deploy reported success.
+
+Two guardrails locked here:
+
+1. The shipped ``.env.docker.example`` must default MINIO_PUBLIC_BASE_URL to
+   EMPTY (presigned prod mode) — the operator copied the old non-empty default,
+   which is what caused the incident.
+2. ``_check_media_public_base_url_resolvable`` fails loud in production when a
+   configured public media host does not resolve, and is a no-op in the default
+   presigned mode.
+"""
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+from app import main
+from app.core.config import settings
+from app.main import (
+    MediaPublicBaseUrlUnresolvableError,
+    _check_media_public_base_url_resolvable,
+)
+
+
+def test_empty_base_is_noop(monkeypatch):
+    """Presigned mode (empty base): guard does nothing and never resolves DNS."""
+    monkeypatch.setattr(settings, "minio_public_base_url", "")
+
+    def _fail(*_a, **_k):
+        raise AssertionError("getaddrinfo must not run when base is empty")
+
+    monkeypatch.setattr(main.socket, "getaddrinfo", _fail)
+    _check_media_public_base_url_resolvable()  # must not raise
+
+
+def test_resolvable_host_passes(monkeypatch):
+    monkeypatch.setattr(settings, "minio_public_base_url", "https://mga-clips.myfreeapps.org")
+    monkeypatch.setattr(settings, "environment", "production")
+    monkeypatch.setattr(main.socket, "getaddrinfo", lambda *_a, **_k: [("ok",)])
+    _check_media_public_base_url_resolvable()  # must not raise
+
+
+def test_unresolvable_host_raises_in_production(monkeypatch):
+    monkeypatch.setattr(settings, "minio_public_base_url", "https://mga-clips.myfreeapps.org")
+    monkeypatch.setattr(settings, "environment", "production")
+
+    def _boom(*_a, **_k):
+        raise socket.gaierror("Name or service not known")
+
+    monkeypatch.setattr(main.socket, "getaddrinfo", _boom)
+    with pytest.raises(MediaPublicBaseUrlUnresolvableError):
+        _check_media_public_base_url_resolvable()
+
+
+def test_unresolvable_host_warns_but_continues_in_dev(monkeypatch):
+    monkeypatch.setattr(settings, "minio_public_base_url", "https://mga-clips.myfreeapps.org")
+    monkeypatch.setattr(settings, "environment", "development")
+
+    def _boom(*_a, **_k):
+        raise socket.gaierror("Name or service not known")
+
+    monkeypatch.setattr(main.socket, "getaddrinfo", _boom)
+    _check_media_public_base_url_resolvable()  # dev: warn, don't crash
+
+
+def test_base_without_host_raises_regardless_of_env(monkeypatch):
+    """A bare hostname (no scheme) is a config error — enforce a full https URL."""
+    monkeypatch.setattr(settings, "minio_public_base_url", "mga-clips.myfreeapps.org")
+    monkeypatch.setattr(settings, "environment", "development")
+    with pytest.raises(MediaPublicBaseUrlUnresolvableError):
+        _check_media_public_base_url_resolvable()
+
+
+def test_env_example_defaults_to_presigned_mode():
+    """Root-cause regression: the shipped example must NOT set an unbound custom
+    domain. Empty MINIO_PUBLIC_BASE_URL == presigned prod mode (the safe default)."""
+    example = Path(__file__).resolve().parent.parent / ".env.docker.example"
+    values = [
+        line.split("=", 1)[1].strip()
+        for line in example.read_text(encoding="utf-8").splitlines()
+        if line.startswith("MINIO_PUBLIC_BASE_URL=")
+    ]
+    assert values, "MINIO_PUBLIC_BASE_URL line missing from .env.docker.example"
+    assert values[-1] == "", (
+        "MINIO_PUBLIC_BASE_URL must ship EMPTY (presigned mode). A non-empty "
+        "unbound custom domain dead-links every clip — the 2026-07-10 incident."
+    )

--- a/infra/templates/.github/workflows/deploy.yml.j2
+++ b/infra/templates/.github/workflows/deploy.yml.j2
@@ -246,6 +246,13 @@ jobs:
               echo "Bundle freshness OK: $DEPLOYED_JS present in caddy"
             fi
 {%- endif %}
+{%- if post_deploy_verifications is defined and post_deploy_verifications %}
+{%- for check in post_deploy_verifications %}
+
+            echo "--- Post-deploy verification: {{ check.name }} ---"
+{{ check.script | indent(width=12, first=True) }}
+{%- endfor %}
+{%- endif %}
 {%- if registry_images | default(false) %}
 
             echo "--- Reclaim disk: prune images + build cache superseded by this deploy ---"


### PR DESCRIPTION
## Problem

Production MGA was emitting every lineup clip URL against **`mga-clips.myfreeapps.org`**, an R2 custom domain that was **never bound** — the `myfreeapps.org` DNS zone lives on **Porkbun**, not Cloudflare, so an R2 custom domain can't be bound without migrating the whole zone. The host is **NXDOMAIN**, so **every clip 404'd in the browser** while `/api/lineups` (530 rows) and `/health` stayed green and the deploy reported success.

Verified live before the fix:
```
"clip_url":"https://mga-clips.myfreeapps.org/pending/voM-FpCNqtU/896-clip.mp4"   # NXDOMAIN
```

## Root cause

- `.env.docker.example` shipped `MINIO_PUBLIC_BASE_URL=https://mga-clips.myfreeapps.org` as its **default**, and the operator copied it to the VPS. The code default is already correct (`""` → presigned R2 URLs — a first-class serving mode the CSP already allows via `*.r2.cloudflarestorage.com`, wired in #825).
- **No deploy gate ever dereferenced a clip URL**, so the misconfig shipped silently. The lifespan bucket-check verifies the S3 *bucket* exists but not that the public read *host* resolves.

## Fix — root cause + recurrence prevention

| Change | File |
|---|---|
| Default `MINIO_PUBLIC_BASE_URL` to empty (presigned mode) + document the custom-domain path's Cloudflare requirement | `backend/.env.docker.example` |
| **Fail-loud boot guard** `_check_media_public_base_url_resolvable` — if a public base URL is set but its host doesn't resolve, crash the deploy in prod (warn in dev). No-op in presigned mode | `backend/app/main.py` |
| **Post-deploy media tripwire** — fetch an accepted lineup's `clip_url` and assert it serves (range GET, 200/206). The gate that was missing | `.github/workflows/deploy-mygamingassistant.yml` |
| Doc comment aligned to presigned-is-prod-default | `backend/app/core/config.py` |
| Regression tests: env-example default locked + boot-guard behavior | `backend/tests/test_media_public_base_url_guard.py` (new) |
| Log deferred zone-migration / custom-domain CDN work ("unify media routing"), per operator | `apps/mygamingassistant/TECH_DEBT.md` |

Presigned mode is the correct architecture given the DNS lives on Porkbun: URLs are signed against the always-reachable R2 S3 endpoint, R2 egress is free, and only accepted/public clips reach prod. Edge-cached CDN URLs via a bound custom domain are deferred to TECH_DEBT (needs the zone on Cloudflare — touches all apps + email).

Tests: 6 new + 12 sibling signing tests pass locally; deploy YAML validated.

## ⚠️ Operational migration required

After merge + deploy, on the VPS set the presigned mode explicitly (the deployed `.env.docker` currently has the broken custom domain):

```bash
# apps/mygamingassistant/backend/.env.docker  — set to EMPTY
MINIO_PUBLIC_BASE_URL=
```

Then restart the api container:
```bash
docker compose -f apps/mygamingassistant/docker-compose.yml up -d --force-recreate api
```

Verify clips serve (any accepted lineup):
```bash
curl -s http://127.0.0.1:8096/api/lineups | grep -oE '"clip_url":"[^"]+"' | head -1
# then range-GET that URL — expect 200/206
```

If `MINIO_PUBLIC_BASE_URL` is ever set to an unbound host again, the **boot guard now crashes the deploy** with a clear message instead of silently serving dead media, and the **media tripwire** fails the deploy if a clip doesn't return 200/206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)