### PR TITLE
feat(mga): render lineup pins on the map board + operator pin-edit surface

### DIFF
--- a/apps/mygamingassistant/frontend/src/__tests__/MapLineupPins.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/MapLineupPins.test.tsx
@@ -212,4 +212,48 @@ describe("MapLineupPins", () => {
     await user.click(within(menu).getByRole("menuitem", { name: /two/i }));
     expect(onPinSelect).toHaveBeenCalledWith("b");
   });
+
+  it("draws a dashed guess ring for lineups with no explicit stand anchor", () => {
+    const { container } = render(
+      <MapLineupPins
+        lineups={[
+          makeLineup({
+            id: "guess",
+            title: "unplaced",
+            // effective coords resolve (from a zone centroid) but no explicit anchor
+            effective_stand_x: 0.4,
+            effective_stand_y: 0.4,
+            stand_anchor_x: null,
+            stand_anchor_y: null,
+          }),
+        ]}
+        mode="stand"
+        selectedLineupId={null}
+        onPinSelect={vi.fn()}
+      />,
+    );
+    const dashed = container.querySelector("circle[stroke-dasharray]");
+    expect(dashed).not.toBeNull();
+  });
+
+  it("omits the dashed ring once the stand anchor is explicitly set", () => {
+    const { container } = render(
+      <MapLineupPins
+        lineups={[
+          makeLineup({
+            id: "placed",
+            title: "placed",
+            effective_stand_x: 0.4,
+            effective_stand_y: 0.4,
+            stand_anchor_x: 0.4,
+            stand_anchor_y: 0.4,
+          }),
+        ]}
+        mode="stand"
+        selectedLineupId={null}
+        onPinSelect={vi.fn()}
+      />,
+    );
+    expect(container.querySelector("circle[stroke-dasharray]")).toBeNull();
+  });
 });

--- a/apps/mygamingassistant/frontend/src/__tests__/PinEditPanel.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/PinEditPanel.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * PinEditPanel tests — empty/progress state, selected-lineup editing surface,
+ * Save vs Save & Next wiring, and the in-flight (saving) disabled state.
+ *
+ * The panel is driven entirely by a usePinEditor-shaped `editor` prop, so
+ * these tests build a stub editor and assert on how the panel renders and
+ * routes clicks — no store or router needed.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import PinEditPanel from "@/components/lineup/PinEditPanel";
+import type { PinEditor } from "@/hooks/usePinEditor";
+import type { Lineup } from "@/types/game";
+
+/** Minimal lineup — PinEditPanel/MinimapPinEditor only read these fields. */
+function fakeLineup(): Lineup {
+  return {
+    id: "l1",
+    title: "Sova A-site dart",
+    effective_stand_x: 0.4,
+    effective_stand_y: 0.4,
+    effective_target_x: 0.6,
+    effective_target_y: 0.6,
+    stand_anchor_x: null,
+    stand_anchor_y: null,
+    target_anchor_x: null,
+    target_anchor_y: null,
+  } as unknown as Lineup;
+}
+
+function makeEditor(overrides: Partial<PinEditor> = {}): PinEditor {
+  return {
+    selectedLineupId: null,
+    selectedLineup: null,
+    standAnchorX: "",
+    standAnchorY: "",
+    targetAnchorX: "",
+    targetAnchorY: "",
+    onStandChange: vi.fn(),
+    onTargetChange: vi.fn(),
+    onResetStand: vi.fn(),
+    onResetTarget: vi.fn(),
+    save: vi.fn(),
+    isSaving: false,
+    setSelected: vi.fn(),
+    hasNext: false,
+    confirmedCount: 0,
+    totalCount: 0,
+    ...overrides,
+  } as PinEditor;
+}
+
+describe("PinEditPanel", () => {
+  it("shows the placeholder and progress count when nothing is selected", () => {
+    render(
+      <PinEditPanel
+        editor={makeEditor({ confirmedCount: 12, totalCount: 40 })}
+        minimapUrl={null}
+      />,
+    );
+    expect(screen.getByText(/click a pin to nudge/i)).toBeDefined();
+    expect(screen.getByText(/12 of 40 placed/i)).toBeDefined();
+  });
+
+  it("renders the editor and both actions when a lineup is selected", () => {
+    render(
+      <PinEditPanel
+        editor={makeEditor({ selectedLineup: fakeLineup() })}
+        minimapUrl="https://example.test/minimap.png"
+      />,
+    );
+    expect(screen.getByText(/sova a-site dart/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /save & next/i })).toBeDefined();
+  });
+
+  it("wires Save to save(false) and Save & Next to save(true)", async () => {
+    const save = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <PinEditPanel
+        editor={makeEditor({ selectedLineup: fakeLineup(), hasNext: true, save })}
+        minimapUrl={null}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+    expect(save).toHaveBeenCalledWith(false);
+    await user.click(screen.getByRole("button", { name: /save & next/i }));
+    expect(save).toHaveBeenCalledWith(true);
+  });
+
+  it("disables Save & Next when there is no next unplaced lineup", () => {
+    render(
+      <PinEditPanel
+        editor={makeEditor({ selectedLineup: fakeLineup(), hasNext: false })}
+        minimapUrl={null}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /save & next/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+  });
+
+  it("shows a saving state and disables actions while a save is in flight", () => {
+    render(
+      <PinEditPanel
+        editor={makeEditor({ selectedLineup: fakeLineup(), hasNext: true, isSaving: true })}
+        minimapUrl={null}
+      />,
+    );
+    // Both buttons collapse to the "Saving…" label and disable.
+    const saving = screen.getAllByRole("button", { name: /saving/i });
+    expect(saving.length).toBeGreaterThanOrEqual(1);
+    saving.forEach((b) => expect(b).toHaveProperty("disabled", true));
+  });
+});

