### PR TITLE
feat(mbk): live guest-preview panel on welcome manual detail

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/welcome-manuals-crud.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/welcome-manuals-crud.spec.ts
@@ -58,8 +58,11 @@ test.describe("Welcome Manuals CRUD (PR 4b)", () => {
       await page.getByTestId("welcome-manual-create-title").fill(title);
       await page.getByTestId("welcome-manual-create-submit").click();
 
-      // Navigates to the new detail page (header heading appears).
-      await expect(page.getByRole("heading", { name: title })).toBeVisible({ timeout: 10000 });
+      // Navigates to the new detail page (header heading appears). Scope to the
+      // header card — the guest-preview panel repeats the title as its own h1.
+      await expect(
+        page.getByTestId("welcome-manual-header-card").getByRole("heading", { name: title }),
+      ).toBeVisible({ timeout: 10000 });
       const detailUrl = page.url();
       const match = detailUrl.match(/\/welcome-manuals\/([0-9a-f-]+)/);
       manualId = match?.[1] ?? null;
@@ -78,7 +81,9 @@ test.describe("Welcome Manuals CRUD (PR 4b)", () => {
 
       // Open it again.
       await page.getByText(title).first().click();
-      await expect(page.getByRole("heading", { name: title })).toBeVisible();
+      await expect(
+        page.getByTestId("welcome-manual-header-card").getByRole("heading", { name: title }),
+      ).toBeVisible();
       await page.waitForLoadState("networkidle");
 
       // 3) EDIT the first section's title + markdown body, then Save.

--- a/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout-mock.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout-mock.spec.ts
@@ -202,7 +202,12 @@ test.describe("Welcome Manuals layout (mocked, no backend)", () => {
     await expect(page.getByTestId("welcome-manual-detail-skeleton")).toBeVisible({ timeout: 5000 });
 
     await expect(page.getByTestId("welcome-manual-header-card")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByRole("heading", { name: "Lakeview Welcome Guide" })).toBeVisible();
+    // Scope to the header card — the guest-preview panel repeats the title as its own h1.
+    await expect(
+      page.getByTestId("welcome-manual-header-card").getByRole("heading", {
+        name: "Lakeview Welcome Guide",
+      }),
+    ).toBeVisible();
     await expect(page.getByTestId("welcome-manual-sections")).toBeVisible();
     const cards = await page.getByTestId("welcome-manual-section-card").count();
     expect(cards).toBe(3);
@@ -210,5 +215,54 @@ test.describe("Welcome Manuals layout (mocked, no backend)", () => {
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
     const vw = page.viewportSize()?.width ?? 0;
     expect(bodyWidth).toBeLessThanOrEqual(vw + 1);
+  });
+
+  test("desktop shows editor + guest preview side by side; toggle hidden", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await plantAuth(page);
+    await stubShell(page);
+    await stubDetail(page);
+
+    await page.goto(`/welcome-manuals/${MANUAL_ID}`);
+    await expect(page.getByTestId("welcome-manual-header-card")).toBeVisible({ timeout: 10000 });
+
+    // Both columns visible on desktop; the mobile Edit/Preview toggle is hidden.
+    await expect(page.getByTestId("welcome-manual-editor-column")).toBeVisible();
+    await expect(page.getByTestId("welcome-manual-preview-column")).toBeVisible();
+    await expect(page.getByTestId("welcome-manual-view-toggle")).toBeHidden();
+
+    // The preview mirrors the sections (title + one preview section per section).
+    const previewSections = await page.getByTestId("welcome-manual-preview-section").count();
+    expect(previewSections).toBe(3);
+
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(1280 + 1);
+  });
+
+  test("mobile toggle switches between editor and guest preview", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    await plantAuth(page);
+    await stubShell(page);
+    await stubDetail(page);
+
+    await page.goto(`/welcome-manuals/${MANUAL_ID}`);
+    await expect(page.getByTestId("welcome-manual-view-toggle")).toBeVisible({ timeout: 10000 });
+
+    // Editor shows by default; preview is hidden.
+    await expect(page.getByTestId("welcome-manual-editor-column")).toBeVisible();
+    await expect(page.getByTestId("welcome-manual-preview-column")).toBeHidden();
+
+    // Switch to preview.
+    await page.getByTestId("welcome-manual-view-toggle-preview").click();
+    await expect(page.getByTestId("welcome-manual-preview-column")).toBeVisible();
+    await expect(page.getByTestId("welcome-manual-editor-column")).toBeHidden();
+
+    // Switch back to editor.
+    await page.getByTestId("welcome-manual-view-toggle-edit").click();
+    await expect(page.getByTestId("welcome-manual-editor-column")).toBeVisible();
+    await expect(page.getByTestId("welcome-manual-preview-column")).toBeHidden();
+
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(375 + 1);
   });
 });

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualDetail.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualDetail.test.tsx
@@ -8,7 +8,7 @@
  *   - The error state offers a retry.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { store } from "@/shared/store";
@@ -120,5 +120,27 @@ describe("WelcomeManualDetail", () => {
     renderDetail();
     expect(screen.getByTestId("email-welcome-manual-button")).not.toBeDisabled();
     expect(screen.getByTestId("welcome-manual-sections")).toBeInTheDocument();
+  });
+
+  it("renders a guest preview panel beside the editor", () => {
+    mockManual = makeManual([makeSection("sec-1")]);
+    renderDetail();
+    expect(screen.getByTestId("welcome-manual-editor-column")).toBeInTheDocument();
+    expect(screen.getByTestId("welcome-manual-preview-column")).toBeInTheDocument();
+    expect(screen.getByTestId("welcome-manual-preview")).toBeInTheDocument();
+  });
+
+  it("toggles the mobile view between edit and preview", () => {
+    mockManual = makeManual([makeSection("sec-1")]);
+    renderDetail();
+    const editTab = screen.getByTestId("welcome-manual-view-toggle-edit");
+    const previewTab = screen.getByTestId("welcome-manual-view-toggle-preview");
+    // Editor is the default selected tab.
+    expect(editTab).toHaveAttribute("aria-selected", "true");
+    expect(previewTab).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.click(previewTab);
+    expect(previewTab).toHaveAttribute("aria-selected", "true");
+    expect(editTab).toHaveAttribute("aria-selected", "false");
   });
 });

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualPreview.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualPreview.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for WelcomeManualPreview — the guest-facing assembled view.
+ *
+ * Verifies it mirrors the emailed PDF structure: title, intro markdown, then
+ * each section's title, body markdown, and images with captions. Also covers
+ * the empty-sections placeholder and the missing-image fallback.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import WelcomeManualPreview from "@/app/features/welcome-manuals/WelcomeManualPreview";
+import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+import type { WelcomeManualSectionImageResponse } from "@/shared/types/welcome-manual/welcome-manual-section-image-response";
+
+function makeImage(
+  overrides: Partial<WelcomeManualSectionImageResponse> = {},
+): WelcomeManualSectionImageResponse {
+  return {
+    id: "img-1",
+    section_id: "sec-1",
+    storage_key: "welcome-manuals/img-1.jpg",
+    caption: "Front door",
+    display_order: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    presigned_url: "https://storage.example.com/img-1.jpg",
+    is_available: true,
+    ...overrides,
+  };
+}
+
+function makeSection(
+  overrides: Partial<WelcomeManualSectionResponse> = {},
+): WelcomeManualSectionResponse {
+  return {
+    id: "sec-1",
+    manual_id: "m-1",
+    title: "Parking",
+    body: "Park in **spot 4**.",
+    display_order: 0,
+    images: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("WelcomeManualPreview", () => {
+  it("renders the title and intro markdown", () => {
+    render(
+      <WelcomeManualPreview
+        title="Lakeview Welcome Guide"
+        introText="Welcome to **our home**!"
+        sections={[]}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Lakeview Welcome Guide" }),
+    ).toBeInTheDocument();
+    const intro = screen.getByTestId("welcome-manual-preview-intro");
+    expect(within(intro).getByText("our home")).toBeInTheDocument();
+  });
+
+  it("shows the empty placeholder when there are no sections", () => {
+    render(
+      <WelcomeManualPreview title="Guide" introText={null} sections={[]} />,
+    );
+    expect(screen.getByTestId("welcome-manual-preview-empty")).toBeInTheDocument();
+  });
+
+  it("renders each section's title and body markdown", () => {
+    render(
+      <WelcomeManualPreview
+        title="Guide"
+        introText={null}
+        sections={[makeSection()]}
+      />,
+    );
+    const section = screen.getByTestId("welcome-manual-preview-section");
+    expect(within(section).getByRole("heading", { name: "Parking" })).toBeInTheDocument();
+    expect(within(section).getByText("spot 4")).toBeInTheDocument();
+  });
+
+  it("renders section images with their captions", () => {
+    render(
+      <WelcomeManualPreview
+        title="Guide"
+        introText={null}
+        sections={[makeSection({ images: [makeImage()] })]}
+      />,
+    );
+    const img = screen.getByTestId("welcome-manual-preview-image");
+    expect(img).toHaveAttribute("src", "https://storage.example.com/img-1.jpg");
+    expect(screen.getByText("Front door")).toBeInTheDocument();
+  });
+
+  it("renders a placeholder when an image is unavailable", () => {
+    render(
+      <WelcomeManualPreview
+        title="Guide"
+        introText={null}
+        sections={[
+          makeSection({
+            images: [makeImage({ is_available: false, presigned_url: null })],
+          }),
+        ]}
+      />,
+    );
+    expect(
+      screen.getByTestId("welcome-manual-preview-image-missing"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("welcome-manual-preview-image")).not.toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPreview.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPreview.tsx
@@ -1,0 +1,94 @@
+import Markdown from "@/shared/components/ui/Markdown";
+import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+
+export interface WelcomeManualPreviewProps {
+  title: string;
+  introText: string | null;
+  /** Sections already sorted by display_order. */
+  sections: WelcomeManualSectionResponse[];
+}
+
+/**
+ * Guest-facing preview of a welcome manual — the assembled view a guest sees
+ * in the emailed PDF. Mirrors the backend PDF structure
+ * (`welcome_manual_pdf_service.py`): centered title, intro markdown, then each
+ * section's title, body markdown, and images with captions.
+ *
+ * Unlike the editor's inline `Markdown` bodies, section images here are the
+ * real uploaded photos (rendered from their presigned URLs), not markdown
+ * images — `Markdown` intentionally drops markdown `img` tags.
+ */
+export default function WelcomeManualPreview({
+  title,
+  introText,
+  sections,
+}: WelcomeManualPreviewProps) {
+  return (
+    <article
+      className="bg-card border rounded-lg p-6 space-y-6"
+      data-testid="welcome-manual-preview"
+    >
+      <h1 className="text-xl font-semibold text-center text-foreground">{title}</h1>
+
+      {introText ? (
+        <div data-testid="welcome-manual-preview-intro">
+          <Markdown content={introText} />
+        </div>
+      ) : null}
+
+      {sections.length > 0 ? (
+        sections.map((section) => (
+          <section
+            key={section.id}
+            className="space-y-2"
+            data-testid="welcome-manual-preview-section"
+            data-section-id={section.id}
+          >
+            <h2 className="text-base font-semibold text-foreground border-b pb-1">
+              {section.title}
+            </h2>
+
+            {section.body ? <Markdown content={section.body} /> : null}
+
+            {section.images.length > 0 ? (
+              <ul className="grid gap-3 sm:grid-cols-2 list-none">
+                {section.images.map((image) => (
+                  <li key={image.id} className="space-y-1">
+                    {image.is_available !== false && image.presigned_url ? (
+                      <img
+                        src={image.presigned_url}
+                        alt={image.caption ?? `${section.title} photo`}
+                        loading="lazy"
+                        className="w-full rounded-md border object-cover"
+                        data-testid="welcome-manual-preview-image"
+                      />
+                    ) : (
+                      <div
+                        className="w-full aspect-video rounded-md border bg-muted flex items-center justify-center text-xs text-muted-foreground"
+                        data-testid="welcome-manual-preview-image-missing"
+                      >
+                        Image unavailable
+                      </div>
+                    )}
+                    {image.caption ? (
+                      <p className="text-xs text-muted-foreground text-center">
+                        {image.caption}
+                      </p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </section>
+        ))
+      ) : (
+        <p
+          className="text-sm text-muted-foreground text-center"
+          data-testid="welcome-manual-preview-empty"
+        >
+          Add sections to see them here.
+        </p>
+      )}
+    </article>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
@@ -16,7 +16,11 @@ import AlertBox from "@/shared/components/ui/AlertBox";
 import Markdown from "@/shared/components/ui/Markdown";
 import { Button, LoadingButton } from "@platform/ui";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
-import { NEW_SECTION_DEFAULT_TITLE } from "@/shared/lib/welcome-manual-constants";
+import {
+  NEW_SECTION_DEFAULT_TITLE,
+  WELCOME_MANUAL_VIEW_MODE,
+  type WelcomeManualViewMode,
+} from "@/shared/lib/welcome-manual-constants";
 import {
   useCreateSectionMutation,
   useDeleteWelcomeManualMutation,
@@ -41,7 +45,9 @@ export default function WelcomeManualDetail() {
   const [pendingFocusId, setPendingFocusId] = useState<string | null>(null);
   // Mobile-only view toggle. Desktop (lg+) shows editor + preview side by side,
   // so this state is ignored there.
-  const [mobileView, setMobileView] = useState<"edit" | "preview">("edit");
+  const [mobileView, setMobileView] = useState<WelcomeManualViewMode>(
+    WELCOME_MANUAL_VIEW_MODE.EDIT,
+  );
 
   const sectionRefs = useRef<Map<string, HTMLElement>>(new Map());
 
@@ -165,10 +171,10 @@ export default function WelcomeManualDetail() {
             <button
               type="button"
               role="tab"
-              aria-selected={mobileView === "edit"}
-              onClick={() => setMobileView("edit")}
+              aria-selected={mobileView === WELCOME_MANUAL_VIEW_MODE.EDIT}
+              onClick={() => setMobileView(WELCOME_MANUAL_VIEW_MODE.EDIT)}
               className={`flex-1 min-h-[44px] rounded-md text-sm font-medium transition-colors ${
-                mobileView === "edit"
+                mobileView === WELCOME_MANUAL_VIEW_MODE.EDIT
                   ? "bg-primary text-primary-foreground"
                   : "text-muted-foreground hover:text-foreground"
               }`}
@@ -179,10 +185,10 @@ export default function WelcomeManualDetail() {
             <button
               type="button"
               role="tab"
-              aria-selected={mobileView === "preview"}
-              onClick={() => setMobileView("preview")}
+              aria-selected={mobileView === WELCOME_MANUAL_VIEW_MODE.PREVIEW}
+              onClick={() => setMobileView(WELCOME_MANUAL_VIEW_MODE.PREVIEW)}
               className={`flex-1 min-h-[44px] rounded-md text-sm font-medium transition-colors ${
-                mobileView === "preview"
+                mobileView === WELCOME_MANUAL_VIEW_MODE.PREVIEW
                   ? "bg-primary text-primary-foreground"
                   : "text-muted-foreground hover:text-foreground"
               }`}
@@ -194,7 +200,9 @@ export default function WelcomeManualDetail() {
 
           <div className="grid gap-6 lg:grid-cols-2 lg:items-start">
             <div
-              className={`space-y-6 lg:block ${mobileView === "edit" ? "block" : "hidden"}`}
+              className={`space-y-6 lg:block ${
+                mobileView === WELCOME_MANUAL_VIEW_MODE.EDIT ? "block" : "hidden"
+              }`}
               data-testid="welcome-manual-editor-column"
             >
               <section
@@ -299,7 +307,9 @@ export default function WelcomeManualDetail() {
             </div>
 
             <div
-              className={`lg:block ${mobileView === "preview" ? "block" : "hidden"}`}
+              className={`lg:block ${
+                mobileView === WELCOME_MANUAL_VIEW_MODE.PREVIEW ? "block" : "hidden"
+              }`}
               data-testid="welcome-manual-preview-column"
             >
               <div className="lg:sticky lg:top-8 space-y-2">

--- a/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
@@ -26,6 +26,7 @@ import { useGetPropertiesQuery } from "@/shared/store/propertiesApi";
 import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
 import WelcomeManualDetailSkeleton from "@/app/features/welcome-manuals/WelcomeManualDetailSkeleton";
 import WelcomeManualSectionCard from "@/app/features/welcome-manuals/WelcomeManualSectionCard";
+import WelcomeManualPreview from "@/app/features/welcome-manuals/WelcomeManualPreview";
 import WelcomeManualForm from "@/app/features/welcome-manuals/WelcomeManualForm";
 import WelcomeManualEmailDialog from "@/app/features/welcome-manuals/WelcomeManualEmailDialog";
 import DeleteWelcomeManualModal from "@/app/features/welcome-manuals/DeleteWelcomeManualModal";
@@ -38,6 +39,9 @@ export default function WelcomeManualDetail() {
   const [showEmailDialog, setShowEmailDialog] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [pendingFocusId, setPendingFocusId] = useState<string | null>(null);
+  // Mobile-only view toggle. Desktop (lg+) shows editor + preview side by side,
+  // so this state is ignored there.
+  const [mobileView, setMobileView] = useState<"edit" | "preview">("edit");
 
   const sectionRefs = useRef<Map<string, HTMLElement>>(new Map());
 
@@ -124,7 +128,7 @@ export default function WelcomeManualDetail() {
   const hasSections = sortedSections.length > 0;
 
   return (
-    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+    <main className="p-4 sm:p-8 space-y-6 max-w-6xl">
       <Link
         to="/welcome-manuals"
         className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground min-h-[44px]"
@@ -152,104 +156,163 @@ export default function WelcomeManualDetail() {
 
       {manual ? (
         <>
-          <section
-            className="border rounded-lg p-4 space-y-3"
-            data-testid="welcome-manual-header-card"
+          <div
+            className="flex rounded-lg border p-1 lg:hidden"
+            role="tablist"
+            aria-label="Editor and guest preview"
+            data-testid="welcome-manual-view-toggle"
           >
-            <SectionHeader
-              title={manual.title}
-              subtitle={
-                property ? (
-                  <Link to="/properties" className="text-sm text-primary hover:underline">
-                    {property.name}
-                  </Link>
-                ) : undefined
-              }
-              actions={
-                <>
-                  <Button
-                    variant="secondary"
-                    size="md"
-                    onClick={() => setShowEditForm(true)}
-                    data-testid="edit-welcome-manual-button"
-                  >
-                    Edit
-                  </Button>
-                  <span title={hasSections ? undefined : "Add at least one section before sending."}>
-                    <Button
-                      variant="secondary"
-                      size="md"
-                      onClick={() => setShowEmailDialog(true)}
-                      disabled={!hasSections}
-                      data-testid="email-welcome-manual-button"
-                    >
-                      <Mail className="h-4 w-4 mr-1" />
-                      Email to guest
-                    </Button>
-                  </span>
-                  <Button
-                    variant="secondary"
-                    size="md"
-                    onClick={() => setShowDeleteModal(true)}
-                    className="text-red-600 border-red-200 hover:bg-red-50"
-                    data-testid="delete-welcome-manual-button"
-                  >
-                    <Trash2 className="h-4 w-4 mr-1" />
-                    Delete
-                  </Button>
-                </>
-              }
-            />
-            {manual.intro_text ? (
-              <div data-testid="welcome-manual-intro">
-                <Markdown content={manual.intro_text} />
+            <button
+              type="button"
+              role="tab"
+              aria-selected={mobileView === "edit"}
+              onClick={() => setMobileView("edit")}
+              className={`flex-1 min-h-[44px] rounded-md text-sm font-medium transition-colors ${
+                mobileView === "edit"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              data-testid="welcome-manual-view-toggle-edit"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={mobileView === "preview"}
+              onClick={() => setMobileView("preview")}
+              className={`flex-1 min-h-[44px] rounded-md text-sm font-medium transition-colors ${
+                mobileView === "preview"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              data-testid="welcome-manual-view-toggle-preview"
+            >
+              Preview
+            </button>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-2 lg:items-start">
+            <div
+              className={`space-y-6 lg:block ${mobileView === "edit" ? "block" : "hidden"}`}
+              data-testid="welcome-manual-editor-column"
+            >
+              <section
+                className="border rounded-lg p-4 space-y-3"
+                data-testid="welcome-manual-header-card"
+              >
+                <SectionHeader
+                  title={manual.title}
+                  subtitle={
+                    property ? (
+                      <Link to="/properties" className="text-sm text-primary hover:underline">
+                        {property.name}
+                      </Link>
+                    ) : undefined
+                  }
+                  actions={
+                    <>
+                      <Button
+                        variant="secondary"
+                        size="md"
+                        onClick={() => setShowEditForm(true)}
+                        data-testid="edit-welcome-manual-button"
+                      >
+                        Edit
+                      </Button>
+                      <span title={hasSections ? undefined : "Add at least one section before sending."}>
+                        <Button
+                          variant="secondary"
+                          size="md"
+                          onClick={() => setShowEmailDialog(true)}
+                          disabled={!hasSections}
+                          data-testid="email-welcome-manual-button"
+                        >
+                          <Mail className="h-4 w-4 mr-1" />
+                          Email to guest
+                        </Button>
+                      </span>
+                      <Button
+                        variant="secondary"
+                        size="md"
+                        onClick={() => setShowDeleteModal(true)}
+                        className="text-red-600 border-red-200 hover:bg-red-50"
+                        data-testid="delete-welcome-manual-button"
+                      >
+                        <Trash2 className="h-4 w-4 mr-1" />
+                        Delete
+                      </Button>
+                    </>
+                  }
+                />
+                {manual.intro_text ? (
+                  <div data-testid="welcome-manual-intro">
+                    <Markdown content={manual.intro_text} />
+                  </div>
+                ) : null}
+              </section>
+
+              {hasSections ? (
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={(event) => void handleDragEnd(event)}
+                >
+                  <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+                    <div className="space-y-4" data-testid="welcome-manual-sections">
+                      {orderedIds.map((id) => {
+                        const section = sectionsById.get(id);
+                        if (!section) return null;
+                        return (
+                          <WelcomeManualSectionCard
+                            key={id}
+                            ref={(node) => registerSectionRef(id, node)}
+                            manualId={manual.id}
+                            section={section}
+                          />
+                        );
+                      })}
+                    </div>
+                  </SortableContext>
+                </DndContext>
+              ) : (
+                <p
+                  className="text-sm text-muted-foreground border rounded-lg p-6 text-center"
+                  data-testid="welcome-manual-sections-empty"
+                >
+                  No sections yet. Add one to start building this guide.
+                </p>
+              )}
+
+              <div className="flex justify-center">
+                <LoadingButton
+                  variant="secondary"
+                  onClick={() => void handleAddSection()}
+                  isLoading={isAddingSection}
+                  loadingText="Adding..."
+                  data-testid="add-welcome-manual-section-button"
+                >
+                  <Plus className="h-4 w-4 mr-1" />
+                  Add section
+                </LoadingButton>
               </div>
-            ) : null}
-          </section>
+            </div>
 
-          {hasSections ? (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={(event) => void handleDragEnd(event)}
+            <div
+              className={`lg:block ${mobileView === "preview" ? "block" : "hidden"}`}
+              data-testid="welcome-manual-preview-column"
             >
-              <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
-                <div className="space-y-4" data-testid="welcome-manual-sections">
-                  {orderedIds.map((id) => {
-                    const section = sectionsById.get(id);
-                    if (!section) return null;
-                    return (
-                      <WelcomeManualSectionCard
-                        key={id}
-                        ref={(node) => registerSectionRef(id, node)}
-                        manualId={manual.id}
-                        section={section}
-                      />
-                    );
-                  })}
-                </div>
-              </SortableContext>
-            </DndContext>
-          ) : (
-            <p
-              className="text-sm text-muted-foreground border rounded-lg p-6 text-center"
-              data-testid="welcome-manual-sections-empty"
-            >
-              No sections yet. Add one to start building this guide.
-            </p>
-          )}
-
-          <div className="flex justify-center">
-            <LoadingButton
-              variant="secondary"
-              onClick={() => void handleAddSection()}
-              isLoading={isAddingSection}
-              loadingText="Adding..."
-              data-testid="add-welcome-manual-section-button"
-            >
-              <Plus className="h-4 w-4 mr-1" />
-              Add section
-            </LoadingButton>
+              <div className="lg:sticky lg:top-8 space-y-2">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Guest preview
+                </p>
+                <WelcomeManualPreview
+                  title={manual.title}
+                  introText={manual.intro_text}
+                  sections={sortedSections}
+                />
+              </div>
+            </div>
           </div>
 
           {showEditForm ? (

--- a/apps/mybookkeeper/frontend/src/shared/lib/welcome-manual-constants.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/welcome-manual-constants.ts
@@ -19,3 +19,15 @@ export const SECTION_IMAGE_STORAGE_DOMAIN = "welcome_manual_section_image";
 
 /** RFC-lite email format check for the email-to-guest dialog's submit gate. */
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Detail-page view modes. On desktop the editor and guest preview show side by
+ * side; on mobile this toggles which one is visible.
+ */
+export const WELCOME_MANUAL_VIEW_MODE = {
+  EDIT: "edit",
+  PREVIEW: "preview",
+} as const;
+
+export type WelcomeManualViewMode =
+  (typeof WELCOME_MANUAL_VIEW_MODE)[keyof typeof WELCOME_MANUAL_VIEW_MODE];


### PR DESCRIPTION
## What

Adds a live **guest preview** to the Welcome Manual detail page so the operator can see the assembled guest/PDF view while editing — no more guessing what the emailed manual looks like.

- **New `WelcomeManualPreview` component** renders the guest view — title, intro markdown, then each section's title, body markdown, and images with captions — mirroring the backend PDF structure (`welcome_manual_pdf_service.py`). Section images render from their presigned URLs, with a placeholder when an image is unavailable.
- **Desktop (`lg+`)**: editor on the left, sticky guest preview on the right.
- **Mobile**: an Edit/Preview segmented toggle switches between the two (44px touch targets). View mode extracted to a `WELCOME_MANUAL_VIEW_MODE` const map.
- Container widened to `max-w-6xl` to fit the split.

## Tests

- **Unit** (`WelcomeManualPreview.test.tsx`): title, intro, section title/body, images + captions, empty-state, and missing-image fallback. Plus detail-page tests for the preview panel presence and the mobile toggle.
- **E2E** (`welcome-manuals-layout-mock.spec.ts`): desktop side-by-side (toggle hidden, 3 preview sections), mobile toggle switching, and no-horizontal-scroll.
- Scoped the title-heading assertions in the crud + layout specs to the header card, since the preview now legitimately repeats the manual title as its own `h1`.

Frontend build ✓, lint ✓ (0 errors), the new/updated unit tests ✓ (11/11), and the layout-mock e2e suite ✓ (run backend-less).

## Notes

- Reuses the existing `Markdown` renderer for intro/body. Markdown `img` tags stay disabled there; the real uploaded section photos render as direct `<img>` from presigned URLs, matching the PDF.
- The full unit suite has 9 pre-existing failures in unrelated domains (`hourly-rate`, `PromoteFromInquiryPanel`, `LeaseTemplateUploadDialog`, `PublicInquiryForm`) that also fail on `main` — this PR touches none of those files or their imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)