### PR TITLE
style(mybookkeeper): widen welcome-manual detail page

### DIFF
--- a/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
@@ -134,7 +134,7 @@ export default function WelcomeManualDetail() {
   const hasSections = sortedSections.length > 0;
 
   return (
-    <main className="p-4 sm:p-8 space-y-6 max-w-6xl">
+    <main className="p-4 sm:p-8 space-y-6 max-w-[96rem]">
       <Link
         to="/welcome-manuals"
         className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground min-h-[44px]"


### PR DESCRIPTION
## What

The welcome-manual detail page (editor on the left, live guest preview on the right) was capped at `max-w-6xl` (1152px), leaving a large empty band down the right side on wide screens. This bumps it to `max-w-[96rem]` (1536px) so the two columns actually use the available width.

Before: content pinned to ~60% of a typical laptop screen. After: fills the screen, capped on ultrawide monitors so the guest-preview reading width stays sane.

## Why it's safe at smaller screens

`max-width` only caps — it never forces content past the viewport — so at `<1536px` the layout is unchanged below the old cap, and at mid-widths (e.g. 1280px) the two columns just get a bit more room. Responsive / no-horizontal-scroll behavior is preserved.

## Testing

- Build + lint clean.
- 13 welcome-manual unit tests pass.
- 6 layout e2e pass (mobile/tablet/desktop no-horizontal-scroll + desktop editor/preview side-by-side + mobile toggle).
- Confirmed Tailwind v4 generates `{max-width:96rem}` in the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)