--- a/apps/mygamingassistant/frontend/src/__tests__/usePinEditor.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/usePinEditor.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * usePinEditor tests — selection via ?edit=, confirmed/next accounting, the
+ * PATCH payload shape (only explicitly-set anchors are sent), and the
+ * no-revert-on-failure guarantee.
+ *
+ * The RTK mutation and the toast helpers are mocked (mirrors ReviewCard.test)
+ * so we can assert call arguments without a real store or server.
+ */
+import { renderHook, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { usePinEditor, isLineupConfirmed } from "@/hooks/usePinEditor";
+import type { Lineup } from "@/types/game";
+
+// --- Mocks -----------------------------------------------------------------
+
+const updateTrigger = vi.fn();
+vi.mock("@/store/lineupsApi", () => ({
+  useUpdateLineupMutation: () => [updateTrigger, { isLoading: false }],
+}));
+
+const showSuccess = vi.fn();
+const showError = vi.fn();
+vi.mock("@platform/ui", () => ({
+  showSuccess: (...a: unknown[]) => showSuccess(...a),
+  showError: (...a: unknown[]) => showError(...a),
+  extractErrorMessage: () => "boom",
+}));
+
+// --- Helpers ---------------------------------------------------------------
+
+function lineup(id: string, standAnchorX: number | null): Lineup {
+  return {
+    id,
+    title: `lineup ${id}`,
+    stand_anchor_x: standAnchorX,
+    stand_anchor_y: standAnchorX,
+    target_anchor_x: null,
+    target_anchor_y: null,
+    effective_stand_x: 0.5,
+    effective_stand_y: 0.5,
+    effective_target_x: 0.5,
+    effective_target_y: 0.5,
+  } as unknown as Lineup;
+}
+
+function renderEditor(lineups: Lineup[], search: string) {
+  return renderHook(() => usePinEditor({ lineups, isSuperuser: true }), {
+    wrapper: ({ children }) => (
+      <MemoryRouter initialEntries={[`/valorant/ascent${search}`]}>
+        {children}
+      </MemoryRouter>
+    ),
+  });
+}
+
+beforeEach(() => {
+  updateTrigger.mockReset();
+  showSuccess.mockReset();
+  showError.mockReset();
+  // Default: resolve successfully.
+  updateTrigger.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+});
+
+// --- Tests -----------------------------------------------------------------
+
+describe("isLineupConfirmed", () => {
+  it("is true only when an explicit stand anchor is set", () => {
+    expect(isLineupConfirmed(lineup("a", 0.3))).toBe(true);
+    expect(isLineupConfirmed(lineup("b", null))).toBe(false);
+  });
+});
+
+describe("usePinEditor", () => {
+  it("counts confirmed lineups and total", () => {
+    const { result } = renderEditor([lineup("a", 0.3), lineup("b", null), lineup("c", 0.9)], "");
+    expect(result.current.confirmedCount).toBe(2);
+    expect(result.current.totalCount).toBe(3);
+  });
+
+  it("selects the ?edit lineup and reports a next unconfirmed target", () => {
+    const { result } = renderEditor(
+      [lineup("a", 0.3), lineup("b", null), lineup("c", null)],
+      "?edit=b",
+    );
+    expect(result.current.selectedLineup?.id).toBe("b");
+    // c is still unconfirmed → Save & Next has somewhere to go.
+    expect(result.current.hasNext).toBe(true);
+  });
+
+  it("sends only explicitly-positioned anchors on save", async () => {
+    const { result } = renderEditor([lineup("a", null)], "?edit=a");
+    // Operator drags the stand pin only; target stays on centroid fallback.
+    act(() => result.current.onStandChange(0.25, 0.75));
+    await act(async () => {
+      await result.current.save(false);
+    });
+    expect(updateTrigger).toHaveBeenCalledWith({
+      id: "a",
+      patch: { stand_anchor_x: 0.25, stand_anchor_y: 0.75 },
+    });
+    expect(showSuccess).toHaveBeenCalled();
+  });
+
+  it("does not revert the dragged position when the save fails", async () => {
+    updateTrigger.mockReturnValue({ unwrap: () => Promise.reject(new Error("nope")) });
+    const { result } = renderEditor([lineup("a", null)], "?edit=a");
+    act(() => result.current.onStandChange(0.11, 0.22));
+    await act(async () => {
+      await result.current.save(false);
+    });
+    expect(showError).toHaveBeenCalled();
+    // Field state retained so the operator can retry.
+    expect(result.current.standAnchorX).toBe("0.11");
+    expect(result.current.standAnchorY).toBe("0.22");
+  });
+});

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardMinimapSidebar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardMinimapSidebar.tsx
@@ -20,8 +20,9 @@
  * onZoneClick is provided, scroll otherwise).
  */
 import { useState } from "react";
