### PR TITLE
feat(mybookkeeper): labeled fields per welcome-manual section

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/wmanualfld260720_add_welcome_manual_section_fields.py
+++ b/apps/mybookkeeper/backend/alembic/versions/wmanualfld260720_add_welcome_manual_section_fields.py
@@ -1,0 +1,55 @@
+"""add welcome_manual_section_fields
+
+Revision ID: wmanualfld260720
+Revises: utillink260624
+Create Date: 2026-07-20
+
+Guest welcome manual — section fields (label + value pairs, e.g. the Wi-Fi
+network name and password). One field per row, attached to a section, ordered
+by ``display_order``, cascade-deleted with the section.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "wmanualfld260720"
+down_revision: Union[str, None] = "utillink260624"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "welcome_manual_section_fields",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("section_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("label", sa.String(length=100), nullable=False),
+        sa.Column("value", sa.String(length=500), nullable=True),
+        sa.Column("display_order", sa.SmallInteger(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["section_id"], ["welcome_manual_sections.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_welcome_manual_section_fields_section_id",
+        "welcome_manual_section_fields",
+        ["section_id"],
+    )
+    op.create_index(
+        "ix_welcome_manual_section_fields_section_order",
+        "welcome_manual_section_fields",
+        ["section_id", "display_order"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_welcome_manual_section_fields_section_order",
+        table_name="welcome_manual_section_fields",
+    )
+    op.drop_index(
+        "ix_welcome_manual_section_fields_section_id",
+        table_name="welcome_manual_section_fields",
+    )
+    op.drop_table("welcome_manual_section_fields")

--- a/apps/mybookkeeper/backend/app/api/welcome_manuals.py
+++ b/apps/mybookkeeper/backend/app/api/welcome_manuals.py
@@ -26,6 +26,15 @@ from app.schemas.welcome_manuals.welcome_manual_response import WelcomeManualRes
 from app.schemas.welcome_manuals.welcome_manual_section_create_request import (
     WelcomeManualSectionCreateRequest,
 )
+from app.schemas.welcome_manuals.welcome_manual_section_field_create_request import (
+    WelcomeManualSectionFieldCreateRequest,
+)
+from app.schemas.welcome_manuals.welcome_manual_section_field_response import (
+    WelcomeManualSectionFieldResponse,
+)
+from app.schemas.welcome_manuals.welcome_manual_section_field_update_request import (
+    WelcomeManualSectionFieldUpdateRequest,
+)
 from app.schemas.welcome_manuals.welcome_manual_section_reorder_request import (
     WelcomeManualSectionReorderRequest,
 )
@@ -40,6 +49,7 @@ from app.schemas.welcome_manuals.welcome_manual_update_request import (
 )
 from app.services.welcome_manuals import (
     welcome_manual_email_service,
+    welcome_manual_section_field_service,
     welcome_manual_section_image_service,
     welcome_manual_section_service,
     welcome_manual_service,
@@ -311,4 +321,80 @@ async def delete_section_image(
         raise HTTPException(status_code=404, detail="Section not found") from exc
     except welcome_manual_section_image_service.ImageNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Image not found") from exc
+    return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Section fields
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{manual_id}/sections/{section_id}/fields",
+    response_model=WelcomeManualSectionFieldResponse,
+    status_code=201,
+)
+async def add_section_field(
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    payload: WelcomeManualSectionFieldCreateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> WelcomeManualSectionFieldResponse:
+    try:
+        return await welcome_manual_section_field_service.add_field(
+            ctx.organization_id, ctx.user_id, manual_id, section_id,
+            payload.label, payload.value,
+        )
+    except welcome_manual_section_field_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+    except welcome_manual_section_field_service.SectionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Section not found") from exc
+    except welcome_manual_section_field_service.TooManyFieldsError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.patch(
+    "/{manual_id}/sections/{section_id}/fields/{field_id}",
+    response_model=WelcomeManualSectionFieldResponse,
+)
+async def update_section_field(
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    field_id: uuid.UUID,
+    payload: WelcomeManualSectionFieldUpdateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> WelcomeManualSectionFieldResponse:
+    try:
+        return await welcome_manual_section_field_service.update_field(
+            ctx.organization_id, ctx.user_id, manual_id, section_id, field_id,
+            payload.to_update_dict(),
+        )
+    except welcome_manual_section_field_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+    except welcome_manual_section_field_service.SectionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Section not found") from exc
+    except welcome_manual_section_field_service.FieldNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Field not found") from exc
+
+
+@router.delete(
+    "/{manual_id}/sections/{section_id}/fields/{field_id}",
+    status_code=204,
+)
+async def delete_section_field(
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    field_id: uuid.UUID,
+    ctx: RequestContext = Depends(require_write_access),
+) -> Response:
+    try:
+        await welcome_manual_section_field_service.delete_field(
+            ctx.organization_id, ctx.user_id, manual_id, section_id, field_id,
+        )
+    except welcome_manual_section_field_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+    except welcome_manual_section_field_service.SectionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Section not found") from exc
+    except welcome_manual_section_field_service.FieldNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Field not found") from exc
     return Response(status_code=204)

--- a/apps/mybookkeeper/backend/app/core/welcome_manual_constants.py
+++ b/apps/mybookkeeper/backend/app/core/welcome_manual_constants.py
@@ -21,6 +21,14 @@ WELCOME_MANUAL_STORAGE_DOMAIN = "welcome-manuals"
 # welcome guide (Wi-Fi, trash, laundry, parking, check-out, house rules…).
 WELCOME_MANUAL_MAX_SECTIONS = 50
 
+# Section fields (label + value pairs, e.g. "Network name" / "Password").
+# Bounds mirrored by the Pydantic schemas. ``WELCOME_MANUAL_MAX_FIELDS`` guards
+# a single section against unbounded field rows.
+WELCOME_MANUAL_MAX_FIELDS = 20
+WELCOME_MANUAL_FIELD_LABEL_MAX_LEN = 100
+WELCOME_MANUAL_FIELD_VALUE_MAX_LEN = 500
+NEW_FIELD_DEFAULT_LABEL = "New field"
+
 # Outcome statuses for a welcome-manual email send (welcome_manual_sends.status).
 # Stored as String(20) + CheckConstraint (never SQLAlchemy Enum, per the schema
 # convention). ``sent`` = SMTP accepted; ``failed`` = SMTP rejected/errored;
@@ -41,3 +49,10 @@ DEFAULT_WELCOME_MANUAL_SECTIONS: tuple[str, ...] = (
     "Laundry",
     "Check-out",
 )
+
+# Stub fields seeded into a default section when the manual is created with
+# ``seed_default_sections=True``. Keyed by the section title; each value is an
+# ordered tuple of field labels (values start empty for the host to fill in).
+DEFAULT_WELCOME_MANUAL_SECTION_FIELDS: dict[str, tuple[str, ...]] = {
+    "Wi-Fi": ("Network name", "Password"),
+}

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -20,6 +20,7 @@ from app.models.listings.listing_blackout_attachment import ListingBlackoutAttac
 from app.models.welcome_manuals.welcome_manual import WelcomeManual
 from app.models.welcome_manuals.welcome_manual_section import WelcomeManualSection
 from app.models.welcome_manuals.welcome_manual_section_image import WelcomeManualSectionImage
+from app.models.welcome_manuals.welcome_manual_section_field import WelcomeManualSectionField
 from app.models.welcome_manuals.welcome_manual_send import WelcomeManualSend
 from app.models.calendar.calendar_email_review_queue import CalendarEmailReviewQueue
 from app.models.calendar.calendar_listing_blocklist import CalendarListingBlocklist

--- a/apps/mybookkeeper/backend/app/models/welcome_manuals/welcome_manual_section_field.py
+++ b/apps/mybookkeeper/backend/app/models/welcome_manuals/welcome_manual_section_field.py
@@ -1,0 +1,44 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, Index, SmallInteger, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.welcome_manual_constants import (
+    WELCOME_MANUAL_FIELD_LABEL_MAX_LEN,
+    WELCOME_MANUAL_FIELD_VALUE_MAX_LEN,
+)
+from app.db.base import Base
+
+
+class WelcomeManualSectionField(Base):
+    """A label + value pair attached to a welcome-manual section (e.g. the
+    Wi-Fi network name and its password). Cascade-deleted with its section.
+    Ordered within the section by ``display_order``.
+    """
+
+    __tablename__ = "welcome_manual_section_fields"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    section_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("welcome_manual_sections.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    label: Mapped[str] = mapped_column(String(WELCOME_MANUAL_FIELD_LABEL_MAX_LEN), nullable=False)
+    value: Mapped[str | None] = mapped_column(String(WELCOME_MANUAL_FIELD_VALUE_MAX_LEN), nullable=True)
+    display_order: Mapped[int] = mapped_column(SmallInteger, nullable=False, default=0, server_default="0")
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_welcome_manual_section_fields_section_order", "section_id", "display_order"),
+    )

--- a/apps/mybookkeeper/backend/app/repositories/__init__.py
+++ b/apps/mybookkeeper/backend/app/repositories/__init__.py
@@ -43,6 +43,7 @@ from app.repositories.listings import listing_blackout_attachment_repo
 from app.repositories.welcome_manuals import welcome_manual_repo
 from app.repositories.welcome_manuals import welcome_manual_section_repo
 from app.repositories.welcome_manuals import welcome_manual_section_image_repo
+from app.repositories.welcome_manuals import welcome_manual_section_field_repo
 from app.repositories.welcome_manuals import welcome_manual_send_repo
 from app.repositories.calendar import calendar_repository
 from app.repositories.calendar import review_queue_repo

--- a/apps/mybookkeeper/backend/app/repositories/welcome_manuals/welcome_manual_section_field_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/welcome_manuals/welcome_manual_section_field_repo.py
@@ -1,0 +1,141 @@
+import uuid
+from typing import Any
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.welcome_manuals.welcome_manual_section_field import (
+    WelcomeManualSectionField,
+)
+
+# Columns mutable via PATCH. ``section_id`` is immutable post-create — moving a
+# field between sections is not a supported flow.
+_UPDATABLE_COLUMNS: frozenset[str] = frozenset({
+    "label",
+    "value",
+    "display_order",
+})
+
+
+async def list_by_section(
+    db: AsyncSession,
+    section_id: uuid.UUID,
+) -> list[WelcomeManualSectionField]:
+    """List fields for a section in display order (then by creation time)."""
+    result = await db.execute(
+        select(WelcomeManualSectionField)
+        .where(WelcomeManualSectionField.section_id == section_id)
+        .order_by(
+            WelcomeManualSectionField.display_order.asc(),
+            WelcomeManualSectionField.created_at.asc(),
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def list_by_section_ids(
+    db: AsyncSession,
+    section_ids: list[uuid.UUID],
+) -> list[WelcomeManualSectionField]:
+    """List fields for many sections in one query (ordered).
+
+    Used when building a full manual response so the per-section field load is a
+    single round trip rather than an N+1. Caller groups by section_id.
+    """
+    if not section_ids:
+        return []
+    result = await db.execute(
+        select(WelcomeManualSectionField)
+        .where(WelcomeManualSectionField.section_id.in_(section_ids))
+        .order_by(
+            WelcomeManualSectionField.display_order.asc(),
+            WelcomeManualSectionField.created_at.asc(),
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def get_by_id(
+    db: AsyncSession,
+    field_id: uuid.UUID,
+    section_id: uuid.UUID,
+) -> WelcomeManualSectionField | None:
+    """Return the field iff it exists and belongs to the given section."""
+    result = await db.execute(
+        select(WelcomeManualSectionField).where(
+            WelcomeManualSectionField.id == field_id,
+            WelcomeManualSectionField.section_id == section_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def next_display_order(
+    db: AsyncSession,
+    section_id: uuid.UUID,
+) -> int:
+    """Return the next display_order slot for a section (max + 1, or 0 if empty)."""
+    result = await db.execute(
+        select(func.max(WelcomeManualSectionField.display_order)).where(
+            WelcomeManualSectionField.section_id == section_id,
+        )
+    )
+    current = result.scalar_one_or_none()
+    return 0 if current is None else int(current) + 1
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    section_id: uuid.UUID,
+    label: str,
+    value: str | None,
+    display_order: int,
+) -> WelcomeManualSectionField:
+    field = WelcomeManualSectionField(
+        section_id=section_id,
+        label=label,
+        value=value,
+        display_order=display_order,
+    )
+    db.add(field)
+    await db.flush()
+    return field
+
+
+async def update(
+    db: AsyncSession,
+    field_id: uuid.UUID,
+    section_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> WelcomeManualSectionField | None:
+    """Apply allowlisted updates to a field. None if it doesn't exist /
+    belongs to a different section."""
+    field = await get_by_id(db, field_id, section_id)
+    if field is None:
+        return None
+    safe_fields = {k: v for k, v in fields.items() if k in _UPDATABLE_COLUMNS}
+    if not safe_fields:
+        return field
+    for key, value in safe_fields.items():
+        setattr(field, key, value)
+    await db.flush()
+    return field
+
+
+async def delete_by_id(
+    db: AsyncSession,
+    field_id: uuid.UUID,
+    section_id: uuid.UUID,
+) -> WelcomeManualSectionField | None:
+    """Delete a field and return the deleted row. None if no row matched."""
+    field = await get_by_id(db, field_id, section_id)
+    if field is None:
+        return None
+    await db.execute(
+        delete(WelcomeManualSectionField).where(
+            WelcomeManualSectionField.id == field_id,
+            WelcomeManualSectionField.section_id == section_id,
+        )
+    )
+    return field

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_field_create_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_field_create_request.py
@@ -1,0 +1,16 @@
+"""Pydantic schema for POST .../sections/{section_id}/fields request body."""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.core.welcome_manual_constants import (
+    WELCOME_MANUAL_FIELD_LABEL_MAX_LEN,
+    WELCOME_MANUAL_FIELD_VALUE_MAX_LEN,
+)
+
+
+class WelcomeManualSectionFieldCreateRequest(BaseModel):
+    label: str = Field(min_length=1, max_length=WELCOME_MANUAL_FIELD_LABEL_MAX_LEN)
+    value: str | None = Field(default=None, max_length=WELCOME_MANUAL_FIELD_VALUE_MAX_LEN)
+
+    model_config = ConfigDict(extra="forbid")

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_field_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_field_response.py
@@ -1,0 +1,15 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WelcomeManualSectionFieldResponse(BaseModel):
+    id: uuid.UUID
+    section_id: uuid.UUID
+    label: str
+    value: str | None = None
+    display_order: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_field_update_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_field_update_request.py
@@ -1,0 +1,29 @@
+"""Pydantic schema for PATCH .../sections/{section_id}/fields/{field_id}.
+
+Allows label editing, value editing (including clearing to null), and
+reordering (display_order).
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.core.welcome_manual_constants import (
+    WELCOME_MANUAL_FIELD_LABEL_MAX_LEN,
+    WELCOME_MANUAL_FIELD_VALUE_MAX_LEN,
+)
+
+
+class WelcomeManualSectionFieldUpdateRequest(BaseModel):
+    label: str | None = Field(default=None, min_length=1, max_length=WELCOME_MANUAL_FIELD_LABEL_MAX_LEN)
+    value: str | None = Field(default=None, max_length=WELCOME_MANUAL_FIELD_VALUE_MAX_LEN)
+    display_order: int | None = Field(default=None, ge=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+    def to_update_dict(self) -> dict[str, object]:
+        """Return only explicitly-provided fields. An explicit ``null`` label is
+        a no-op (label is required); an explicit ``null`` value clears it."""
+        data = self.model_dump(exclude_unset=True)
+        if "label" in data and data["label"] is None:
+            data.pop("label")
+        return data

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_response.py
@@ -3,17 +3,21 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
+from app.schemas.welcome_manuals.welcome_manual_section_field_response import (
+    WelcomeManualSectionFieldResponse,
+)
 from app.schemas.welcome_manuals.welcome_manual_section_image_response import (
     WelcomeManualSectionImageResponse,
 )
 
 
 class WelcomeManualSectionResponse(BaseModel):
-    """One section of a welcome manual, with its ordered images.
+    """One section of a welcome manual, with its ordered fields and images.
 
-    ``images`` is populated (with presigned URLs) on the full-manual read
-    paths. Section-mutation responses (add / update / reorder) return an empty
-    list — the frontend refetches the manual after those edits.
+    ``fields`` and ``images`` (the latter with presigned URLs) are populated on
+    the full-manual read paths. Section-mutation responses (add / update /
+    reorder) return empty lists — the frontend refetches the manual after those
+    edits.
     """
 
     id: uuid.UUID
@@ -21,6 +25,7 @@ class WelcomeManualSectionResponse(BaseModel):
     title: str
     body: str | None = None
     display_order: int
+    fields: list[WelcomeManualSectionFieldResponse] = []
     images: list[WelcomeManualSectionImageResponse] = []
     created_at: datetime
     updated_at: datetime

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_email_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_email_service.py
@@ -32,6 +32,7 @@ from app.db.session import unit_of_work
 from app.repositories import (
     user_repo,
     welcome_manual_repo,
+    welcome_manual_section_field_repo,
     welcome_manual_section_image_repo,
     welcome_manual_section_repo,
     welcome_manual_send_repo,
@@ -42,6 +43,7 @@ from app.schemas.welcome_manuals.welcome_manual_send_response import (
 from app.services.system import email_service
 from app.services.system.email_service import EmailAttachment
 from app.services.welcome_manuals.welcome_manual_pdf_service import (
+    SectionFieldPdfData,
     SectionImagePdfData,
     SectionPdfData,
     WelcomeManualPdfData,
@@ -130,7 +132,7 @@ def _fetch_image_bytes(images, *, manual_id: uuid.UUID) -> dict[uuid.UUID, bytes
     return by_image
 
 
-def _build_pdf_data(manual, sections, images, image_bytes) -> WelcomeManualPdfData:
+def _build_pdf_data(manual, sections, images, fields, image_bytes) -> WelcomeManualPdfData:
     """Assemble the pure PDF data carrier from the loaded ORM rows + bytes."""
     images_by_section: dict[uuid.UUID, list[SectionImagePdfData]] = {}
     for image in images:
@@ -140,10 +142,16 @@ def _build_pdf_data(manual, sections, images, image_bytes) -> WelcomeManualPdfDa
         images_by_section.setdefault(image.section_id, []).append(
             SectionImagePdfData(image_bytes=content, caption=image.caption),
         )
+    fields_by_section: dict[uuid.UUID, list[SectionFieldPdfData]] = {}
+    for field in fields:
+        fields_by_section.setdefault(field.section_id, []).append(
+            SectionFieldPdfData(label=field.label, value=field.value),
+        )
     section_data = [
         SectionPdfData(
             title=section.title,
             body=section.body,
+            fields=fields_by_section.get(section.id, []),
             images=images_by_section.get(section.id, []),
         )
         for section in sections
@@ -174,9 +182,9 @@ async def send_manual_to_guest(
         if manual is None:
             raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
         sections = await welcome_manual_section_repo.list_by_manual(db, manual.id)
-        images = await welcome_manual_section_image_repo.list_by_section_ids(
-            db, [s.id for s in sections],
-        )
+        section_ids = [s.id for s in sections]
+        images = await welcome_manual_section_image_repo.list_by_section_ids(db, section_ids)
+        fields = await welcome_manual_section_field_repo.list_by_section_ids(db, section_ids)
         host = await user_repo.get_by_id(db, manual.user_id)
         host_email = host.email if host is not None else None
         manual_title = manual.title
@@ -196,7 +204,7 @@ async def send_manual_to_guest(
 
     image_bytes = _fetch_image_bytes(images, manual_id=manual_id)
     pdf_bytes = generate_welcome_manual_pdf(
-        _build_pdf_data(manual, sections, images, image_bytes),
+        _build_pdf_data(manual, sections, images, fields, image_bytes),
     )
 
     attachment = EmailAttachment(

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_pdf_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_pdf_service.py
@@ -60,9 +60,16 @@ class SectionImagePdfData:
 
 
 @dataclass(frozen=True)
+class SectionFieldPdfData:
+    label: str
+    value: str | None = None
+
+
+@dataclass(frozen=True)
 class SectionPdfData:
     title: str
     body: str | None = None
+    fields: list[SectionFieldPdfData] = field(default_factory=list)
     images: list[SectionImagePdfData] = field(default_factory=list)
 
 
@@ -147,6 +154,12 @@ def generate_welcome_manual_pdf(data: WelcomeManualPdfData) -> bytes:
         story.append(Spacer(1, 4))
         if section.body and section.body.strip():
             story.extend(markdown_to_flowables(section.body, body_style))
+        # Fields (label: value) render as plain escaped text — not Markdown —
+        # after the body and before the images.
+        for section_field in section.fields:
+            label = html_mod.escape(section_field.label)
+            value = html_mod.escape(section_field.value or "")
+            story.append(Paragraph(f"{label}: {value}", body_style))
         for image in section.images:
             story.extend(_build_image_flowable(image, content_width, caption_style))
         story.append(Spacer(1, 10))

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_section_field_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_section_field_service.py
@@ -1,0 +1,118 @@
+"""Welcome-manual section field service — orchestration for the ordered
+label + value pairs of a section. Scope is enforced by re-fetching the parent
+manual (org-scoped) and the section (manual-scoped) before touching any field.
+"""
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.welcome_manual_constants import WELCOME_MANUAL_MAX_FIELDS
+from app.db.session import unit_of_work
+from app.models.welcome_manuals.welcome_manual_section import WelcomeManualSection
+from app.repositories import (
+    welcome_manual_repo,
+    welcome_manual_section_field_repo,
+    welcome_manual_section_repo,
+)
+from app.schemas.welcome_manuals.welcome_manual_section_field_response import (
+    WelcomeManualSectionFieldResponse,
+)
+from app.services.welcome_manuals.welcome_manual_section_service import (
+    ManualNotFoundError,  # noqa: F401 — re-exported for the route
+    SectionNotFoundError,  # noqa: F401 — re-exported for the route
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FieldNotFoundError(LookupError):
+    """The field doesn't exist or belongs to a different section."""
+
+
+class TooManyFieldsError(Exception):
+    """The section already has the maximum number of fields (-> HTTP 409)."""
+
+
+async def _load_section(
+    db: AsyncSession,
+    organization_id: uuid.UUID,
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+) -> WelcomeManualSection:
+    """Resolve the section, enforcing org → manual → section scoping. Raises
+    ManualNotFoundError / SectionNotFoundError."""
+    manual = await welcome_manual_repo.get_by_id(db, manual_id, organization_id)
+    if manual is None:
+        raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
+    section = await welcome_manual_section_repo.get_by_id(db, section_id, manual.id)
+    if section is None:
+        raise SectionNotFoundError(f"Section {section_id} not found")
+    return section
+
+
+async def add_field(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    label: str,
+    value: str | None,
+) -> WelcomeManualSectionFieldResponse:
+    """Append a field to a section.
+
+    Raises:
+        ManualNotFoundError / SectionNotFoundError: scope failures.
+        TooManyFieldsError: the section is already at the field cap.
+    """
+    async with unit_of_work() as db:
+        section = await _load_section(db, organization_id, manual_id, section_id)
+
+        existing = await welcome_manual_section_field_repo.list_by_section(db, section.id)
+        if len(existing) >= WELCOME_MANUAL_MAX_FIELDS:
+            raise TooManyFieldsError(
+                f"A section can have at most {WELCOME_MANUAL_MAX_FIELDS} fields",
+            )
+
+        next_order = await welcome_manual_section_field_repo.next_display_order(db, section.id)
+        field = await welcome_manual_section_field_repo.create(
+            db,
+            section_id=section.id,
+            label=label,
+            value=value,
+            display_order=next_order,
+        )
+        return WelcomeManualSectionFieldResponse.model_validate(field)
+
+
+async def update_field(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    field_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> WelcomeManualSectionFieldResponse:
+    """Update a field's label, value and/or display_order."""
+    async with unit_of_work() as db:
+        section = await _load_section(db, organization_id, manual_id, section_id)
+        field = await welcome_manual_section_field_repo.update(db, field_id, section.id, fields)
+        if field is None:
+            raise FieldNotFoundError(f"Field {field_id} not found")
+        return WelcomeManualSectionFieldResponse.model_validate(field)
+
+
+async def delete_field(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    field_id: uuid.UUID,
+) -> None:
+    """Delete a field from a section."""
+    async with unit_of_work() as db:
+        section = await _load_section(db, organization_id, manual_id, section_id)
+        deleted = await welcome_manual_section_field_repo.delete_by_id(db, field_id, section.id)
+        if deleted is None:
+            raise FieldNotFoundError(f"Field {field_id} not found")

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_service.py
@@ -6,11 +6,15 @@ lives in ``welcome_manual_section_service``.
 """
 import uuid
 
-from app.core.welcome_manual_constants import DEFAULT_WELCOME_MANUAL_SECTIONS
+from app.core.welcome_manual_constants import (
+    DEFAULT_WELCOME_MANUAL_SECTION_FIELDS,
+    DEFAULT_WELCOME_MANUAL_SECTIONS,
+)
 from app.db.session import AsyncSessionLocal, unit_of_work
 from app.repositories import (
     property_repo,
     welcome_manual_repo,
+    welcome_manual_section_field_repo,
     welcome_manual_section_image_repo,
     welcome_manual_section_repo,
 )
@@ -21,6 +25,9 @@ from app.schemas.welcome_manuals.welcome_manual_list_response import (
     WelcomeManualListResponse,
 )
 from app.schemas.welcome_manuals.welcome_manual_response import WelcomeManualResponse
+from app.schemas.welcome_manuals.welcome_manual_section_field_response import (
+    WelcomeManualSectionFieldResponse,
+)
 from app.schemas.welcome_manuals.welcome_manual_section_image_response import (
     WelcomeManualSectionImageResponse,
 )
@@ -36,23 +43,33 @@ from app.services.welcome_manuals.section_image_response_builder import (
 )
 
 
-def _build_section_responses(sections, images) -> list[WelcomeManualSectionResponse]:
-    """Build ordered section responses with each section's images attached.
+def _build_section_responses(sections, images, fields) -> list[WelcomeManualSectionResponse]:
+    """Build ordered section responses with each section's fields + images attached.
 
-    ``images`` is a flat list of ORM image rows spanning ALL the sections;
-    presigned URLs are minted once over the flat list (one HEAD per image),
-    then grouped by section. No SQLAlchemy ``images`` relationship exists on the
-    section model — ``model_validate`` falls back to the field default, and we
-    overwrite it here — which keeps this safe under async (no lazy load).
+    ``images`` and ``fields`` are flat lists of ORM rows spanning ALL the
+    sections; presigned URLs are minted once over the flat image list (one HEAD
+    per image), then both are grouped by section. No SQLAlchemy relationships
+    exist on the section model — ``model_validate`` falls back to the field
+    defaults, and we overwrite them here — which keeps this safe under async
+    (no lazy load).
     """
     image_responses = [WelcomeManualSectionImageResponse.model_validate(img) for img in images]
     signed = attach_presigned_urls(image_responses)
-    by_section: dict[uuid.UUID, list[WelcomeManualSectionImageResponse]] = {}
+    images_by_section: dict[uuid.UUID, list[WelcomeManualSectionImageResponse]] = {}
     for image in signed:
-        by_section.setdefault(image.section_id, []).append(image)
+        images_by_section.setdefault(image.section_id, []).append(image)
+
+    field_responses = [WelcomeManualSectionFieldResponse.model_validate(f) for f in fields]
+    fields_by_section: dict[uuid.UUID, list[WelcomeManualSectionFieldResponse]] = {}
+    for field in field_responses:
+        fields_by_section.setdefault(field.section_id, []).append(field)
+
     return [
         WelcomeManualSectionResponse.model_validate(s).model_copy(
-            update={"images": by_section.get(s.id, [])},
+            update={
+                "fields": fields_by_section.get(s.id, []),
+                "images": images_by_section.get(s.id, []),
+            },
         )
         for s in sections
     ]
@@ -83,10 +100,10 @@ async def get_manual(
         if manual is None:
             raise LookupError(f"Welcome manual {manual_id} not found")
         sections = await welcome_manual_section_repo.list_by_manual(db, manual.id)
-        images = await welcome_manual_section_image_repo.list_by_section_ids(
-            db, [s.id for s in sections],
-        )
-    return _to_response(manual, _build_section_responses(sections, images))
+        section_ids = [s.id for s in sections]
+        images = await welcome_manual_section_image_repo.list_by_section_ids(db, section_ids)
+        fields = await welcome_manual_section_field_repo.list_by_section_ids(db, section_ids)
+    return _to_response(manual, _build_section_responses(sections, images, fields))
 
 
 async def list_manuals(
@@ -148,6 +165,7 @@ async def create_manual(
         )
 
         sections = []
+        fields = []
         if payload.seed_default_sections:
             for index, title in enumerate(DEFAULT_WELCOME_MANUAL_SECTIONS):
                 section = await welcome_manual_section_repo.create(
@@ -158,9 +176,20 @@ async def create_manual(
                     display_order=index,
                 )
                 sections.append(section)
+                for field_index, label in enumerate(
+                    DEFAULT_WELCOME_MANUAL_SECTION_FIELDS.get(title, ()),
+                ):
+                    field = await welcome_manual_section_field_repo.create(
+                        db,
+                        section_id=section.id,
+                        label=label,
+                        value=None,
+                        display_order=field_index,
+                    )
+                    fields.append(field)
 
         # Freshly-seeded sections never have images yet.
-        return _to_response(manual, _build_section_responses(sections, []))
+        return _to_response(manual, _build_section_responses(sections, [], fields))
 
 
 async def update_manual(
@@ -191,10 +220,10 @@ async def update_manual(
             raise LookupError(f"Welcome manual {manual_id} not found")
 
         sections = await welcome_manual_section_repo.list_by_manual(db, manual.id)
-        images = await welcome_manual_section_image_repo.list_by_section_ids(
-            db, [s.id for s in sections],
-        )
-        return _to_response(manual, _build_section_responses(sections, images))
+        section_ids = [s.id for s in sections]
+        images = await welcome_manual_section_image_repo.list_by_section_ids(db, section_ids)
+        fields = await welcome_manual_section_field_repo.list_by_section_ids(db, section_ids)
+        return _to_response(manual, _build_section_responses(sections, images, fields))
 
 
 async def soft_delete_manual(

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_field_routes.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_field_routes.py
@@ -1,0 +1,186 @@
+"""API route tests for welcome-manual section fields. Mocks the service layer."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.welcome_manuals.welcome_manual_section_field_response import (
+    WelcomeManualSectionFieldResponse,
+)
+from app.services.welcome_manuals import welcome_manual_section_field_service
+
+
+def _ctx(org_id: uuid.UUID, user_id: uuid.UUID) -> RequestContext:
+    return RequestContext(organization_id=org_id, user_id=user_id, org_role=OrgRole.OWNER)
+
+
+def _override_auth(org_id: uuid.UUID, user_id: uuid.UUID) -> None:
+    app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+    app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+
+def _field_response(section_id: uuid.UUID, *, order: int = 0, label: str = "Network name", value: str | None = None) -> WelcomeManualSectionFieldResponse:
+    return WelcomeManualSectionFieldResponse(
+        id=uuid.uuid4(),
+        section_id=section_id,
+        label=label,
+        value=value,
+        display_order=order,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def patch_field_service(name: str, **kwargs):
+    return patch.object(welcome_manual_section_field_service, name, **kwargs)
+
+
+class TestAdd:
+    @pytest.mark.asyncio
+    async def test_add_201(self) -> None:
+        org_id, user_id, manual_id, section_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_field_service("add_field", return_value=_field_response(section_id, value="v")):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/fields",
+                    json={"label": "Network name", "value": "v"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 201
+        body = response.json()
+        assert body["label"] == "Network name"
+        assert body["value"] == "v"
+
+    @pytest.mark.asyncio
+    async def test_add_manual_404(self) -> None:
+        org_id, user_id, manual_id, section_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_field_service(
+                "add_field",
+                side_effect=welcome_manual_section_field_service.ManualNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/fields",
+                    json={"label": "L"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_add_section_404(self) -> None:
+        org_id, user_id, manual_id, section_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_field_service(
+                "add_field",
+                side_effect=welcome_manual_section_field_service.SectionNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/fields",
+                    json={"label": "L"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_add_too_many_409(self) -> None:
+        org_id, user_id, manual_id, section_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_field_service(
+                "add_field",
+                side_effect=welcome_manual_section_field_service.TooManyFieldsError("too many"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/fields",
+                    json={"label": "L"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 409
+
+
+class TestUpdateDelete:
+    @pytest.mark.asyncio
+    async def test_update_200(self) -> None:
+        org_id, user_id, manual_id, section_id, field_id = (uuid.uuid4() for _ in range(5))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_field_service(
+                "update_field",
+                return_value=_field_response(section_id, label="renamed"),
+            ):
+                client = TestClient(app)
+                response = client.patch(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/fields/{field_id}",
+                    json={"label": "renamed"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 200
+        assert response.json()["label"] == "renamed"
+
+    @pytest.mark.asyncio
+    async def test_update_field_404(self) -> None:
+        org_id, user_id, manual_id, section_id, field_id = (uuid.uuid4() for _ in range(5))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_field_service(
+                "update_field",
+                side_effect=welcome_manual_section_field_service.FieldNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.patch(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/fields/{field_id}",
+                    json={"value": "x"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_204(self) -> None:
+        org_id, user_id, manual_id, section_id, field_id = (uuid.uuid4() for _ in range(5))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_field_service("delete_field", return_value=None):
+                client = TestClient(app)
+                response = client.delete(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/fields/{field_id}",
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_delete_field_404(self) -> None:
+        org_id, user_id, manual_id, section_id, field_id = (uuid.uuid4() for _ in range(5))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_field_service(
+                "delete_field",
+                side_effect=welcome_manual_section_field_service.FieldNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.delete(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/fields/{field_id}",
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_pdf_service.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_pdf_service.py
@@ -12,6 +12,7 @@ import io
 from PIL import Image
 
 from app.services.welcome_manuals.welcome_manual_pdf_service import (
+    SectionFieldPdfData,
     SectionImagePdfData,
     SectionPdfData,
     WelcomeManualPdfData,
@@ -146,6 +147,54 @@ class TestImages:
                             SectionImagePdfData(image_bytes=b"\x00\x01garbage", caption="bad"),
                             SectionImagePdfData(image_bytes=_png_bytes(), caption="good"),
                         ],
+                    ),
+                ],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")
+
+
+class TestFields:
+    def test_section_with_fields_renders(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                sections=[
+                    SectionPdfData(
+                        title="Wi-Fi",
+                        body="Connect to the guest network.",
+                        fields=[
+                            SectionFieldPdfData(label="Network name", value="GuestNet"),
+                            SectionFieldPdfData(label="Password", value="sunny123"),
+                        ],
+                    ),
+                ],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")
+
+    def test_field_with_null_value_renders(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                sections=[
+                    SectionPdfData(
+                        title="Wi-Fi",
+                        fields=[SectionFieldPdfData(label="Password", value=None)],
+                    ),
+                ],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")
+
+    def test_field_special_chars_do_not_break_render(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                sections=[
+                    SectionPdfData(
+                        title="Wi-Fi",
+                        fields=[SectionFieldPdfData(label="A & B <c>", value="x > y & z < w")],
                     ),
                 ],
             ),

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_section_field_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_section_field_repo.py
@@ -1,0 +1,121 @@
+"""Repository tests for welcome_manual_section_fields."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.welcome_manuals import (
+    welcome_manual_repo,
+    welcome_manual_section_field_repo,
+    welcome_manual_section_repo,
+)
+
+
+async def _make_section(db: AsyncSession, org: Organization, user: User):
+    manual = await welcome_manual_repo.create_manual(
+        db, organization_id=org.id, user_id=user.id,
+        property_id=None, title="G", intro_text=None,
+    )
+    await db.flush()
+    section = await welcome_manual_section_repo.create(
+        db, manual_id=manual.id, title="Wi-Fi", body=None, display_order=0,
+    )
+    await db.flush()
+    return section
+
+
+class TestOrderingAndCreate:
+    @pytest.mark.asyncio
+    async def test_create_and_list_in_order(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        await welcome_manual_section_field_repo.create(db, section_id=section.id, label="B", value=None, display_order=1)
+        await welcome_manual_section_field_repo.create(db, section_id=section.id, label="A", value="v", display_order=0)
+        await db.commit()
+        fields = await welcome_manual_section_field_repo.list_by_section(db, section.id)
+        assert [f.label for f in fields] == ["A", "B"]
+        assert fields[0].value == "v"
+
+    @pytest.mark.asyncio
+    async def test_next_display_order(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        assert await welcome_manual_section_field_repo.next_display_order(db, section.id) == 0
+        await welcome_manual_section_field_repo.create(db, section_id=section.id, label="A", value=None, display_order=0)
+        await db.flush()
+        assert await welcome_manual_section_field_repo.next_display_order(db, section.id) == 1
+
+
+class TestListBySectionIds:
+    @pytest.mark.asyncio
+    async def test_groups_across_sections(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        s1 = await _make_section(db, test_org, test_user)
+        s2 = await _make_section(db, test_org, test_user)
+        await welcome_manual_section_field_repo.create(db, section_id=s1.id, label="a", value=None, display_order=0)
+        await welcome_manual_section_field_repo.create(db, section_id=s1.id, label="b", value=None, display_order=1)
+        await welcome_manual_section_field_repo.create(db, section_id=s2.id, label="c", value=None, display_order=0)
+        await db.commit()
+        fields = await welcome_manual_section_field_repo.list_by_section_ids(db, [s1.id, s2.id])
+        by_section: dict = {}
+        for f in fields:
+            by_section.setdefault(f.section_id, []).append(f)
+        assert len(by_section[s1.id]) == 2
+        assert len(by_section[s2.id]) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_input(self, db: AsyncSession) -> None:
+        assert await welcome_manual_section_field_repo.list_by_section_ids(db, []) == []
+
+
+class TestUpdateDelete:
+    @pytest.mark.asyncio
+    async def test_update_allowlist(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        field = await welcome_manual_section_field_repo.create(
+            db, section_id=section.id, label="Network name", value=None, display_order=0,
+        )
+        await db.commit()
+        updated = await welcome_manual_section_field_repo.update(
+            db, field.id, section.id,
+            {"label": "SSID", "value": "GuestNet", "display_order": 3, "section_id": uuid.uuid4()},
+        )
+        assert updated is not None
+        assert updated.label == "SSID"
+        assert updated.value == "GuestNet"
+        assert updated.display_order == 3
+        assert updated.section_id == section.id  # immutable
+
+    @pytest.mark.asyncio
+    async def test_update_value_to_null(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        field = await welcome_manual_section_field_repo.create(
+            db, section_id=section.id, label="Password", value="hunter2", display_order=0,
+        )
+        await db.commit()
+        updated = await welcome_manual_section_field_repo.update(
+            db, field.id, section.id, {"value": None},
+        )
+        assert updated is not None
+        assert updated.value is None
+
+    @pytest.mark.asyncio
+    async def test_get_wrong_section_returns_none(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        field = await welcome_manual_section_field_repo.create(
+            db, section_id=section.id, label="A", value=None, display_order=0,
+        )
+        await db.commit()
+        assert await welcome_manual_section_field_repo.get_by_id(db, field.id, uuid.uuid4()) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_row_then_none(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        field = await welcome_manual_section_field_repo.create(
+            db, section_id=section.id, label="A", value=None, display_order=0,
+        )
+        await db.commit()
+        deleted = await welcome_manual_section_field_repo.delete_by_id(db, field.id, section.id)
+        assert deleted is not None and deleted.label == "A"
+        assert await welcome_manual_section_field_repo.delete_by_id(db, field.id, section.id) is None

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_section_field_service.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_section_field_service.py
@@ -1,0 +1,149 @@
+"""Service-layer tests for welcome_manual_section_field_service.
+
+Patches ``unit_of_work`` on the service module to point at the in-memory SQLite
+session (same pattern as test_welcome_manual_section_image_service).
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.welcome_manual_constants import WELCOME_MANUAL_MAX_FIELDS
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.welcome_manuals import (
+    welcome_manual_repo,
+    welcome_manual_section_field_repo,
+    welcome_manual_section_repo,
+)
+from app.services.welcome_manuals import welcome_manual_section_field_service
+
+
+def _patch_uow(db: AsyncSession):
+    @asynccontextmanager
+    async def _fake():
+        yield db
+
+    return patch(
+        "app.services.welcome_manuals.welcome_manual_section_field_service.unit_of_work",
+        _fake,
+    )
+
+
+async def _make_section(db: AsyncSession, org: Organization, user: User):
+    manual = await welcome_manual_repo.create_manual(
+        db, organization_id=org.id, user_id=user.id,
+        property_id=None, title="G", intro_text=None,
+    )
+    await db.flush()
+    section = await welcome_manual_section_repo.create(
+        db, manual_id=manual.id, title="Wi-Fi", body=None, display_order=0,
+    )
+    await db.flush()
+    return manual, section
+
+
+class TestAdd:
+    @pytest.mark.asyncio
+    async def test_appends_field(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        await db.commit()
+        with _patch_uow(db):
+            first = await welcome_manual_section_field_service.add_field(
+                test_org.id, test_user.id, manual.id, section.id, "Network name", None,
+            )
+            second = await welcome_manual_section_field_service.add_field(
+                test_org.id, test_user.id, manual.id, section.id, "Password", "hunter2",
+            )
+        assert first.display_order == 0
+        assert second.display_order == 1
+        assert second.value == "hunter2"
+
+    @pytest.mark.asyncio
+    async def test_manual_not_found(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        with _patch_uow(db):
+            with pytest.raises(welcome_manual_section_field_service.ManualNotFoundError):
+                await welcome_manual_section_field_service.add_field(
+                    test_org.id, test_user.id, uuid.uuid4(), uuid.uuid4(), "L", None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_section_not_found(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, _section = await _make_section(db, test_org, test_user)
+        await db.commit()
+        with _patch_uow(db):
+            with pytest.raises(welcome_manual_section_field_service.SectionNotFoundError):
+                await welcome_manual_section_field_service.add_field(
+                    test_org.id, test_user.id, manual.id, uuid.uuid4(), "L", None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_cross_org_manual_not_found(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        await db.commit()
+        with _patch_uow(db):
+            with pytest.raises(welcome_manual_section_field_service.ManualNotFoundError):
+                await welcome_manual_section_field_service.add_field(
+                    uuid.uuid4(), test_user.id, manual.id, section.id, "L", None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_too_many_fields(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        for i in range(WELCOME_MANUAL_MAX_FIELDS):
+            await welcome_manual_section_field_repo.create(
+                db, section_id=section.id, label=f"f{i}", value=None, display_order=i,
+            )
+        await db.commit()
+        with _patch_uow(db):
+            with pytest.raises(welcome_manual_section_field_service.TooManyFieldsError):
+                await welcome_manual_section_field_service.add_field(
+                    test_org.id, test_user.id, manual.id, section.id, "one too many", None,
+                )
+
+
+class TestUpdateDelete:
+    @pytest.mark.asyncio
+    async def test_update_field(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        field = await welcome_manual_section_field_repo.create(
+            db, section_id=section.id, label="Password", value=None, display_order=0,
+        )
+        await db.commit()
+        with _patch_uow(db):
+            updated = await welcome_manual_section_field_service.update_field(
+                test_org.id, test_user.id, manual.id, section.id, field.id,
+                {"value": "sunny123"},
+            )
+        assert updated.value == "sunny123"
+
+    @pytest.mark.asyncio
+    async def test_update_field_not_found(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        await db.commit()
+        with _patch_uow(db):
+            with pytest.raises(welcome_manual_section_field_service.FieldNotFoundError):
+                await welcome_manual_section_field_service.update_field(
+                    test_org.id, test_user.id, manual.id, section.id, uuid.uuid4(),
+                    {"value": "x"},
+                )
+
+    @pytest.mark.asyncio
+    async def test_delete_field(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        field = await welcome_manual_section_field_repo.create(
+            db, section_id=section.id, label="A", value=None, display_order=0,
+        )
+        await db.commit()
+        with _patch_uow(db):
+            await welcome_manual_section_field_service.delete_field(
+                test_org.id, test_user.id, manual.id, section.id, field.id,
+            )
+            with pytest.raises(welcome_manual_section_field_service.FieldNotFoundError):
+                await welcome_manual_section_field_service.delete_field(
+                    test_org.id, test_user.id, manual.id, section.id, field.id,
+                )

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_service.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_service.py
@@ -12,7 +12,10 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.welcome_manual_constants import DEFAULT_WELCOME_MANUAL_SECTIONS
+from app.core.welcome_manual_constants import (
+    DEFAULT_WELCOME_MANUAL_SECTION_FIELDS,
+    DEFAULT_WELCOME_MANUAL_SECTIONS,
+)
 from app.models.organization.organization import Organization
 from app.models.properties.property import Property
 from app.models.user.user import User
@@ -57,6 +60,32 @@ class TestCreate:
         assert resp.title == "Guide"
         assert [s.title for s in resp.sections] == list(DEFAULT_WELCOME_MANUAL_SECTIONS)
         assert [s.display_order for s in resp.sections] == list(range(len(DEFAULT_WELCOME_MANUAL_SECTIONS)))
+
+    @pytest.mark.asyncio
+    async def test_seeds_wifi_section_fields(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        with _patch(db):
+            resp = await welcome_manual_service.create_manual(
+                test_org.id, test_user.id, WelcomeManualCreateRequest(title="Guide"),
+            )
+        wifi = next(s for s in resp.sections if s.title == "Wi-Fi")
+        expected = list(DEFAULT_WELCOME_MANUAL_SECTION_FIELDS["Wi-Fi"])
+        assert [f.label for f in wifi.fields] == expected
+        assert [f.value for f in wifi.fields] == [None] * len(expected)
+        assert [f.display_order for f in wifi.fields] == list(range(len(expected)))
+        # Sections without a default-field mapping seed no fields.
+        parking = next(s for s in resp.sections if s.title == "Parking")
+        assert parking.fields == []
+
+    @pytest.mark.asyncio
+    async def test_get_manual_includes_seeded_fields(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        with _patch(db):
+            created = await welcome_manual_service.create_manual(
+                test_org.id, test_user.id, WelcomeManualCreateRequest(title="Guide"),
+            )
+            await db.commit()
+            fetched = await welcome_manual_service.get_manual(test_org.id, test_user.id, created.id)
+        wifi = next(s for s in fetched.sections if s.title == "Wi-Fi")
+        assert [f.label for f in wifi.fields] == list(DEFAULT_WELCOME_MANUAL_SECTION_FIELDS["Wi-Fi"])
 
     @pytest.mark.asyncio
     async def test_no_seed_when_disabled(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:

--- a/apps/mybookkeeper/frontend/e2e/welcome-manuals-crud.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/welcome-manuals-crud.spec.ts
@@ -22,7 +22,13 @@ const FIXTURE_PHOTO = path.join(__dirname, "fixtures", "listings", "test-photo-w
 interface ManualDetail {
   id: string;
   title: string;
-  sections: Array<{ id: string; title: string; display_order: number; images: unknown[] }>;
+  sections: Array<{
+    id: string;
+    title: string;
+    display_order: number;
+    fields: Array<{ id: string; label: string; value: string | null; display_order: number }>;
+    images: unknown[];
+  }>;
 }
 
 async function fetchManual(api: APIRequestContext, id: string): Promise<ManualDetail> {
@@ -101,6 +107,28 @@ test.describe("Welcome Manuals CRUD (PR 4b)", () => {
         const updated = await fetchManual(api, manualId!);
         const edited = updated.sections.find((s) => s.title === `Wi-Fi Details ${runId}`);
         expect(edited).toBeTruthy();
+      }).toPass({ timeout: 10000 });
+
+      // 3b) ADD a field to the first section — fill label + value, blur, and
+      // assert the persisted row via the API (mirrors the image assertion:
+      // verify backend state, not just visibility).
+      const fieldCard = page.getByTestId("welcome-manual-section-card").first();
+      await fieldCard.getByTestId("welcome-manual-field-add-button").click();
+      const fieldRow = fieldCard.getByTestId("welcome-manual-field-card").first();
+      await expect(fieldRow).toBeVisible({ timeout: 10000 });
+      const fieldLabel = `Wi-Fi network ${runId}`;
+      const fieldValue = `Lakeview-${runId}`;
+      await fieldRow.getByTestId("welcome-manual-field-label").fill(fieldLabel);
+      await fieldRow.getByTestId("welcome-manual-field-value").fill(fieldValue);
+      // Blur the value input to trigger the save.
+      await fieldRow.getByTestId("welcome-manual-field-value").blur();
+
+      await expect(async () => {
+        const withField = await fetchManual(api, manualId!);
+        const match = withField.sections
+          .flatMap((s) => s.fields)
+          .find((f) => f.label === fieldLabel && f.value === fieldValue);
+        expect(match).toBeTruthy();
       }).toPass({ timeout: 10000 });
 
       // 4) ADD a section — it appears as a new card.

--- a/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout-mock.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout-mock.spec.ts
@@ -125,6 +125,7 @@ async function stubDetail(page: Page, delayMs = 0): Promise<void> {
           title: `Section ${i + 1}`,
           body: "Some instructions",
           display_order: i,
+          fields: [],
           images: [],
           created_at: "2026-01-01T00:00:00Z",
           updated_at: "2026-01-01T00:00:00Z",

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualDetail.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualDetail.test.tsx
@@ -41,6 +41,9 @@ vi.mock("@/shared/store/welcomeManualsApi", () => ({
   useUploadSectionImagesMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useUpdateSectionImageMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useDeleteSectionImageMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useCreateSectionFieldMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useUpdateSectionFieldMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useDeleteSectionFieldMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
 }));
 
 vi.mock("@/shared/store/propertiesApi", () => ({
@@ -54,6 +57,7 @@ function makeSection(id: string): WelcomeManualSectionResponse {
     title: "Wi-Fi",
     body: "instructions",
     display_order: 0,
+    fields: [],
     images: [],
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualPreview.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualPreview.test.tsx
@@ -9,7 +9,22 @@ import { describe, it, expect } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import WelcomeManualPreview from "@/app/features/welcome-manuals/WelcomeManualPreview";
 import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+import type { WelcomeManualSectionFieldResponse } from "@/shared/types/welcome-manual/welcome-manual-section-field-response";
 import type { WelcomeManualSectionImageResponse } from "@/shared/types/welcome-manual/welcome-manual-section-image-response";
+
+function makeField(
+  overrides: Partial<WelcomeManualSectionFieldResponse> = {},
+): WelcomeManualSectionFieldResponse {
+  return {
+    id: "fld-1",
+    section_id: "sec-1",
+    label: "Wi-Fi network",
+    value: "Lakeview",
+    display_order: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
 
 function makeImage(
   overrides: Partial<WelcomeManualSectionImageResponse> = {},
@@ -36,6 +51,7 @@ function makeSection(
     title: "Parking",
     body: "Park in **spot 4**.",
     display_order: 0,
+    fields: [],
     images: [],
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
@@ -77,6 +93,49 @@ describe("WelcomeManualPreview", () => {
     const section = screen.getByTestId("welcome-manual-preview-section");
     expect(within(section).getByRole("heading", { name: "Parking" })).toBeInTheDocument();
     expect(within(section).getByText("spot 4")).toBeInTheDocument();
+  });
+
+  it("renders section fields as label/value pairs", () => {
+    render(
+      <WelcomeManualPreview
+        title="Guide"
+        introText={null}
+        sections={[
+          makeSection({
+            fields: [
+              makeField({ id: "fld-1", label: "Wi-Fi network", value: "Lakeview" }),
+              makeField({ id: "fld-2", label: "Check-out", value: "11am" }),
+            ],
+          }),
+        ]}
+      />,
+    );
+    const rows = screen.getAllByTestId("welcome-manual-preview-field");
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText("Wi-Fi network")).toBeInTheDocument();
+    expect(screen.getByText("Lakeview")).toBeInTheDocument();
+    expect(screen.getByText("Check-out")).toBeInTheDocument();
+    expect(screen.getByText("11am")).toBeInTheDocument();
+  });
+
+  it("skips a field row where both label and value are empty", () => {
+    render(
+      <WelcomeManualPreview
+        title="Guide"
+        introText={null}
+        sections={[
+          makeSection({
+            fields: [
+              makeField({ id: "fld-1", label: "Wi-Fi network", value: "Lakeview" }),
+              makeField({ id: "fld-2", label: "", value: null }),
+            ],
+          }),
+        ]}
+      />,
+    );
+    // Only the populated row renders; the all-empty row is dropped.
+    expect(screen.getAllByTestId("welcome-manual-preview-field")).toHaveLength(1);
+    expect(screen.getByText("Wi-Fi network")).toBeInTheDocument();
   });
 
   it("renders section images with their captions", () => {

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualSectionCard.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualSectionCard.test.tsx
@@ -23,13 +23,16 @@ vi.mock("@/shared/lib/toast-store", () => ({
   showSuccess: vi.fn(),
 }));
 
-// Image manager hits these but we only assert section editing here.
+// Image + field managers hit these but we only assert section editing here.
 vi.mock("@/shared/store/welcomeManualsApi", () => ({
   useUpdateSectionMutation: vi.fn(() => [updateSectionMock, { isLoading: false }]),
   useDeleteSectionMutation: vi.fn(() => [deleteSectionMock, { isLoading: false }]),
   useUploadSectionImagesMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useUpdateSectionImageMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useDeleteSectionImageMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useCreateSectionFieldMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useUpdateSectionFieldMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useDeleteSectionFieldMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
 }));
 
 function makeSection(overrides: Partial<WelcomeManualSectionResponse>): WelcomeManualSectionResponse {
@@ -39,6 +42,7 @@ function makeSection(overrides: Partial<WelcomeManualSectionResponse>): WelcomeM
     title: "Wi-Fi",
     body: "Network: Lakeview, password hunter2",
     display_order: 0,
+    fields: [],
     images: [],
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
@@ -92,5 +96,13 @@ describe("WelcomeManualSectionCard", () => {
     expect(body.placeholder).toBe("Add instructions for guests…");
     // No preview rendered when the body is empty.
     expect(screen.queryByTestId("welcome-manual-section-body-preview")).not.toBeInTheDocument();
+  });
+
+  it("renders the field manager with an Add-field button", () => {
+    renderCard(makeSection({}));
+    expect(screen.getByTestId("welcome-manual-field-manager")).toBeInTheDocument();
+    expect(screen.getByTestId("welcome-manual-field-add-button")).toBeInTheDocument();
+    // No fields seeded → empty state shows.
+    expect(screen.getByTestId("welcome-manual-field-empty-state")).toBeInTheDocument();
   });
 });

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualSectionFieldManager.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualSectionFieldManager.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the welcome-manual section field manager.
+ *
+ * Verifies:
+ *   - The empty state renders when a section has no fields.
+ *   - Clicking "Add field" creates a field seeded with the default label.
+ *   - An existing field row renders its label + value.
+ *   - Editing a value and blurring saves a dirty-only PATCH (changed field only).
+ *   - The "Add field" button is disabled once the section hits the field cap.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WelcomeManualSectionFieldManager from "@/app/features/welcome-manuals/WelcomeManualSectionFieldManager";
+import {
+  MAX_FIELDS_PER_SECTION,
+  NEW_FIELD_DEFAULT_LABEL,
+} from "@/shared/lib/welcome-manual-constants";
+import type { WelcomeManualSectionFieldResponse } from "@/shared/types/welcome-manual/welcome-manual-section-field-response";
+
+const createFieldMock = vi.fn();
+const updateFieldMock = vi.fn();
+const deleteFieldMock = vi.fn();
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+vi.mock("@/shared/store/welcomeManualsApi", () => ({
+  useCreateSectionFieldMutation: vi.fn(() => [createFieldMock, { isLoading: false }]),
+  useUpdateSectionFieldMutation: vi.fn(() => [updateFieldMock, { isLoading: false }]),
+  useDeleteSectionFieldMutation: vi.fn(() => [deleteFieldMock, { isLoading: false }]),
+}));
+
+function makeField(
+  overrides: Partial<WelcomeManualSectionFieldResponse> = {},
+): WelcomeManualSectionFieldResponse {
+  return {
+    id: "fld-1",
+    section_id: "sec-1",
+    label: "Wi-Fi network",
+    value: "Lakeview",
+    display_order: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderManager(fields: WelcomeManualSectionFieldResponse[]) {
+  return render(
+    <WelcomeManualSectionFieldManager manualId="m-1" sectionId="sec-1" fields={fields} />,
+  );
+}
+
+describe("WelcomeManualSectionFieldManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the empty state when there are no fields", () => {
+    renderManager([]);
+    expect(screen.getByTestId("welcome-manual-field-empty-state")).toBeInTheDocument();
+    expect(screen.queryByTestId("welcome-manual-field-list")).not.toBeInTheDocument();
+  });
+
+  it("creates a field seeded with the default label when Add field is clicked", async () => {
+    createFieldMock.mockReturnValue({ unwrap: () => Promise.resolve(makeField()) });
+    renderManager([]);
+
+    await userEvent.click(screen.getByTestId("welcome-manual-field-add-button"));
+
+    await waitFor(() => {
+      expect(createFieldMock).toHaveBeenCalledWith({
+        manualId: "m-1",
+        sectionId: "sec-1",
+        data: { label: NEW_FIELD_DEFAULT_LABEL, value: null },
+      });
+    });
+  });
+
+  it("renders an existing field row with its label and value", () => {
+    renderManager([makeField()]);
+    const label = screen.getByTestId("welcome-manual-field-label") as HTMLInputElement;
+    const value = screen.getByTestId("welcome-manual-field-value") as HTMLInputElement;
+    expect(label.value).toBe("Wi-Fi network");
+    expect(value.value).toBe("Lakeview");
+  });
+
+  it("saves a dirty-only PATCH when a value is edited and blurred", async () => {
+    updateFieldMock.mockReturnValue({ unwrap: () => Promise.resolve(makeField()) });
+    renderManager([makeField()]);
+
+    const value = screen.getByTestId("welcome-manual-field-value");
+    await userEvent.clear(value);
+    await userEvent.type(value, "Harbor");
+    await userEvent.tab();
+
+    await waitFor(() => {
+      expect(updateFieldMock).toHaveBeenCalledWith({
+        manualId: "m-1",
+        sectionId: "sec-1",
+        fieldId: "fld-1",
+        value: "Harbor",
+      });
+    });
+  });
+
+  it("does not save on blur when the value is unchanged", async () => {
+    renderManager([makeField()]);
+    const value = screen.getByTestId("welcome-manual-field-value");
+    await userEvent.click(value);
+    await userEvent.tab();
+    expect(updateFieldMock).not.toHaveBeenCalled();
+  });
+
+  it("disables the Add field button once the section hits the field cap", () => {
+    const fields = Array.from({ length: MAX_FIELDS_PER_SECTION }, (_, i) =>
+      makeField({ id: `fld-${i}`, display_order: i }),
+    );
+    renderManager(fields);
+    expect(screen.getByTestId("welcome-manual-field-add-button")).toBeDisabled();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPreview.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPreview.tsx
@@ -50,6 +50,21 @@ export default function WelcomeManualPreview({
 
             {section.body ? <Markdown content={section.body} /> : null}
 
+            {section.fields.length > 0 ? (
+              <dl className="grid gap-2 sm:grid-cols-2" data-testid="welcome-manual-preview-fields">
+                {section.fields
+                  .filter((field) => field.label.trim() !== "" || (field.value ?? "").trim() !== "")
+                  .map((field) => (
+                    <div key={field.id} data-testid="welcome-manual-preview-field">
+                      <dt className="text-xs font-semibold text-muted-foreground">
+                        {field.label}
+                      </dt>
+                      <dd className="text-sm text-foreground">{field.value}</dd>
+                    </div>
+                  ))}
+              </dl>
+            ) : null}
+
             {section.images.length > 0 ? (
               <ul className="grid gap-3 sm:grid-cols-2 list-none">
                 {section.images.map((image) => (

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionCard.tsx
@@ -8,6 +8,7 @@ import Markdown from "@/shared/components/ui/Markdown";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import { useDeleteSectionMutation } from "@/shared/store/welcomeManualsApi";
 import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+import WelcomeManualSectionFieldManager from "./WelcomeManualSectionFieldManager";
 import WelcomeManualSectionImageManager from "./WelcomeManualSectionImageManager";
 import { useSectionEditor } from "./useSectionEditor";
 
@@ -136,6 +137,15 @@ const WelcomeManualSectionCard = forwardRef<HTMLElement, WelcomeManualSectionCar
           >
             Save
           </LoadingButton>
+        </div>
+
+        <div className="border-t pt-3">
+          <p className="text-xs font-medium text-muted-foreground mb-2">Details</p>
+          <WelcomeManualSectionFieldManager
+            manualId={manualId}
+            sectionId={section.id}
+            fields={section.fields}
+          />
         </div>
 
         <div className="border-t pt-3">

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionFieldCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionFieldCard.tsx
@@ -1,0 +1,94 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, X } from "lucide-react";
+import type { WelcomeManualSectionFieldResponse } from "@/shared/types/welcome-manual/welcome-manual-section-field-response";
+
+export interface WelcomeManualSectionFieldCardProps {
+  field: WelcomeManualSectionFieldResponse;
+  onDelete: () => void;
+  onLabelSave: (label: string) => void;
+  onValueSave: (value: string) => void;
+}
+
+export default function WelcomeManualSectionFieldCard({
+  field,
+  onDelete,
+  onLabelSave,
+  onValueSave,
+}: WelcomeManualSectionFieldCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: field.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  function handleLabelBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const trimmed = e.target.value.trim();
+    if (trimmed === field.label) return;
+    onLabelSave(trimmed);
+  }
+
+  function handleValueBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const trimmed = e.target.value.trim();
+    if (trimmed === (field.value ?? "")) return;
+    onValueSave(trimmed);
+  }
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 border rounded-lg p-2 bg-card"
+      data-testid="welcome-manual-field-card"
+      data-field-id={field.id}
+    >
+      <button
+        {...attributes}
+        {...listeners}
+        type="button"
+        className="text-muted-foreground hover:text-foreground cursor-grab active:cursor-grabbing min-h-[44px] min-w-[44px] flex items-center justify-center"
+        aria-label={`Drag to reorder field ${field.label}`}
+        data-testid="welcome-manual-field-drag-handle"
+      >
+        <GripVertical size={16} />
+      </button>
+
+      {/* Uncontrolled: ``key`` re-mounts the input when the server value changes
+          (after a successful save or a revert) so the displayed value
+          re-baselines without a setState-in-effect. Edits live in the DOM and
+          are read on blur. */}
+      <input
+        key={`label-${field.label}`}
+        defaultValue={field.label}
+        onBlur={handleLabelBlur}
+        placeholder="Field name"
+        className="flex-1 min-w-0 border rounded-md px-2 py-2 text-sm min-h-[44px] bg-transparent focus:outline-none focus:bg-muted/40"
+        aria-label="Field name"
+        data-testid="welcome-manual-field-label"
+      />
+      <input
+        key={`value-${field.value ?? ""}`}
+        defaultValue={field.value ?? ""}
+        onBlur={handleValueBlur}
+        placeholder="Value"
+        className="flex-1 min-w-0 border rounded-md px-2 py-2 text-sm min-h-[44px] bg-transparent focus:outline-none focus:bg-muted/40"
+        aria-label="Field value"
+        data-testid="welcome-manual-field-value"
+      />
+
+      <button
+        type="button"
+        onClick={onDelete}
+        className="text-red-600 hover:bg-red-50 rounded p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
+        aria-label="Remove field"
+        data-testid="welcome-manual-field-delete-button"
+      >
+        <X size={16} />
+      </button>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionFieldManager.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionFieldManager.tsx
@@ -1,0 +1,190 @@
+import { useState } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { Plus } from "lucide-react";
+import { LoadingButton, ConfirmDialog } from "@platform/ui";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import {
+  MAX_FIELDS_PER_SECTION,
+  NEW_FIELD_DEFAULT_LABEL,
+} from "@/shared/lib/welcome-manual-constants";
+import {
+  useCreateSectionFieldMutation,
+  useDeleteSectionFieldMutation,
+  useUpdateSectionFieldMutation,
+} from "@/shared/store/welcomeManualsApi";
+import type { WelcomeManualSectionFieldResponse } from "@/shared/types/welcome-manual/welcome-manual-section-field-response";
+import WelcomeManualSectionFieldCard from "./WelcomeManualSectionFieldCard";
+
+export interface WelcomeManualSectionFieldManagerProps {
+  manualId: string;
+  sectionId: string;
+  fields: readonly WelcomeManualSectionFieldResponse[];
+}
+
+export default function WelcomeManualSectionFieldManager({
+  manualId,
+  sectionId,
+  fields,
+}: WelcomeManualSectionFieldManagerProps) {
+  const [createField, { isLoading: isAdding }] = useCreateSectionFieldMutation();
+  const [deleteField] = useDeleteSectionFieldMutation();
+  const [updateField] = useUpdateSectionFieldMutation();
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [orderedIds, setOrderedIds] = useState<string[] | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const sortedFields = [...fields].sort((a, b) => a.display_order - b.display_order);
+  const displayIds = orderedIds ?? sortedFields.map((f) => f.id);
+  const fieldsById = new Map(sortedFields.map((f) => [f.id, f]));
+  const atCap = sortedFields.length >= MAX_FIELDS_PER_SECTION;
+
+  async function handleAdd() {
+    if (atCap) return;
+    try {
+      await createField({
+        manualId,
+        sectionId,
+        data: { label: NEW_FIELD_DEFAULT_LABEL, value: null },
+      }).unwrap();
+    } catch {
+      showError("I couldn't add that field. Want to try again?");
+    }
+  }
+
+  async function handleConfirmDelete() {
+    const fieldId = confirmDeleteId;
+    if (!fieldId) return;
+    setConfirmDeleteId(null);
+    try {
+      await deleteField({ manualId, sectionId, fieldId }).unwrap();
+      showSuccess("Field removed.");
+    } catch {
+      showError("I couldn't remove that field. Want to try again?");
+    }
+  }
+
+  async function handleFieldSave(
+    fieldId: string,
+    changes: { label?: string; value?: string | null },
+  ) {
+    try {
+      await updateField({ manualId, sectionId, fieldId, ...changes }).unwrap();
+    } catch {
+      showError("I couldn't save that field. Want to try again?");
+    }
+  }
+
+  async function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = displayIds.indexOf(String(active.id));
+    const newIndex = displayIds.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const newOrder = arrayMove(displayIds, oldIndex, newIndex);
+    setOrderedIds(newOrder);
+
+    // There's no bulk-order endpoint for section fields — fire one PATCH per
+    // field whose display_order changed. Small-N per section keeps this cheap,
+    // mirroring the image manager.
+    try {
+      await Promise.all(
+        newOrder.map((fieldId, index) => {
+          const current = fieldsById.get(fieldId);
+          if (!current) return Promise.resolve();
+          if (current.display_order === index) return Promise.resolve();
+          return updateField({ manualId, sectionId, fieldId, display_order: index }).unwrap();
+        }),
+      );
+    } catch {
+      showError("I couldn't save the new order. Reverting.");
+      setOrderedIds(null);
+    }
+  }
+
+  return (
+    <div className="space-y-3" data-testid="welcome-manual-field-manager">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          {atCap
+            ? `You've reached the ${MAX_FIELDS_PER_SECTION}-field limit for this section.`
+            : "Label / value pairs, like Wi-Fi network → password."}
+        </p>
+        <LoadingButton
+          variant="secondary"
+          size="sm"
+          isLoading={isAdding}
+          loadingText="Adding…"
+          onClick={handleAdd}
+          disabled={atCap}
+          type="button"
+          data-testid="welcome-manual-field-add-button"
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          Add field
+        </LoadingButton>
+      </div>
+
+      {sortedFields.length === 0 ? (
+        <p
+          className="text-sm text-muted-foreground border rounded-lg p-6 text-center"
+          data-testid="welcome-manual-field-empty-state"
+        >
+          No details yet. Add a few key facts guests will want at a glance.
+        </p>
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={displayIds} strategy={verticalListSortingStrategy}>
+            <ul className="space-y-2 list-none" data-testid="welcome-manual-field-list">
+              {displayIds.map((fieldId) => {
+                const field = fieldsById.get(fieldId);
+                if (!field) return null;
+                return (
+                  <WelcomeManualSectionFieldCard
+                    key={fieldId}
+                    field={field}
+                    onDelete={() => setConfirmDeleteId(fieldId)}
+                    onLabelSave={(label) => void handleFieldSave(fieldId, { label })}
+                    onValueSave={(value) => void handleFieldSave(fieldId, { value: value || null })}
+                  />
+                );
+              })}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <ConfirmDialog
+        open={!!confirmDeleteId}
+        title="Remove this field?"
+        description="The field will be deleted from this section. This can't be undone."
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        variant="danger"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/welcome-manual-constants.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/welcome-manual-constants.ts
@@ -4,6 +4,12 @@ export const WELCOME_MANUAL_PAGE_SIZE = 25;
 /** Default title applied to a freshly-added section before the host renames it. */
 export const NEW_SECTION_DEFAULT_TITLE = "New section";
 
+/** Max label/value fields allowed per section. */
+export const MAX_FIELDS_PER_SECTION = 20;
+
+/** Default label applied to a freshly-added field before the host renames it. */
+export const NEW_FIELD_DEFAULT_LABEL = "New field";
+
 /** Max upload size per section image, in bytes (10MB). Mirrors listing photos. */
 export const SECTION_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
 

--- a/apps/mybookkeeper/frontend/src/shared/store/welcomeManualsApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/welcomeManualsApi.ts
@@ -5,6 +5,7 @@ import type { WelcomeManualListArgs } from "@/shared/types/welcome-manual/welcom
 import type { WelcomeManualListResponse } from "@/shared/types/welcome-manual/welcome-manual-list-response";
 import type { WelcomeManualResponse } from "@/shared/types/welcome-manual/welcome-manual-response";
 import type { WelcomeManualSectionCreateRequest } from "@/shared/types/welcome-manual/welcome-manual-section-create-request";
+import type { WelcomeManualSectionFieldResponse } from "@/shared/types/welcome-manual/welcome-manual-section-field-response";
 import type { WelcomeManualSectionImageResponse } from "@/shared/types/welcome-manual/welcome-manual-section-image-response";
 import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
 import type { WelcomeManualSectionUpdateRequest } from "@/shared/types/welcome-manual/welcome-manual-section-update-request";
@@ -175,6 +176,56 @@ const welcomeManualsApi = baseApi.injectEndpoints({
         { type: "WelcomeManual", id: arg.manualId },
       ],
     }),
+    // ---- Section fields ----
+    createSectionField: builder.mutation<
+      WelcomeManualSectionFieldResponse,
+      { manualId: string; sectionId: string; data: { label: string; value?: string | null } }
+    >({
+      query: ({ manualId, sectionId, data }) => ({
+        url: `/welcome-manuals/${manualId}/sections/${sectionId}/fields`,
+        method: "POST",
+        data,
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+    updateSectionField: builder.mutation<
+      WelcomeManualSectionFieldResponse,
+      {
+        manualId: string;
+        sectionId: string;
+        fieldId: string;
+        label?: string | null;
+        value?: string | null;
+        display_order?: number;
+      }
+    >({
+      query: ({ manualId, sectionId, fieldId, label, value, display_order }) => ({
+        url: `/welcome-manuals/${manualId}/sections/${sectionId}/fields/${fieldId}`,
+        method: "PATCH",
+        data: {
+          ...(label !== undefined ? { label } : {}),
+          ...(value !== undefined ? { value } : {}),
+          ...(display_order !== undefined ? { display_order } : {}),
+        },
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+    deleteSectionField: builder.mutation<
+      void,
+      { manualId: string; sectionId: string; fieldId: string }
+    >({
+      query: ({ manualId, sectionId, fieldId }) => ({
+        url: `/welcome-manuals/${manualId}/sections/${sectionId}/fields/${fieldId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
   }),
 });
 
@@ -192,4 +243,7 @@ export const {
   useUploadSectionImagesMutation,
   useUpdateSectionImageMutation,
   useDeleteSectionImageMutation,
+  useCreateSectionFieldMutation,
+  useUpdateSectionFieldMutation,
+  useDeleteSectionFieldMutation,
 } = welcomeManualsApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/index.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/index.ts
@@ -6,6 +6,7 @@ export type { WelcomeManualListArgs } from "./welcome-manual-list-args";
 export type { WelcomeManualListResponse } from "./welcome-manual-list-response";
 export type { WelcomeManualResponse } from "./welcome-manual-response";
 export type { WelcomeManualSectionCreateRequest } from "./welcome-manual-section-create-request";
+export type { WelcomeManualSectionFieldResponse } from "./welcome-manual-section-field-response";
 export type { WelcomeManualSectionImageResponse } from "./welcome-manual-section-image-response";
 export type { WelcomeManualSectionResponse } from "./welcome-manual-section-response";
 export type { WelcomeManualSectionUpdateRequest } from "./welcome-manual-section-update-request";

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-field-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-field-response.ts
@@ -1,0 +1,13 @@
+/**
+ * Mirrors backend `WelcomeManualSectionFieldResponse`. A field is a simple
+ * label/value pair (e.g. "Wi-Fi network" → "Lakeview") ordered within a
+ * section. ``value`` is nullable — a label with no value yet is allowed.
+ */
+export interface WelcomeManualSectionFieldResponse {
+  id: string;
+  section_id: string;
+  label: string;
+  value: string | null;
+  display_order: number;
+  created_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-response.ts
@@ -1,9 +1,10 @@
+import type { WelcomeManualSectionFieldResponse } from "./welcome-manual-section-field-response";
 import type { WelcomeManualSectionImageResponse } from "./welcome-manual-section-image-response";
 
 /**
- * Mirrors backend `WelcomeManualSectionResponse`. ``images`` is populated on
- * the full-manual read paths; section-mutation responses (add / update /
- * reorder) return an empty list and the frontend refetches the manual.
+ * Mirrors backend `WelcomeManualSectionResponse`. ``fields`` and ``images`` are
+ * populated on the full-manual read paths; section-mutation responses (add /
+ * update / reorder) return empty lists and the frontend refetches the manual.
  */
 export interface WelcomeManualSectionResponse {
   id: string;
@@ -11,6 +12,7 @@ export interface WelcomeManualSectionResponse {
   title: string;
   body: string | null;
   display_order: number;
+  fields: WelcomeManualSectionFieldResponse[];
   images: WelcomeManualSectionImageResponse[];
   created_at: string;
   updated_at: string;

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -623,13 +623,18 @@
         "backend/app/core/welcome_manual_constants.py",
         "backend/alembic/versions/wmanual260530_add_welcome_manuals_domain.py",
         "backend/alembic/versions/wmanualimg260530_add_welcome_manual_section_images.py",
+        "backend/alembic/versions/wmanualfld260720_add_welcome_manual_section_fields.py",
         "backend/alembic/versions/wmanualsend260530_add_welcome_manual_sends.py"
       ],
       "backend_tests": [
         "test_welcome_manual_image_routes.py",
+        "test_welcome_manual_field_routes.py",
+        "test_welcome_manual_section_field_repo.py",
+        "test_welcome_manual_section_field_service.py",
         "test_welcome_manual_pdf_service.py",
         "test_welcome_manual_markdown_pdf.py",
         "test_welcome_manual_send_repo.py",
+        "test_welcome_manual_service.py",
         "test_welcome_manual_email_routes.py",
         "test_welcome_manual_send_audit_masking.py"
       ],


### PR DESCRIPTION
## What

Adds a generic **label + value field list** to any welcome-manual section, so hosts can capture structured details (Wi-Fi network name + password, door codes, checkout time) as discrete fields instead of burying them in prose. The **Wi-Fi** section seeds two empty fields — "Network name" and "Password" — when a manual is created; the host fills in the values.

This is the follow-up to the preview panel: _"i'd rather see fields especially for things like wifi. a network name field and password field."_

## Stacked on #990

> ⚠️ **Base branch is `feature/mbk-welcome-manual-preview` (PR #990), not `main`.** Merge #990 first, then this PR's base auto-retargets or is retargeted to `main`. Reviewing the diff against the preview branch keeps it focused on just the fields feature.

## Backend

- New `welcome_manual_section_fields` table — `section_id` FK (`ON DELETE CASCADE`, indexed), `label` (String 100, required), `value` (String 500, nullable), `display_order` (SmallInteger). Migration `wmanualfld260720`, single head verified.
- Repo / service / schema / API layers mirror the existing section-image pattern:
  - `POST/PATCH/DELETE /welcome-manuals/{id}/sections/{sid}/fields[/{fid}]`
  - `org → manual → section` scope gate on every mutation
  - Max 20 fields per section (`409` on overflow)
- Fields attach to `WelcomeManualSectionResponse`. The **PDF** and **guest email** render `label: value` rows after the section body, before images.

## Frontend

- `WelcomeManualSectionFieldManager` + `WelcomeManualSectionFieldCard` — dnd-kit reorder, uncontrolled inputs with onBlur save — embedded in the section card's new "Details" block, above Photos.
- Guest preview renders a `<dl>` of the section's non-empty fields.
- RTK Query `createSectionField` / `updateSectionField` / `deleteSectionField` mutations invalidate the manual so the preview stays live.

## Testing

- Backend: **176** welcome-manual pytest pass (repo, service, routes for fields + updated service/PDF/email suites).
- Frontend: build + lint clean (0 errors); unit tests for the field manager, updated section-card / preview / detail tests; e2e crud + layout-mock updated.
- **Live API round-trip verified** against a running backend: creating a manual seeds exactly `["Network name", "Password"]` (null values); POST → PATCH → GET → DELETE all round-trip correctly; test manual cleaned up.

## Operational migration

Additive schema only — the migration adds one new table, no changes to existing columns. Apply `alembic upgrade head` on deploy; no env changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)