-import type { MapZone, ZoneDensity } from "@/types/game";
+import type { Lineup, MapZone, ZoneDensity } from "@/types/game";
 import { zoneAnchorId } from "./glanceBoardUtils";
+import MapLineupPins, { type PinMode } from "./MapLineupPins";
 
 interface Props {
   minimapUrl: string | null;
@@ -36,6 +37,13 @@ interface Props {
    *  so the operator can see the current filter. Pass null when no zone
    *  filter is active. */
   activeZoneSlug?: string | null;
+  /** Lineups to overlay as pins on the minimap. Requires pinMode to be set
+   *  and the minimap image to be present (pins only render in the image
+   *  branch, never the text-list fallback). */
+  lineups?: Lineup[];
+  pinMode?: PinMode | null;
+  selectedLineupId?: string | null;
+  onPinSelect?: (lineupId: string) => void;
 }
 
 // Density fill/stroke — same tokens as MapZoneOverlay
@@ -73,6 +81,10 @@ export default function GlanceBoardMinimapSidebar({
   viewBoxSize = 1000,
   onZoneClick,
   activeZoneSlug = null,
+  lineups,
+  pinMode = null,
+  selectedLineupId = null,
+  onPinSelect,
 }: Props) {
   const [minimapFailed, setMinimapFailed] = useState(false);
   const [hoveredZoneSlug, setHoveredZoneSlug] = useState<string | null>(null);
@@ -209,6 +221,19 @@ export default function GlanceBoardMinimapSidebar({
           </div>
         );
       })()}
+
+      {/* Lineup-pin overlay — only in the image branch (this render path is
+          inherently !minimapFailed). Aligns with zones via the shared 1000×
+          viewBox. */}
+      {pinMode && lineups && onPinSelect && (
+        <MapLineupPins
+          lineups={lineups}
+          mode={pinMode}
+          selectedLineupId={selectedLineupId}
+          onPinSelect={onPinSelect}
+          viewBoxSize={viewBoxSize}
+        />
+      )}
     </nav>
   );
 }

--- a/apps/mygamingassistant/frontend/src/components/lineup/MapLineupPins.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/MapLineupPins.tsx
@@ -46,6 +46,9 @@ interface Pin {
   x: number; // viewBox units
   y: number;
   title: string;
+  /** True when this pin sits on the zone centroid (no explicit anchor set) —
+   *  rendered with a dashed ring so the operator can spot unplaced lineups. */
+  isGuess: boolean;
 }
 
 interface Cluster {
@@ -91,6 +94,7 @@ function buildPins(
           x: l.effective_stand_x * viewBoxSize,
           y: l.effective_stand_y * viewBoxSize,
           title: l.title,
+          isGuess: l.stand_anchor_x == null,
         });
       }
     }
@@ -103,6 +107,7 @@ function buildPins(
           x: l.effective_target_x * viewBoxSize,
           y: l.effective_target_y * viewBoxSize,
           title: l.title,
+          isGuess: l.target_anchor_x == null,
         });
       }
     }
@@ -181,6 +186,18 @@ export default function MapLineupPins({
                 }}
               >
                 <circle cx={p.x} cy={p.y} r={22} fill="transparent" />
+                {p.isGuess && (
+                  <circle
+                    cx={p.x}
+                    cy={p.y}
+                    r={16}
+                    fill="none"
+                    stroke={fill}
+                    strokeWidth={2}
+                    strokeDasharray="4 3"
+                    opacity={0.5}
+                  />
+                )}
                 {isSelected && (
                   <circle
                     cx={p.x}

--- a/apps/mygamingassistant/frontend/src/components/lineup/MapSpatialSidebar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/MapSpatialSidebar.tsx
@@ -1,0 +1,84 @@
+/**
+ * MapSpatialSidebar — the left column of the glance board.
+ *
+ * Composes the three spatial surfaces so MapPage stays thin:
+ *   1. PinModeToggle       — Off/Stand/Target/Both (public; drives ?pins=)
+ *   2. GlanceBoardMinimapSidebar — minimap + zone polygons + the lineup-pin
+ *      overlay (MapLineupPins) when a pin mode is active
+ *   3. PinEditPanel        — operator-only nudge surface (?edit=<id>)
+ *
+ * Pin selection routing:
+ *   - Superuser  → select the lineup for editing (opens PinEditPanel)
+ *   - Public     → smooth-scroll the board to that lineup's target-zone
+ *     section, reusing the existing zoneAnchorId scroll anchors.
+ */
+import GlanceBoardMinimapSidebar from "./GlanceBoardMinimapSidebar";
+import PinModeToggle from "./PinModeToggle";
+import PinEditPanel from "./PinEditPanel";
+import { usePinEditor } from "@/hooks/usePinEditor";
+import { zoneAnchorId } from "./glanceBoardUtils";
+import type { PinMode } from "./MapLineupPins";
+import type { Lineup, MapZone, ZoneDensity } from "@/types/game";
+
+interface Props {
+  minimapUrl: string | null;
+  zones: MapZone[];
+  density: ZoneDensity;
+  onZoneClick: (zoneSlug: string) => void;
+  activeZoneSlug: string | null;
+  lineups: Lineup[];
+  pinMode: PinMode | null;
+  onPinModeChange: (next: PinMode | null) => void;
+  isSuperuser: boolean;
+}
+
+export default function MapSpatialSidebar({
+  minimapUrl,
+  zones,
+  density,
+  onZoneClick,
+  activeZoneSlug,
+  lineups,
+  pinMode,
+  onPinModeChange,
+  isSuperuser,
+}: Props) {
+  const editor = usePinEditor({ lineups, isSuperuser });
+
+  function handlePinSelect(lineupId: string) {
+    if (isSuperuser) {
+      editor.setSelected(lineupId);
+      return;
+    }
+    // Public viewer — jump the board to the lineup's target-zone section.
+    const l = lineups.find((x) => x.id === lineupId);
+    const slug = l?.target_zone?.slug;
+    if (slug) {
+      document
+        .getElementById(zoneAnchorId(slug))
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <PinModeToggle mode={pinMode} onChange={onPinModeChange} />
+
+      <GlanceBoardMinimapSidebar
+        minimapUrl={minimapUrl}
+        zones={zones}
+        density={density}
+        onZoneClick={onZoneClick}
+        activeZoneSlug={activeZoneSlug}
+        lineups={lineups}
+        pinMode={pinMode}
+        selectedLineupId={editor.selectedLineupId}
+        onPinSelect={handlePinSelect}
+      />
+
+      {isSuperuser && pinMode && (
+        <PinEditPanel editor={editor} minimapUrl={minimapUrl} />
+      )}
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/lineup/PinEditPanel.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/PinEditPanel.tsx
@@ -1,0 +1,121 @@
+/**
+ * PinEditPanel — operator-only surface for nudging an accepted lineup's pins.
+ *
+ * Mounts below the minimap in the map sidebar. When no lineup is selected it
+ * shows a placeholder + a confirmed/total progress count. When a pin is
+ * selected (via ?edit=<id>) it renders the draggable MinimapPinEditor and
+ * Save / Save & Next actions.
+ *
+ * Reuses MinimapPinEditor (the review-queue dual-pin editor) and the
+ * usePinEditor hook, so pin dragging, keyboard nudging, the dashed "guess"
+ * ring, and the PATCH persistence all match the review flow.
+ */
+import { Check, X } from "lucide-react";
+import MinimapPinEditor from "@/components/review/MinimapPinEditor";
+import type { PinEditor } from "@/hooks/usePinEditor";
+
+interface Props {
+  editor: PinEditor;
+  /** Minimap image URL for the editor inset (same source as the sidebar). */
+  minimapUrl: string | null;
+}
+
+export default function PinEditPanel({ editor, minimapUrl }: Props) {
+  const {
+    selectedLineup,
+    standAnchorX,
+    standAnchorY,
+    targetAnchorX,
+    targetAnchorY,
+    onStandChange,
+    onTargetChange,
+    onResetStand,
+    onResetTarget,
+    save,
+    isSaving,
+    setSelected,
+    hasNext,
+    confirmedCount,
+    totalCount,
+  } = editor;
+
+  // Empty state — no pin selected yet. Doubles as the progress indicator so
+  // the operator can see how much of the map is still on centroid fallback.
+  if (!selectedLineup) {
+    return (
+      <div className="rounded-lg border bg-card p-3 text-xs text-muted-foreground">
+        <p>Click a pin to nudge its position.</p>
+        {totalCount > 0 && (
+          <p className="mt-1 font-medium text-foreground">
+            {confirmedCount} of {totalCount} placed
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border bg-card p-3 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Editing pin
+          </p>
+          <p className="text-sm font-medium truncate" title={selectedLineup.title}>
+            {selectedLineup.title}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setSelected(null)}
+          disabled={isSaving}
+          className="p-1 rounded hover:bg-muted/40 transition-colors disabled:opacity-40 flex-shrink-0"
+          aria-label="Close pin editor"
+        >
+          <X className="w-4 h-4" aria-hidden />
+        </button>
+      </div>
+
+      <MinimapPinEditor
+        lineup={selectedLineup}
+        minimapUrl={minimapUrl}
+        standAnchorX={standAnchorX}
+        standAnchorY={standAnchorY}
+        targetAnchorX={targetAnchorX}
+        targetAnchorY={targetAnchorY}
+        onStandChange={onStandChange}
+        onTargetChange={onTargetChange}
+        onResetStand={onResetStand}
+        onResetTarget={onResetTarget}
+        disabled={isSaving}
+      />
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => save(false)}
+          disabled={isSaving}
+          className="flex-1 inline-flex items-center justify-center gap-1.5 h-8 rounded-md border border-input bg-background px-2 text-xs font-medium hover:enabled:bg-muted/40 disabled:opacity-50 transition-colors"
+        >
+          {isSaving ? (
+            "Saving…"
+          ) : (
+            <>
+              <Check className="w-3.5 h-3.5" aria-hidden />
+              Save
+            </>
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => save(true)}
+          disabled={isSaving || !hasNext}
+          title={hasNext ? "Save and jump to the next unplaced pin" : "No more unplaced pins"}
+          className="flex-1 inline-flex items-center justify-center h-8 rounded-md bg-primary px-2 text-xs font-medium text-primary-foreground hover:enabled:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          {isSaving ? "Saving…" : "Save & Next"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/map/MapPageSkeleton.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/MapPageSkeleton.tsx
@@ -1,0 +1,17 @@
+/**
+ * MapPageSkeleton — loading placeholder for MapPage while the map detail
+ * query is in flight. Mirrors the top bar + a large board block so the
+ * layout doesn't shift when data arrives.
+ */
+export default function MapPageSkeleton() {
+  return (
+    <main className="p-4 sm:p-8 space-y-4">
+      <div className="flex items-center gap-3">
+        <div className="w-9 h-9 rounded-md bg-muted/40 animate-pulse" />
+        <div className="h-7 w-40 bg-muted/40 rounded animate-pulse" />
+      </div>
+      <div className="h-10 bg-muted/40 rounded-lg animate-pulse" />
+      <div className="h-96 bg-muted/40 rounded-xl animate-pulse" />
+    </main>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/hooks/usePinEditor.ts
+++ b/apps/mygamingassistant/frontend/src/hooks/usePinEditor.ts
@@ -1,0 +1,178 @@
+/**
+ * usePinEditor — orchestration for the accepted-lineup pin-edit surface.
+ *
+ * The map board (MapPage) renders every accepted lineup as a pin on the
+ * minimap (see MapLineupPins). This hook lets the operator select one of
+ * those pins and nudge its stand/target anchor, persisting via the same
+ * PATCH endpoint the review queue uses (useUpdateLineupMutation).
+ *
+ * Selection lives in the URL (`?edit=<lineupId>`) so the edit surface is
+ * deep-linkable and survives refresh. Local field-string state mirrors
+ * MinimapPinEditor's contract: empty string = "use the effective/centroid
+ * fallback"; a numeric string = an explicit operator-set anchor.
+ *
+ * Save semantics (constrained by LineupPatch, which cannot send null):
+ *   - Only anchors with a non-empty field string are sent. An untouched
+ *     centroid-fallback pin (field "") is omitted so saving never freezes a
+ *     zone centroid into an explicit anchor.
+ *   - A save failure does NOT revert the dragged position — the operator
+ *     keeps their work and can retry.
+ *
+ * "Confirmed" = the lineup has an explicit stand anchor (stand_anchor_x set),
+ * matching MinimapPinEditor's `isGuess` predicate. Save & Next advances to
+ * the next still-unconfirmed lineup so the operator can burn down the queue.
+ */
+import { useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { showError, showSuccess, extractErrorMessage } from "@platform/ui";
+import { useUpdateLineupMutation } from "@/store/lineupsApi";
+import type { Lineup, LineupPatch } from "@/types/game";
+
+/** number|null → field string ("" when null, so MinimapPinEditor shows the fallback). */
+function toFieldStr(v: number | null | undefined): string {
+  return v == null ? "" : String(v);
+}
+
+/** A lineup is "confirmed" once it has an explicit stand anchor. */
+export function isLineupConfirmed(l: Lineup): boolean {
+  return l.stand_anchor_x != null;
+}
+
+interface Args {
+  lineups: Lineup[];
+  isSuperuser: boolean;
+}
+
+export function usePinEditor({ lineups, isSuperuser }: Args) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Only superusers get an edit selection — a public viewer's ?edit= is inert.
+  const selectedLineupId = isSuperuser ? searchParams.get("edit") : null;
+
+  const selectedLineup = useMemo(
+    () => lineups.find((l) => l.id === selectedLineupId) ?? null,
+    [lineups, selectedLineupId],
+  );
+
+  // Field-string state (empty = fallback). Seeded from the selected lineup's
+  // EXPLICIT anchors so an already-placed pin shows as placed and re-saving
+  // is a no-op, while an unplaced pin (null) seeds "" → centroid fallback.
+  const [standAnchorX, setStandAnchorX] = useState("");
+  const [standAnchorY, setStandAnchorY] = useState("");
+  const [targetAnchorX, setTargetAnchorX] = useState("");
+  const [targetAnchorY, setTargetAnchorY] = useState("");
+
+  // Re-seed the fields when — and only when — the SELECTED ID changes, using
+  // the React "adjust state during render" pattern (not an effect). This
+  // re-seeds on selection change without clobbering an in-progress drag when
+  // the lineups list refetches (RTK cache invalidation after a save) while
+  // the same lineup stays selected.
+  const [seededForId, setSeededForId] = useState<string | null>(null);
+  if (selectedLineupId !== seededForId) {
+    setSeededForId(selectedLineupId);
+    setStandAnchorX(toFieldStr(selectedLineup?.stand_anchor_x));
+    setStandAnchorY(toFieldStr(selectedLineup?.stand_anchor_y));
+    setTargetAnchorX(toFieldStr(selectedLineup?.target_anchor_x));
+    setTargetAnchorY(toFieldStr(selectedLineup?.target_anchor_y));
+  }
+
+  const [updateLineup, { isLoading: isSaving }] = useUpdateLineupMutation();
+
+  function setSelected(id: string | null) {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (id) next.set("edit", id);
+        else next.delete("edit");
+        return next;
+      },
+      { replace: true },
+    );
+  }
+
+  // Drag / keyboard handlers write normalized [0,1] into the field strings.
+  function onStandChange(x: number, y: number) {
+    setStandAnchorX(String(x));
+    setStandAnchorY(String(y));
+  }
+  function onTargetChange(x: number, y: number) {
+    setTargetAnchorX(String(x));
+    setTargetAnchorY(String(y));
+  }
+  function onResetStand() {
+    setStandAnchorX("");
+    setStandAnchorY("");
+  }
+  function onResetTarget() {
+    setTargetAnchorX("");
+    setTargetAnchorY("");
+  }
+
+  // Next still-unconfirmed lineup after the current one (list order), for
+  // Save & Next. Excludes the current lineup (about to become confirmed).
+  const nextUnconfirmed = useMemo(() => {
+    if (!selectedLineupId) return null;
+    const idx = lineups.findIndex((l) => l.id === selectedLineupId);
+    const ordered = idx >= 0
+      ? [...lineups.slice(idx + 1), ...lineups.slice(0, idx)]
+      : lineups;
+    return ordered.find((l) => l.id !== selectedLineupId && !isLineupConfirmed(l)) ?? null;
+  }, [lineups, selectedLineupId]);
+
+  function buildPatch(): LineupPatch {
+    const patch: LineupPatch = {};
+    if (standAnchorX !== "" && standAnchorY !== "") {
+      patch.stand_anchor_x = parseFloat(standAnchorX);
+      patch.stand_anchor_y = parseFloat(standAnchorY);
+    }
+    if (targetAnchorX !== "" && targetAnchorY !== "") {
+      patch.target_anchor_x = parseFloat(targetAnchorX);
+      patch.target_anchor_y = parseFloat(targetAnchorY);
+    }
+    return patch;
+  }
+
+  async function save(advance: boolean) {
+    if (!selectedLineup || isSaving) return;
+    const patch = buildPatch();
+    try {
+      await updateLineup({ id: selectedLineup.id, patch }).unwrap();
+      showSuccess("Pin position saved.");
+      if (advance) {
+        // Selecting the next id re-seeds the fields via the effect above.
+        setSelected(nextUnconfirmed ? nextUnconfirmed.id : null);
+        if (!nextUnconfirmed) showSuccess("All lineups confirmed — nice.");
+      } else {
+        setSelected(null);
+      }
+    } catch (err) {
+      // Do NOT revert — keep the operator's dragged position so they can retry.
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  const confirmedCount = useMemo(
+    () => lineups.reduce((acc, l) => acc + (isLineupConfirmed(l) ? 1 : 0), 0),
+    [lineups],
+  );
+
+  return {
+    selectedLineupId,
+    selectedLineup,
+    standAnchorX,
+    standAnchorY,
+    targetAnchorX,
+    targetAnchorY,
+    onStandChange,
+    onTargetChange,
+    onResetStand,
+    onResetTarget,
+    save,
+    isSaving,
+    setSelected,
+    hasNext: nextUnconfirmed != null,
+    confirmedCount,
+    totalCount: lineups.length,
+  };
+}
+
+export type PinEditor = ReturnType<typeof usePinEditor>;

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -38,8 +38,9 @@ import type { PinMode } from "@/components/lineup/MapLineupPins";
 import KeyboardShortcutsHelp from "@/components/lineup/KeyboardShortcutsHelp";
 import GlanceBoard from "@/components/lineup/GlanceBoard";
 import LineupListBoard from "@/components/lineup/LineupListBoard";
-import GlanceBoardMinimapSidebar from "@/components/lineup/GlanceBoardMinimapSidebar";
+import MapSpatialSidebar from "@/components/lineup/MapSpatialSidebar";
 import MapPageTopBar from "@/components/map/MapPageTopBar";
+import MapPageSkeleton from "@/components/map/MapPageSkeleton";
 import DesignKnobsPanel from "@/components/lineup/DesignKnobsPanel";
 import { useDesignKnobs } from "@/hooks/useDesignKnobs";
 import MinimapUploadDialog from "@/components/game/MinimapUploadDialog";
@@ -301,16 +302,7 @@ export default function MapPage() {
   // Loading / error states
   // ---------------------------------------------------------------------------
   if (mapLoading) {
-    return (
-      <main className="p-4 sm:p-8 space-y-4">
-        <div className="flex items-center gap-3">
-          <div className="w-9 h-9 rounded-md bg-muted/40 animate-pulse" />
-          <div className="h-7 w-40 bg-muted/40 rounded animate-pulse" />
-        </div>
-        <div className="h-10 bg-muted/40 rounded-lg animate-pulse" />
-        <div className="h-96 bg-muted/40 rounded-xl animate-pulse" />
-      </main>
-    );
+    return <MapPageSkeleton />;
   }
 
   if (mapError || !mapDetail) {
@@ -426,12 +418,16 @@ export default function MapPage() {
             className="hidden lg:block w-[440px] shrink-0 p-3 border-r overflow-y-auto sticky top-10 h-[calc(100vh-40px)]"
             aria-label="Map zone navigation"
           >
-            <GlanceBoardMinimapSidebar
+            <MapSpatialSidebar
               minimapUrl={mapDetail.minimap_url}
               zones={mapDetail.zones}
               density={density}
               onZoneClick={handleZoneClick}
               activeZoneSlug={zoneFilter}
+              lineups={allMapLineups}
+              pinMode={pinMode}
+              onPinModeChange={(m) => updateParam("pins", m)}
+              isSuperuser={isSuperuser}
             />
           </aside>
 


### PR DESCRIPTION
## What

Turns the map glance board into a spatial editor for lineup pins — the main lever for placing the ~870 lineups that currently render on zone-centroid fallbacks.

### Display (public)
- Mounts the previously-orphaned `MapLineupPins` overlay inside `GlanceBoardMinimapSidebar`, driven by the existing `?pins=stand|target|both` URL contract (it was parsed by `MapPage` but never rendered — a load-bearing contract with no consumer until now).
- Surfaces `PinModeToggle` (Off / Stand / Target / Both) via a new `MapSpatialSidebar` wrapper.
- Unplaced pins (no explicit anchor) get a dashed **guess ring** so the operator can spot what still needs placing.
- A public viewer clicking a pin scrolls the board to that lineup's target-zone section.

### Edit (operator-only)
- New `usePinEditor` hook owns `?edit=<lineupId>` selection, local field state, the PATCH via `useUpdateLineupMutation`, and **Save** / **Save & Next** (advance to the next still-unplaced lineup).
- New `PinEditPanel` reuses `MinimapPinEditor` (the review-queue dual-pin editor) and doubles as a **"N of M placed"** progress indicator in its empty state.
- Click-time save feedback (button shows *Saving…*, disables); a save failure **keeps the dragged position** so the operator can retry.
- Only anchors the operator actually positioned are sent, so saving never freezes a centroid into an explicit anchor.

## File-size discipline
`MapPage.tsx` stays under the 500-LOC growth guard (525, was 529): all new orchestration lives in `usePinEditor` + `MapSpatialSidebar` + `PinEditPanel`, and the loading skeleton was extracted to `MapPageSkeleton` to offset the wiring.

## Tests
- `MapLineupPins`: dashed guess ring present when unplaced, absent once a stand anchor is set.
- `PinEditPanel`: empty/progress state, selected-lineup editor, Save vs Save & Next wiring, in-flight disabled state.
- `usePinEditor`: `?edit=` selection, confirmed/next accounting, PATCH payload only includes explicitly-set anchors, no-revert-on-save-failure.

`npm run typecheck` ✓ · `npm run build` ✓ · file-size guard ✓ · new/changed files lint-clean · full vitest suite green except one pre-existing unrelated failure (`MicroClipShiftOverlay`, fails identically on `main`).

## Follow-up
The pre-placed KAY/O Ascent anchors seed into the DB when the operator runs `import-lineups`; this PR is the UI they land in. Operator then verifies/nudges locally (fe:5176) before the multi-source backfill rolls across the remaining buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)