### PR TITLE
feat(mybookkeeper): add "Where to Eat" restaurant directory to welcome manuals

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/wmanualplace260721_add_welcome_manual_places.py
+++ b/apps/mybookkeeper/backend/alembic/versions/wmanualplace260721_add_welcome_manual_places.py
@@ -1,0 +1,53 @@
+"""add welcome_manual_places
+
+Revision ID: wmanualplace260721
+Revises: wmanualfld260720
+Create Date: 2026-07-21
+
+Guest welcome manual — restaurant "places" (a flat guest dining directory).
+One place per row, attached directly to the manual (no section parent),
+ordered by ``display_order``, cascade-deleted with the manual.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "wmanualplace260721"
+down_revision: Union[str, None] = "wmanualfld260720"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "welcome_manual_places",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("manual_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=150), nullable=False),
+        sa.Column("cuisine", sa.String(length=50), nullable=False),
+        sa.Column("price_tier", sa.String(length=4), nullable=True),
+        sa.Column("note", sa.String(length=500), nullable=True),
+        sa.Column("map_url", sa.String(length=2048), nullable=True),
+        sa.Column("display_order", sa.SmallInteger(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["manual_id"], ["welcome_manuals.id"], ondelete="CASCADE"),
+        sa.CheckConstraint(
+            "price_tier IN ('$', '$$', '$$$') OR price_tier IS NULL",
+            name="ck_welcome_manual_places_price_tier",
+        ),
+    )
+    op.create_index(
+        "ix_welcome_manual_places_manual_order",
+        "welcome_manual_places",
+        ["manual_id", "display_order"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_welcome_manual_places_manual_order",
+        table_name="welcome_manual_places",
+    )
+    op.drop_table("welcome_manual_places")

--- a/apps/mybookkeeper/backend/app/api/welcome_manuals.py
+++ b/apps/mybookkeeper/backend/app/api/welcome_manuals.py
@@ -35,6 +35,15 @@ from app.schemas.welcome_manuals.welcome_manual_section_field_response import (
 from app.schemas.welcome_manuals.welcome_manual_section_field_update_request import (
     WelcomeManualSectionFieldUpdateRequest,
 )
+from app.schemas.welcome_manuals.welcome_manual_place_create_request import (
+    WelcomeManualPlaceCreateRequest,
+)
+from app.schemas.welcome_manuals.welcome_manual_place_response import (
+    WelcomeManualPlaceResponse,
+)
+from app.schemas.welcome_manuals.welcome_manual_place_update_request import (
+    WelcomeManualPlaceUpdateRequest,
+)
 from app.schemas.welcome_manuals.welcome_manual_section_reorder_request import (
     WelcomeManualSectionReorderRequest,
 )
@@ -49,6 +58,7 @@ from app.schemas.welcome_manuals.welcome_manual_update_request import (
 )
 from app.services.welcome_manuals import (
     welcome_manual_email_service,
+    welcome_manual_place_service,
     welcome_manual_section_field_service,
     welcome_manual_section_image_service,
     welcome_manual_section_service,
@@ -397,4 +407,71 @@ async def delete_section_field(
         raise HTTPException(status_code=404, detail="Section not found") from exc
     except welcome_manual_section_field_service.FieldNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Field not found") from exc
+    return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Places (restaurant recommendations — a flat guest dining directory)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{manual_id}/places",
+    response_model=WelcomeManualPlaceResponse,
+    status_code=201,
+)
+async def add_place(
+    manual_id: uuid.UUID,
+    payload: WelcomeManualPlaceCreateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> WelcomeManualPlaceResponse:
+    try:
+        return await welcome_manual_place_service.add_place(
+            ctx.organization_id, ctx.user_id, manual_id,
+            payload.name, payload.cuisine, payload.price_tier, payload.note, payload.map_url,
+        )
+    except welcome_manual_place_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+    except welcome_manual_place_service.TooManyPlacesError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.patch(
+    "/{manual_id}/places/{place_id}",
+    response_model=WelcomeManualPlaceResponse,
+)
+async def update_place(
+    manual_id: uuid.UUID,
+    place_id: uuid.UUID,
+    payload: WelcomeManualPlaceUpdateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> WelcomeManualPlaceResponse:
+    try:
+        return await welcome_manual_place_service.update_place(
+            ctx.organization_id, ctx.user_id, manual_id, place_id,
+            payload.to_update_dict(),
+        )
+    except welcome_manual_place_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+    except welcome_manual_place_service.PlaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Place not found") from exc
+
+
+@router.delete(
+    "/{manual_id}/places/{place_id}",
+    status_code=204,
+)
+async def delete_place(
+    manual_id: uuid.UUID,
+    place_id: uuid.UUID,
+    ctx: RequestContext = Depends(require_write_access),
+) -> Response:
+    try:
+        await welcome_manual_place_service.delete_place(
+            ctx.organization_id, ctx.user_id, manual_id, place_id,
+        )
+    except welcome_manual_place_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+    except welcome_manual_place_service.PlaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Place not found") from exc
     return Response(status_code=204)

--- a/apps/mybookkeeper/backend/app/core/welcome_manual_constants.py
+++ b/apps/mybookkeeper/backend/app/core/welcome_manual_constants.py
@@ -56,3 +56,13 @@ DEFAULT_WELCOME_MANUAL_SECTIONS: tuple[str, ...] = (
 DEFAULT_WELCOME_MANUAL_SECTION_FIELDS: dict[str, tuple[str, ...]] = {
     "Wi-Fi": ("Network name", "Password"),
 }
+
+# Restaurant "places" (a guest dining directory) attached directly to a
+# manual — no section parent. Bounds mirrored by the Pydantic schemas.
+# ``WELCOME_MANUAL_MAX_PLACES`` guards a single manual against unbounded rows.
+WELCOME_MANUAL_MAX_PLACES = 200
+PLACE_NAME_MAX_LEN = 150
+PLACE_CUISINE_MAX_LEN = 50
+PLACE_NOTE_MAX_LEN = 500
+PLACE_MAP_URL_MAX_LEN = 2048
+WELCOME_MANUAL_PRICE_TIERS: tuple[str, ...] = ("$", "$$", "$$$")

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -21,6 +21,7 @@ from app.models.welcome_manuals.welcome_manual import WelcomeManual
 from app.models.welcome_manuals.welcome_manual_section import WelcomeManualSection
 from app.models.welcome_manuals.welcome_manual_section_image import WelcomeManualSectionImage
 from app.models.welcome_manuals.welcome_manual_section_field import WelcomeManualSectionField
+from app.models.welcome_manuals.welcome_manual_place import WelcomeManualPlace
 from app.models.welcome_manuals.welcome_manual_send import WelcomeManualSend
 from app.models.calendar.calendar_email_review_queue import CalendarEmailReviewQueue
 from app.models.calendar.calendar_listing_blocklist import CalendarListingBlocklist

--- a/apps/mybookkeeper/backend/app/models/welcome_manuals/welcome_manual_place.py
+++ b/apps/mybookkeeper/backend/app/models/welcome_manuals/welcome_manual_place.py
@@ -1,0 +1,61 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, SmallInteger, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.welcome_manual_constants import (
+    PLACE_CUISINE_MAX_LEN,
+    PLACE_MAP_URL_MAX_LEN,
+    PLACE_NAME_MAX_LEN,
+    PLACE_NOTE_MAX_LEN,
+    WELCOME_MANUAL_PRICE_TIERS,
+)
+from app.db.base import Base
+
+_PRICE_TIER_CHECK_SQL = (
+    "price_tier IN (" + ", ".join(f"'{t}'" for t in WELCOME_MANUAL_PRICE_TIERS) + ") OR price_tier IS NULL"
+)
+
+
+class WelcomeManualPlace(Base):
+    """A restaurant recommendation ("place") attached directly to a welcome
+    manual (a guest dining directory) — no section parent, unlike sections'
+    label/value fields. Cascade-deleted with the manual. Ordered within the
+    manual by ``display_order``.
+
+    DEFERRED — do NOT build these now:
+    - Per-place food photos: a future ``welcome_manual_place_images`` child
+      table, mirroring ``welcome_manual_section_image.py``.
+    - "Must-have dishes": a future additive column or child table on this
+      model.
+    """
+
+    __tablename__ = "welcome_manual_places"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    manual_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("welcome_manuals.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    name: Mapped[str] = mapped_column(String(PLACE_NAME_MAX_LEN), nullable=False)
+    cuisine: Mapped[str] = mapped_column(String(PLACE_CUISINE_MAX_LEN), nullable=False)
+    price_tier: Mapped[str | None] = mapped_column(String(4), nullable=True)
+    note: Mapped[str | None] = mapped_column(String(PLACE_NOTE_MAX_LEN), nullable=True)
+    map_url: Mapped[str | None] = mapped_column(String(PLACE_MAP_URL_MAX_LEN), nullable=True)
+    display_order: Mapped[int] = mapped_column(SmallInteger, nullable=False, default=0, server_default="0")
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(_PRICE_TIER_CHECK_SQL, name="ck_welcome_manual_places_price_tier"),
+        Index("ix_welcome_manual_places_manual_order", "manual_id", "display_order"),
+    )

--- a/apps/mybookkeeper/backend/app/repositories/__init__.py
+++ b/apps/mybookkeeper/backend/app/repositories/__init__.py
@@ -44,6 +44,7 @@ from app.repositories.welcome_manuals import welcome_manual_repo
 from app.repositories.welcome_manuals import welcome_manual_section_repo
 from app.repositories.welcome_manuals import welcome_manual_section_image_repo
 from app.repositories.welcome_manuals import welcome_manual_section_field_repo
+from app.repositories.welcome_manuals import welcome_manual_place_repo
 from app.repositories.welcome_manuals import welcome_manual_send_repo
 from app.repositories.calendar import calendar_repository
 from app.repositories.calendar import review_queue_repo

--- a/apps/mybookkeeper/backend/app/repositories/welcome_manuals/welcome_manual_place_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/welcome_manuals/welcome_manual_place_repo.py
@@ -1,0 +1,126 @@
+import uuid
+from typing import Any
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.welcome_manuals.welcome_manual_place import WelcomeManualPlace
+
+# Columns mutable via PATCH. ``manual_id`` is immutable post-create — moving a
+# place between manuals is not a supported flow.
+_UPDATABLE_COLUMNS: frozenset[str] = frozenset({
+    "name",
+    "cuisine",
+    "price_tier",
+    "note",
+    "map_url",
+    "display_order",
+})
+
+
+async def list_by_manual(
+    db: AsyncSession,
+    manual_id: uuid.UUID,
+) -> list[WelcomeManualPlace]:
+    """List places for a manual in display order (then by creation time)."""
+    result = await db.execute(
+        select(WelcomeManualPlace)
+        .where(WelcomeManualPlace.manual_id == manual_id)
+        .order_by(
+            WelcomeManualPlace.display_order.asc(),
+            WelcomeManualPlace.created_at.asc(),
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def get_by_id(
+    db: AsyncSession,
+    place_id: uuid.UUID,
+    manual_id: uuid.UUID,
+) -> WelcomeManualPlace | None:
+    """Return the place iff it exists and belongs to the given manual."""
+    result = await db.execute(
+        select(WelcomeManualPlace).where(
+            WelcomeManualPlace.id == place_id,
+            WelcomeManualPlace.manual_id == manual_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def next_display_order(
+    db: AsyncSession,
+    manual_id: uuid.UUID,
+) -> int:
+    """Return the next display_order slot for a manual (max + 1, or 0 if empty)."""
+    result = await db.execute(
+        select(func.max(WelcomeManualPlace.display_order)).where(
+            WelcomeManualPlace.manual_id == manual_id,
+        )
+    )
+    current = result.scalar_one_or_none()
+    return 0 if current is None else int(current) + 1
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    manual_id: uuid.UUID,
+    name: str,
+    cuisine: str,
+    price_tier: str | None,
+    note: str | None,
+    map_url: str | None,
+    display_order: int,
+) -> WelcomeManualPlace:
+    place = WelcomeManualPlace(
+        manual_id=manual_id,
+        name=name,
+        cuisine=cuisine,
+        price_tier=price_tier,
+        note=note,
+        map_url=map_url,
+        display_order=display_order,
+    )
+    db.add(place)
+    await db.flush()
+    return place
+
+
+async def update(
+    db: AsyncSession,
+    place_id: uuid.UUID,
+    manual_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> WelcomeManualPlace | None:
+    """Apply allowlisted updates to a place. None if it doesn't exist /
+    belongs to a different manual."""
+    place = await get_by_id(db, place_id, manual_id)
+    if place is None:
+        return None
+    safe_fields = {k: v for k, v in fields.items() if k in _UPDATABLE_COLUMNS}
+    if not safe_fields:
+        return place
+    for key, value in safe_fields.items():
+        setattr(place, key, value)
+    await db.flush()
+    return place
+
+
+async def delete_by_id(
+    db: AsyncSession,
+    place_id: uuid.UUID,
+    manual_id: uuid.UUID,
+) -> WelcomeManualPlace | None:
+    """Delete a place and return the deleted row. None if no row matched."""
+    place = await get_by_id(db, place_id, manual_id)
+    if place is None:
+        return None
+    await db.execute(
+        delete(WelcomeManualPlace).where(
+            WelcomeManualPlace.id == place_id,
+            WelcomeManualPlace.manual_id == manual_id,
+        )
+    )
+    return place

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_place_create_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_place_create_request.py
@@ -1,0 +1,36 @@
+"""Pydantic schema for POST .../{manual_id}/places request body."""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.core.welcome_manual_constants import (
+    PLACE_CUISINE_MAX_LEN,
+    PLACE_MAP_URL_MAX_LEN,
+    PLACE_NAME_MAX_LEN,
+    PLACE_NOTE_MAX_LEN,
+    WELCOME_MANUAL_PRICE_TIERS,
+)
+
+
+class WelcomeManualPlaceCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=PLACE_NAME_MAX_LEN)
+    cuisine: str = Field(min_length=1, max_length=PLACE_CUISINE_MAX_LEN)
+    price_tier: str | None = Field(default=None)
+    note: str | None = Field(default=None, max_length=PLACE_NOTE_MAX_LEN)
+    map_url: str | None = Field(default=None, max_length=PLACE_MAP_URL_MAX_LEN)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("price_tier")
+    @classmethod
+    def price_tier_must_be_valid(cls, v: str | None) -> str | None:
+        if v is not None and v not in WELCOME_MANUAL_PRICE_TIERS:
+            raise ValueError(f"price_tier must be one of {WELCOME_MANUAL_PRICE_TIERS}")
+        return v
+
+    @field_validator("map_url")
+    @classmethod
+    def map_url_must_be_http(cls, v: str | None) -> str | None:
+        if v is not None and not v.startswith(("http://", "https://")):
+            raise ValueError("map_url must be an http(s) URL")
+        return v

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_place_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_place_response.py
@@ -1,0 +1,18 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WelcomeManualPlaceResponse(BaseModel):
+    id: uuid.UUID
+    manual_id: uuid.UUID
+    name: str
+    cuisine: str
+    price_tier: str | None = None
+    note: str | None = None
+    map_url: str | None = None
+    display_order: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_place_update_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_place_update_request.py
@@ -1,0 +1,51 @@
+"""Pydantic schema for PATCH .../{manual_id}/places/{place_id}.
+
+Allows name/cuisine editing, price_tier/note/map_url editing (including
+clearing to null), and reordering (display_order).
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.core.welcome_manual_constants import (
+    PLACE_CUISINE_MAX_LEN,
+    PLACE_MAP_URL_MAX_LEN,
+    PLACE_NAME_MAX_LEN,
+    PLACE_NOTE_MAX_LEN,
+    WELCOME_MANUAL_PRICE_TIERS,
+)
+
+
+class WelcomeManualPlaceUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=PLACE_NAME_MAX_LEN)
+    cuisine: str | None = Field(default=None, min_length=1, max_length=PLACE_CUISINE_MAX_LEN)
+    price_tier: str | None = Field(default=None)
+    note: str | None = Field(default=None, max_length=PLACE_NOTE_MAX_LEN)
+    map_url: str | None = Field(default=None, max_length=PLACE_MAP_URL_MAX_LEN)
+    display_order: int | None = Field(default=None, ge=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("price_tier")
+    @classmethod
+    def price_tier_must_be_valid(cls, v: str | None) -> str | None:
+        if v is not None and v not in WELCOME_MANUAL_PRICE_TIERS:
+            raise ValueError(f"price_tier must be one of {WELCOME_MANUAL_PRICE_TIERS}")
+        return v
+
+    @field_validator("map_url")
+    @classmethod
+    def map_url_must_be_http(cls, v: str | None) -> str | None:
+        if v is not None and not v.startswith(("http://", "https://")):
+            raise ValueError("map_url must be an http(s) URL")
+        return v
+
+    def to_update_dict(self) -> dict[str, object]:
+        """Return only explicitly-provided fields. An explicit ``null`` name,
+        cuisine, or display_order is a no-op (all NOT NULL columns); an explicit
+        ``null`` price_tier, note, or map_url clears it."""
+        data = self.model_dump(exclude_unset=True)
+        for required in ("name", "cuisine", "display_order"):
+            if required in data and data[required] is None:
+                data.pop(required)
+        return data

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_response.py
@@ -3,13 +3,17 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
+from app.schemas.welcome_manuals.welcome_manual_place_response import (
+    WelcomeManualPlaceResponse,
+)
 from app.schemas.welcome_manuals.welcome_manual_section_response import (
     WelcomeManualSectionResponse,
 )
 
 
 class WelcomeManualResponse(BaseModel):
-    """Full welcome-manual payload for detail views — includes ordered sections."""
+    """Full welcome-manual payload for detail views — includes ordered sections
+    and the flat restaurant-places directory."""
 
     id: uuid.UUID
     organization_id: uuid.UUID
@@ -20,6 +24,7 @@ class WelcomeManualResponse(BaseModel):
     intro_text: str | None = None
 
     sections: list[WelcomeManualSectionResponse] = []
+    places: list[WelcomeManualPlaceResponse] = []
 
     created_at: datetime
     updated_at: datetime

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_place_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_place_service.py
@@ -1,0 +1,104 @@
+"""Welcome-manual place service — orchestration for the flat list of
+restaurant recommendations attached directly to a manual (no section parent).
+Scope is enforced by re-fetching the parent manual (org-scoped) before
+touching any place.
+"""
+import logging
+import uuid
+from typing import Any
+
+from app.core.welcome_manual_constants import WELCOME_MANUAL_MAX_PLACES
+from app.db.session import unit_of_work
+from app.repositories import welcome_manual_place_repo, welcome_manual_repo
+from app.schemas.welcome_manuals.welcome_manual_place_response import (
+    WelcomeManualPlaceResponse,
+)
+from app.services.welcome_manuals.welcome_manual_section_service import (
+    ManualNotFoundError,  # noqa: F401 — re-exported for the route
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PlaceNotFoundError(LookupError):
+    """The place doesn't exist or belongs to a different manual."""
+
+
+class TooManyPlacesError(Exception):
+    """The manual already has the maximum number of places (-> HTTP 409)."""
+
+
+async def add_place(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    name: str,
+    cuisine: str,
+    price_tier: str | None,
+    note: str | None,
+    map_url: str | None,
+) -> WelcomeManualPlaceResponse:
+    """Append a place to a manual.
+
+    Raises:
+        ManualNotFoundError: scope failure.
+        TooManyPlacesError: the manual is already at the place cap.
+    """
+    async with unit_of_work() as db:
+        manual = await welcome_manual_repo.get_by_id(db, manual_id, organization_id)
+        if manual is None:
+            raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
+
+        existing = await welcome_manual_place_repo.list_by_manual(db, manual.id)
+        if len(existing) >= WELCOME_MANUAL_MAX_PLACES:
+            raise TooManyPlacesError(
+                f"A manual can have at most {WELCOME_MANUAL_MAX_PLACES} places",
+            )
+
+        next_order = await welcome_manual_place_repo.next_display_order(db, manual.id)
+        place = await welcome_manual_place_repo.create(
+            db,
+            manual_id=manual.id,
+            name=name,
+            cuisine=cuisine,
+            price_tier=price_tier,
+            note=note,
+            map_url=map_url,
+            display_order=next_order,
+        )
+        return WelcomeManualPlaceResponse.model_validate(place)
+
+
+async def update_place(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    place_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> WelcomeManualPlaceResponse:
+    """Update a place's name, cuisine, price_tier, note, map_url, and/or
+    display_order."""
+    async with unit_of_work() as db:
+        manual = await welcome_manual_repo.get_by_id(db, manual_id, organization_id)
+        if manual is None:
+            raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
+        place = await welcome_manual_place_repo.update(db, place_id, manual.id, fields)
+        if place is None:
+            raise PlaceNotFoundError(f"Place {place_id} not found")
+        return WelcomeManualPlaceResponse.model_validate(place)
+
+
+async def delete_place(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    place_id: uuid.UUID,
+) -> None:
+    """Delete a place from a manual."""
+    async with unit_of_work() as db:
+        manual = await welcome_manual_repo.get_by_id(db, manual_id, organization_id)
+        if manual is None:
+            raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
+        deleted = await welcome_manual_place_repo.delete_by_id(db, place_id, manual.id)
+        if deleted is None:
+            raise PlaceNotFoundError(f"Place {place_id} not found")

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_service.py
@@ -13,6 +13,7 @@ from app.core.welcome_manual_constants import (
 from app.db.session import AsyncSessionLocal, unit_of_work
 from app.repositories import (
     property_repo,
+    welcome_manual_place_repo,
     welcome_manual_repo,
     welcome_manual_section_field_repo,
     welcome_manual_section_image_repo,
@@ -23,6 +24,9 @@ from app.schemas.welcome_manuals.welcome_manual_create_request import (
 )
 from app.schemas.welcome_manuals.welcome_manual_list_response import (
     WelcomeManualListResponse,
+)
+from app.schemas.welcome_manuals.welcome_manual_place_response import (
+    WelcomeManualPlaceResponse,
 )
 from app.schemas.welcome_manuals.welcome_manual_response import WelcomeManualResponse
 from app.schemas.welcome_manuals.welcome_manual_section_field_response import (
@@ -75,14 +79,20 @@ def _build_section_responses(sections, images, fields) -> list[WelcomeManualSect
     ]
 
 
-def _to_response(manual, section_responses=()) -> WelcomeManualResponse:
-    """Convert an ORM manual + pre-built section responses to a response model.
+def _to_response(manual, section_responses=(), place_responses=()) -> WelcomeManualResponse:
+    """Convert an ORM manual + pre-built section/place responses to a response
+    model.
 
     Centralising this construction prevents drift between get / create /
     update response shapes.
     """
     base = WelcomeManualResponse.model_validate(manual)
-    return base.model_copy(update={"sections": list(section_responses)})
+    return base.model_copy(
+        update={
+            "sections": list(section_responses),
+            "places": list(place_responses),
+        },
+    )
 
 
 async def get_manual(
@@ -103,7 +113,9 @@ async def get_manual(
         section_ids = [s.id for s in sections]
         images = await welcome_manual_section_image_repo.list_by_section_ids(db, section_ids)
         fields = await welcome_manual_section_field_repo.list_by_section_ids(db, section_ids)
-    return _to_response(manual, _build_section_responses(sections, images, fields))
+        places = await welcome_manual_place_repo.list_by_manual(db, manual.id)
+    place_responses = [WelcomeManualPlaceResponse.model_validate(p) for p in places]
+    return _to_response(manual, _build_section_responses(sections, images, fields), place_responses)
 
 
 async def list_manuals(
@@ -188,8 +200,9 @@ async def create_manual(
                     )
                     fields.append(field)
 
-        # Freshly-seeded sections never have images yet.
-        return _to_response(manual, _build_section_responses(sections, [], fields))
+        # Freshly-seeded sections never have images yet. New manuals start
+        # with zero places — places are never seeded on create.
+        return _to_response(manual, _build_section_responses(sections, [], fields), [])
 
 
 async def update_manual(
@@ -223,7 +236,9 @@ async def update_manual(
         section_ids = [s.id for s in sections]
         images = await welcome_manual_section_image_repo.list_by_section_ids(db, section_ids)
         fields = await welcome_manual_section_field_repo.list_by_section_ids(db, section_ids)
-        return _to_response(manual, _build_section_responses(sections, images, fields))
+        places = await welcome_manual_place_repo.list_by_manual(db, manual.id)
+        place_responses = [WelcomeManualPlaceResponse.model_validate(p) for p in places]
+        return _to_response(manual, _build_section_responses(sections, images, fields), place_responses)
 
 
 async def soft_delete_manual(

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_place_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_place_repo.py
@@ -1,0 +1,119 @@
+"""Repository tests for welcome_manual_places."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.welcome_manuals import welcome_manual_place_repo, welcome_manual_repo
+
+
+async def _make_manual(db: AsyncSession, org: Organization, user: User):
+    manual = await welcome_manual_repo.create_manual(
+        db, organization_id=org.id, user_id=user.id,
+        property_id=None, title="G", intro_text=None,
+    )
+    await db.flush()
+    return manual
+
+
+class TestOrderingAndCreate:
+    @pytest.mark.asyncio
+    async def test_create_and_list_in_order(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await welcome_manual_place_repo.create(
+            db, manual_id=manual.id, name="B", cuisine="Italian",
+            price_tier=None, note=None, map_url=None, display_order=1,
+        )
+        await welcome_manual_place_repo.create(
+            db, manual_id=manual.id, name="A", cuisine="Mexican",
+            price_tier="$$", note="Great tacos", map_url="https://maps.example.com/a", display_order=0,
+        )
+        await db.commit()
+        places = await welcome_manual_place_repo.list_by_manual(db, manual.id)
+        assert [p.name for p in places] == ["A", "B"]
+        assert places[0].cuisine == "Mexican"
+        assert places[0].price_tier == "$$"
+
+    @pytest.mark.asyncio
+    async def test_next_display_order(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        assert await welcome_manual_place_repo.next_display_order(db, manual.id) == 0
+        await welcome_manual_place_repo.create(
+            db, manual_id=manual.id, name="A", cuisine="Japanese & Sushi",
+            price_tier=None, note=None, map_url=None, display_order=0,
+        )
+        await db.flush()
+        assert await welcome_manual_place_repo.next_display_order(db, manual.id) == 1
+
+
+class TestUpdateDelete:
+    @pytest.mark.asyncio
+    async def test_update_allowlist(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        place = await welcome_manual_place_repo.create(
+            db, manual_id=manual.id, name="Taco Spot", cuisine="Mexican",
+            price_tier="$", note=None, map_url=None, display_order=0,
+        )
+        await db.commit()
+        updated = await welcome_manual_place_repo.update(
+            db, place.id, manual.id,
+            {
+                "name": "Taco Spot 2",
+                "cuisine": "Tex-Mex",
+                "price_tier": "$$",
+                "note": "Ask for the salsa verde",
+                "map_url": "https://maps.example.com/taco",
+                "display_order": 3,
+                "manual_id": uuid.uuid4(),
+            },
+        )
+        assert updated is not None
+        assert updated.name == "Taco Spot 2"
+        assert updated.cuisine == "Tex-Mex"
+        assert updated.price_tier == "$$"
+        assert updated.note == "Ask for the salsa verde"
+        assert updated.map_url == "https://maps.example.com/taco"
+        assert updated.display_order == 3
+        assert updated.manual_id == manual.id  # immutable
+
+    @pytest.mark.asyncio
+    async def test_update_nullable_fields_to_null(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        place = await welcome_manual_place_repo.create(
+            db, manual_id=manual.id, name="Ramen House", cuisine="Japanese",
+            price_tier="$$", note="Cash only", map_url="https://maps.example.com/r", display_order=0,
+        )
+        await db.commit()
+        updated = await welcome_manual_place_repo.update(
+            db, place.id, manual.id, {"price_tier": None, "note": None, "map_url": None},
+        )
+        assert updated is not None
+        assert updated.price_tier is None
+        assert updated.note is None
+        assert updated.map_url is None
+
+    @pytest.mark.asyncio
+    async def test_get_wrong_manual_returns_none(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        place = await welcome_manual_place_repo.create(
+            db, manual_id=manual.id, name="A", cuisine="Thai",
+            price_tier=None, note=None, map_url=None, display_order=0,
+        )
+        await db.commit()
+        assert await welcome_manual_place_repo.get_by_id(db, place.id, uuid.uuid4()) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_row_then_none(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        place = await welcome_manual_place_repo.create(
+            db, manual_id=manual.id, name="A", cuisine="Thai",
+            price_tier=None, note=None, map_url=None, display_order=0,
+        )
+        await db.commit()
+        deleted = await welcome_manual_place_repo.delete_by_id(db, place.id, manual.id)
+        assert deleted is not None and deleted.name == "A"
+        assert await welcome_manual_place_repo.delete_by_id(db, place.id, manual.id) is None

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_place_routes.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_place_routes.py
@@ -1,0 +1,255 @@
+"""API route tests for welcome-manual places. Mocks the service layer."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.welcome_manuals.welcome_manual_place_response import (
+    WelcomeManualPlaceResponse,
+)
+from app.services.welcome_manuals import welcome_manual_place_service
+
+
+def _ctx(org_id: uuid.UUID, user_id: uuid.UUID) -> RequestContext:
+    return RequestContext(organization_id=org_id, user_id=user_id, org_role=OrgRole.OWNER)
+
+
+def _override_auth(org_id: uuid.UUID, user_id: uuid.UUID) -> None:
+    app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+    app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+
+def _place_response(
+    manual_id: uuid.UUID,
+    *,
+    order: int = 0,
+    name: str = "Taco Spot",
+    cuisine: str = "Mexican",
+    price_tier: str | None = None,
+) -> WelcomeManualPlaceResponse:
+    return WelcomeManualPlaceResponse(
+        id=uuid.uuid4(),
+        manual_id=manual_id,
+        name=name,
+        cuisine=cuisine,
+        price_tier=price_tier,
+        note=None,
+        map_url=None,
+        display_order=order,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def patch_place_service(name: str, **kwargs):
+    return patch.object(welcome_manual_place_service, name, **kwargs)
+
+
+class TestAdd:
+    @pytest.mark.asyncio
+    async def test_add_201(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_place_service("add_place", return_value=_place_response(manual_id, price_tier="$$")):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/places",
+                    json={"name": "Taco Spot", "cuisine": "Mexican", "price_tier": "$$"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 201
+        body = response.json()
+        assert body["name"] == "Taco Spot"
+        assert body["cuisine"] == "Mexican"
+        assert body["price_tier"] == "$$"
+
+    @pytest.mark.asyncio
+    async def test_add_invalid_price_tier_422(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            client = TestClient(app)
+            response = client.post(
+                f"/welcome-manuals/{manual_id}/places",
+                json={"name": "Taco Spot", "cuisine": "Mexican", "price_tier": "$$$$"},
+            )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_add_non_http_map_url_422(self) -> None:
+        """A stored ``javascript:`` scheme would become an href — reject at the
+        validation boundary before it can reach the guest-facing directory."""
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            client = TestClient(app)
+            response = client.post(
+                f"/welcome-manuals/{manual_id}/places",
+                json={
+                    "name": "Taco Spot",
+                    "cuisine": "Mexican",
+                    "map_url": "javascript:alert(1)",
+                },
+            )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_add_manual_404(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_place_service(
+                "add_place",
+                side_effect=welcome_manual_place_service.ManualNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/places",
+                    json={"name": "Taco Spot", "cuisine": "Mexican"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_add_too_many_409(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_place_service(
+                "add_place",
+                side_effect=welcome_manual_place_service.TooManyPlacesError("too many"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/places",
+                    json={"name": "Taco Spot", "cuisine": "Mexican"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 409
+
+
+class TestUpdateDelete:
+    @pytest.mark.asyncio
+    async def test_update_200(self) -> None:
+        org_id, user_id, manual_id, place_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_place_service(
+                "update_place",
+                return_value=_place_response(manual_id, name="renamed"),
+            ):
+                client = TestClient(app)
+                response = client.patch(
+                    f"/welcome-manuals/{manual_id}/places/{place_id}",
+                    json={"name": "renamed"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 200
+        assert response.json()["name"] == "renamed"
+
+    @pytest.mark.asyncio
+    async def test_update_null_display_order_is_noop_not_500(self) -> None:
+        """An explicit ``display_order: null`` must be dropped (the column is
+        NOT NULL) rather than flow through to a NOT NULL IntegrityError -> 500.
+        The service should be called with a fields dict that omits it."""
+        org_id, user_id, manual_id, place_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_place_service(
+                "update_place",
+                return_value=_place_response(manual_id, name="renamed"),
+            ) as mock_update:
+                client = TestClient(app)
+                response = client.patch(
+                    f"/welcome-manuals/{manual_id}/places/{place_id}",
+                    json={"name": "renamed", "display_order": None},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 200
+        fields = mock_update.call_args.kwargs.get("fields", mock_update.call_args.args[-1])
+        assert "display_order" not in fields
+        assert fields["name"] == "renamed"
+
+    @pytest.mark.asyncio
+    async def test_update_manual_404(self) -> None:
+        org_id, user_id, manual_id, place_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_place_service(
+                "update_place",
+                side_effect=welcome_manual_place_service.ManualNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.patch(
+                    f"/welcome-manuals/{manual_id}/places/{place_id}",
+                    json={"name": "x"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_update_place_404(self) -> None:
+        org_id, user_id, manual_id, place_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_place_service(
+                "update_place",
+                side_effect=welcome_manual_place_service.PlaceNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.patch(
+                    f"/welcome-manuals/{manual_id}/places/{place_id}",
+                    json={"note": "x"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_204(self) -> None:
+        org_id, user_id, manual_id, place_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_place_service("delete_place", return_value=None):
+                client = TestClient(app)
+                response = client.delete(
+                    f"/welcome-manuals/{manual_id}/places/{place_id}",
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_delete_place_404(self) -> None:
+        org_id, user_id, manual_id, place_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_place_service(
+                "delete_place",
+                side_effect=welcome_manual_place_service.PlaceNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.delete(
+                    f"/welcome-manuals/{manual_id}/places/{place_id}",
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404

--- a/apps/mybookkeeper/frontend/e2e/fixtures/welcome-manual.ts
+++ b/apps/mybookkeeper/frontend/e2e/fixtures/welcome-manual.ts
@@ -11,6 +11,7 @@ interface CreatedManual {
   id: string;
   title: string;
   sections: Array<{ id: string; title: string; display_order: number }>;
+  places: Array<{ id: string; name: string; display_order: number }>;
 }
 
 /**

--- a/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout-mock.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout-mock.spec.ts
@@ -102,7 +102,47 @@ async function stubList(page: Page, delayMs = 0): Promise<void> {
   });
 }
 
-async function stubDetail(page: Page, delayMs = 0): Promise<void> {
+const SAMPLE_PLACES = [
+  {
+    id: "00000000-0000-0000-0000-0000000000p1",
+    manual_id: MANUAL_ID,
+    name: "Taco Spot",
+    cuisine: "Mexican",
+    price_tier: "$",
+    note: "Great al pastor",
+    map_url: null,
+    display_order: 0,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "00000000-0000-0000-0000-0000000000p2",
+    manual_id: MANUAL_ID,
+    name: "Nice Cantina",
+    cuisine: "Mexican",
+    price_tier: "$$",
+    note: null,
+    map_url: null,
+    display_order: 1,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "00000000-0000-0000-0000-0000000000p3",
+    manual_id: MANUAL_ID,
+    name: "Sushi Bar",
+    cuisine: "Japanese",
+    price_tier: "$$$",
+    note: null,
+    map_url: "https://maps.example.com/sushi",
+    display_order: 2,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+async function stubDetail(
+  page: Page,
+  delayMs = 0,
+  places: unknown[] = [],
+): Promise<void> {
   await page.route(`**/api/welcome-manuals/${MANUAL_ID}`, async (route, request) => {
     if (request.method() !== "GET") {
       await route.continue();
@@ -130,6 +170,7 @@ async function stubDetail(page: Page, delayMs = 0): Promise<void> {
           created_at: "2026-01-01T00:00:00Z",
           updated_at: "2026-01-01T00:00:00Z",
         })),
+        places,
         created_at: "2026-01-01T00:00:00Z",
         updated_at: "2026-01-01T00:00:00Z",
       }),
@@ -238,6 +279,37 @@ test.describe("Welcome Manuals layout (mocked, no backend)", () => {
 
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
     expect(bodyWidth).toBeLessThanOrEqual(1280 + 1);
+  });
+
+  test("guest preview renders the Where to Eat directory with genre + price filters", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await plantAuth(page);
+    await stubShell(page);
+    await stubDetail(page, 0, SAMPLE_PLACES);
+
+    await page.goto(`/welcome-manuals/${MANUAL_ID}`);
+    const directory = page.getByTestId("welcome-manual-place-directory");
+    await expect(directory).toBeVisible({ timeout: 10000 });
+
+    // Genre chips: "All" + the two distinct cuisines present.
+    await expect(directory.getByTestId("welcome-manual-place-directory-genre-chip")).toHaveCount(3);
+    // Price chips: one per distinct tier present ($, $$, $$$).
+    await expect(directory.getByTestId("welcome-manual-place-directory-price-chip")).toHaveCount(3);
+    // All three places show initially.
+    await expect(directory.getByTestId("welcome-manual-place-directory-item")).toHaveCount(3);
+
+    // Filter by a genre → only that cuisine's place remains.
+    await directory.getByRole("button", { name: "Japanese" }).click();
+    await expect(directory.getByTestId("welcome-manual-place-directory-item")).toHaveCount(1);
+    await expect(directory.getByText("Sushi Bar")).toBeVisible();
+
+    // Reset to All, then filter by price → only the $ place remains.
+    await directory.getByRole("button", { name: "All" }).click();
+    await directory.getByTestId("welcome-manual-place-directory-price-chip").first().click();
+    await expect(directory.getByTestId("welcome-manual-place-directory-item")).toHaveCount(1);
+    await expect(directory.getByText("Taco Spot")).toBeVisible();
   });
 
   test("mobile toggle switches between editor and guest preview", async ({ page }) => {

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualCreateDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualCreateDialog.test.tsx
@@ -44,6 +44,7 @@ const CREATED: WelcomeManualResponse = {
   title: "My Guide",
   intro_text: null,
   sections: [],
+  places: [],
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
 };

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualDetail.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualDetail.test.tsx
@@ -44,6 +44,9 @@ vi.mock("@/shared/store/welcomeManualsApi", () => ({
   useCreateSectionFieldMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useUpdateSectionFieldMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useDeleteSectionFieldMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useCreatePlaceMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useUpdatePlaceMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useDeletePlaceMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
 }));
 
 vi.mock("@/shared/store/propertiesApi", () => ({
@@ -73,6 +76,7 @@ function makeManual(sections: WelcomeManualSectionResponse[]): WelcomeManualResp
     title: "Lakeview Welcome Guide",
     intro_text: null,
     sections,
+    places: [],
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
   };

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualPreview.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualPreview.test.tsx
@@ -66,6 +66,7 @@ describe("WelcomeManualPreview", () => {
         title="Lakeview Welcome Guide"
         introText="Welcome to **our home**!"
         sections={[]}
+        places={[]}
       />,
     );
     expect(
@@ -77,7 +78,7 @@ describe("WelcomeManualPreview", () => {
 
   it("shows the empty placeholder when there are no sections", () => {
     render(
-      <WelcomeManualPreview title="Guide" introText={null} sections={[]} />,
+      <WelcomeManualPreview title="Guide" introText={null} sections={[]} places={[]} />,
     );
     expect(screen.getByTestId("welcome-manual-preview-empty")).toBeInTheDocument();
   });
@@ -88,6 +89,7 @@ describe("WelcomeManualPreview", () => {
         title="Guide"
         introText={null}
         sections={[makeSection()]}
+        places={[]}
       />,
     );
     const section = screen.getByTestId("welcome-manual-preview-section");
@@ -108,6 +110,7 @@ describe("WelcomeManualPreview", () => {
             ],
           }),
         ]}
+        places={[]}
       />,
     );
     const rows = screen.getAllByTestId("welcome-manual-preview-field");
@@ -131,6 +134,7 @@ describe("WelcomeManualPreview", () => {
             ],
           }),
         ]}
+        places={[]}
       />,
     );
     // Only the populated row renders; the all-empty row is dropped.
@@ -144,6 +148,7 @@ describe("WelcomeManualPreview", () => {
         title="Guide"
         introText={null}
         sections={[makeSection({ images: [makeImage()] })]}
+        places={[]}
       />,
     );
     const img = screen.getByTestId("welcome-manual-preview-image");
@@ -161,6 +166,7 @@ describe("WelcomeManualPreview", () => {
             images: [makeImage({ is_available: false, presigned_url: null })],
           }),
         ]}
+        places={[]}
       />,
     );
     expect(

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPlaceCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPlaceCard.tsx
@@ -1,0 +1,154 @@
+import { X } from "lucide-react";
+import { WELCOME_MANUAL_PRICE_TIERS } from "@/shared/lib/welcome-manual-constants";
+import type { WelcomeManualPlaceResponse } from "@/shared/types/welcome-manual/welcome-manual-place-response";
+
+export interface WelcomeManualPlaceCardProps {
+  place: WelcomeManualPlaceResponse;
+  cuisineOptions: readonly string[];
+  onDelete: () => void;
+  onNameSave: (name: string) => void;
+  onCuisineSave: (cuisine: string) => void;
+  onPriceTierChange: (priceTier: "$" | "$$" | "$$$" | null) => void;
+  onNoteSave: (note: string) => void;
+  onMapUrlSave: (mapUrl: string) => void;
+}
+
+const inputClass =
+  "flex-1 min-w-0 border rounded-md px-2 py-2 text-sm min-h-[44px] bg-transparent focus:outline-none focus:bg-muted/40";
+
+export default function WelcomeManualPlaceCard({
+  place,
+  cuisineOptions,
+  onDelete,
+  onNameSave,
+  onCuisineSave,
+  onPriceTierChange,
+  onNoteSave,
+  onMapUrlSave,
+}: WelcomeManualPlaceCardProps) {
+  const cuisineListId = `welcome-manual-place-cuisine-list-${place.id}`;
+
+  function handleNameBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const trimmed = e.target.value.trim();
+    if (trimmed === place.name) return;
+    onNameSave(trimmed);
+  }
+
+  function handleCuisineBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const trimmed = e.target.value.trim();
+    if (trimmed === place.cuisine) return;
+    onCuisineSave(trimmed);
+  }
+
+  function handleNoteBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const trimmed = e.target.value.trim();
+    if (trimmed === (place.note ?? "")) return;
+    onNoteSave(trimmed);
+  }
+
+  function handleMapUrlBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const trimmed = e.target.value.trim();
+    if (trimmed === (place.map_url ?? "")) return;
+    onMapUrlSave(trimmed);
+  }
+
+  function handlePriceTierClick(tier: "$" | "$$" | "$$$") {
+    onPriceTierChange(place.price_tier === tier ? null : tier);
+  }
+
+  return (
+    <li
+      className="border rounded-lg p-3 space-y-2 bg-card"
+      data-testid="welcome-manual-place-card"
+      data-place-id={place.id}
+    >
+      <div className="flex items-start gap-2">
+        <div className="flex-1 min-w-0 space-y-2">
+          {/* Uncontrolled: ``key`` re-mounts each input when the server value
+              changes (after a successful save or a revert) so the displayed
+              value re-baselines without a setState-in-effect. Edits live in
+              the DOM and are read on blur. */}
+          <input
+            key={`name-${place.name}`}
+            defaultValue={place.name}
+            onBlur={handleNameBlur}
+            placeholder="Restaurant name"
+            className={`${inputClass} font-medium`}
+            aria-label="Restaurant name"
+            data-testid="welcome-manual-place-name"
+          />
+
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              key={`cuisine-${place.cuisine}`}
+              defaultValue={place.cuisine}
+              onBlur={handleCuisineBlur}
+              placeholder="Cuisine"
+              list={cuisineListId}
+              className={inputClass}
+              aria-label="Cuisine"
+              data-testid="welcome-manual-place-cuisine"
+            />
+            <datalist id={cuisineListId}>
+              {cuisineOptions.map((cuisine) => (
+                <option key={cuisine} value={cuisine} />
+              ))}
+            </datalist>
+
+            <div className="flex gap-1" role="group" aria-label="Price tier">
+              {WELCOME_MANUAL_PRICE_TIERS.map((tier) => {
+                const isActive = place.price_tier === tier;
+                return (
+                  <button
+                    key={tier}
+                    type="button"
+                    aria-pressed={isActive}
+                    onClick={() => handlePriceTierClick(tier)}
+                    className={`min-h-[44px] min-w-[44px] px-2 rounded-md border text-sm font-medium ${
+                      isActive
+                        ? "bg-primary text-primary-foreground border-primary"
+                        : "text-muted-foreground hover:text-foreground"
+                    }`}
+                    data-testid="welcome-manual-place-price-tier-button"
+                  >
+                    {tier}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <input
+            key={`note-${place.note ?? ""}`}
+            defaultValue={place.note ?? ""}
+            onBlur={handleNoteBlur}
+            placeholder="Note (what to order, tips, etc.)"
+            className={inputClass}
+            aria-label="Note"
+            data-testid="welcome-manual-place-note"
+          />
+
+          <input
+            key={`map-url-${place.map_url ?? ""}`}
+            defaultValue={place.map_url ?? ""}
+            onBlur={handleMapUrlBlur}
+            placeholder="Google Maps link"
+            className={inputClass}
+            aria-label="Map link"
+            data-testid="welcome-manual-place-map-url"
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={onDelete}
+          className="text-red-600 hover:bg-red-50 rounded p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
+          aria-label={`Remove place ${place.name}`}
+          data-testid="welcome-manual-place-delete-button"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPlaceDirectory.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPlaceDirectory.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import { MapPin } from "lucide-react";
+import { WELCOME_MANUAL_PRICE_TIERS } from "@/shared/lib/welcome-manual-constants";
+import type { WelcomeManualPlaceResponse } from "@/shared/types/welcome-manual/welcome-manual-place-response";
+
+export interface WelcomeManualPlaceDirectoryProps {
+  places: WelcomeManualPlaceResponse[];
+}
+
+function buildMapHref(place: WelcomeManualPlaceResponse): string {
+  // Only trust http(s) URLs — never emit a stored ``javascript:``/``data:``
+  // scheme into an href. Anything else falls back to a name search.
+  if (place.map_url && /^https?:\/\//i.test(place.map_url)) return place.map_url;
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(place.name)}`;
+}
+
+/**
+ * Guest-facing "Where to Eat" directory rendered in the welcome-manual
+ * preview. Read-only — filtering happens entirely client-side over the
+ * places already loaded with the manual.
+ */
+export default function WelcomeManualPlaceDirectory({
+  places,
+}: WelcomeManualPlaceDirectoryProps) {
+  const [search, setSearch] = useState("");
+  const [selectedCuisine, setSelectedCuisine] = useState<string | null>(null);
+  const [selectedPriceTier, setSelectedPriceTier] = useState<"$" | "$$" | "$$$" | null>(null);
+
+  if (places.length === 0) return null;
+
+  const cuisines = Array.from(new Set(places.map((p) => p.cuisine))).sort();
+  const priceTiers = WELCOME_MANUAL_PRICE_TIERS.filter((tier) =>
+    places.some((p) => p.price_tier === tier),
+  );
+
+  const query = search.trim().toLowerCase();
+  const filteredPlaces = places.filter((place) => {
+    const matchesSearch =
+      !query ||
+      place.name.toLowerCase().includes(query) ||
+      place.cuisine.toLowerCase().includes(query) ||
+      (place.note ?? "").toLowerCase().includes(query);
+    const matchesCuisine = !selectedCuisine || place.cuisine === selectedCuisine;
+    const matchesPriceTier = !selectedPriceTier || place.price_tier === selectedPriceTier;
+    return matchesSearch && matchesCuisine && matchesPriceTier;
+  });
+
+  const groups = new Map<string, WelcomeManualPlaceResponse[]>();
+  for (const place of filteredPlaces) {
+    const list = groups.get(place.cuisine) ?? [];
+    list.push(place);
+    groups.set(place.cuisine, list);
+  }
+  const sortedCuisineKeys = Array.from(groups.keys()).sort();
+
+  return (
+    <section
+      className="space-y-3"
+      data-testid="welcome-manual-place-directory"
+    >
+      <h2 className="text-base font-semibold text-foreground border-b pb-1">Where to Eat</h2>
+
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search restaurants, cuisine, or notes…"
+        className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+        aria-label="Search restaurants"
+        data-testid="welcome-manual-place-directory-search"
+      />
+
+      <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by cuisine">
+        <button
+          type="button"
+          aria-pressed={selectedCuisine === null}
+          onClick={() => setSelectedCuisine(null)}
+          className={`min-h-[44px] px-3 rounded-full border text-sm font-medium ${
+            selectedCuisine === null
+              ? "bg-primary text-primary-foreground border-primary"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+          data-testid="welcome-manual-place-directory-genre-chip"
+        >
+          All
+        </button>
+        {cuisines.map((cuisine) => {
+          const isActive = selectedCuisine === cuisine;
+          return (
+            <button
+              key={cuisine}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => setSelectedCuisine(isActive ? null : cuisine)}
+              className={`min-h-[44px] px-3 rounded-full border text-sm font-medium ${
+                isActive
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              data-testid="welcome-manual-place-directory-genre-chip"
+            >
+              {cuisine}
+            </button>
+          );
+        })}
+      </div>
+
+      {priceTiers.length > 0 ? (
+        <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by price">
+          {priceTiers.map((tier) => {
+            const isActive = selectedPriceTier === tier;
+            return (
+              <button
+                key={tier}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => setSelectedPriceTier(isActive ? null : tier)}
+                className={`min-h-[44px] min-w-[44px] px-3 rounded-full border text-sm font-medium ${
+                  isActive
+                    ? "bg-primary text-primary-foreground border-primary"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+                data-testid="welcome-manual-place-directory-price-chip"
+              >
+                {tier}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {filteredPlaces.length === 0 ? (
+        <p
+          className="text-sm text-muted-foreground text-center py-4"
+          data-testid="welcome-manual-place-directory-no-matches"
+        >
+          No places match your filters.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {sortedCuisineKeys.map((cuisine) => (
+            <div key={cuisine} data-testid="welcome-manual-place-directory-group">
+              <h3 className="text-sm font-semibold text-foreground mb-2">{cuisine}</h3>
+              <ul className="space-y-2 list-none">
+                {(groups.get(cuisine) ?? []).map((place) => (
+                  <li
+                    key={place.id}
+                    className="border rounded-lg p-3 space-y-1"
+                    data-testid="welcome-manual-place-directory-item"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-bold text-foreground">{place.name}</span>
+                      {place.price_tier ? (
+                        <span className="text-xs font-medium text-muted-foreground border rounded-full px-2 py-0.5">
+                          {place.price_tier}
+                        </span>
+                      ) : null}
+                    </div>
+                    {place.note ? (
+                      <p className="text-sm text-muted-foreground">{place.note}</p>
+                    ) : null}
+                    <a
+                      href={buildMapHref(place)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-sm text-primary hover:underline min-h-[44px]"
+                    >
+                      <MapPin className="h-4 w-4" aria-hidden="true" />
+                      Map
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPlaceManager.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPlaceManager.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { LoadingButton, ConfirmDialog } from "@platform/ui";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import {
+  NEW_PLACE_DEFAULT_NAME,
+  WELCOME_MANUAL_MAX_PLACES,
+} from "@/shared/lib/welcome-manual-constants";
+import {
+  useCreatePlaceMutation,
+  useDeletePlaceMutation,
+  useUpdatePlaceMutation,
+} from "@/shared/store/welcomeManualsApi";
+import type { WelcomeManualPlaceResponse } from "@/shared/types/welcome-manual/welcome-manual-place-response";
+import WelcomeManualPlaceCard from "./WelcomeManualPlaceCard";
+
+export interface WelcomeManualPlaceManagerProps {
+  manualId: string;
+  places: WelcomeManualPlaceResponse[];
+}
+
+export default function WelcomeManualPlaceManager({
+  manualId,
+  places,
+}: WelcomeManualPlaceManagerProps) {
+  const [createPlace, { isLoading: isAdding }] = useCreatePlaceMutation();
+  const [deletePlace] = useDeletePlaceMutation();
+  const [updatePlace] = useUpdatePlaceMutation();
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const sortedPlaces = [...places].sort((a, b) => a.display_order - b.display_order);
+  const atCap = sortedPlaces.length >= WELCOME_MANUAL_MAX_PLACES;
+  const cuisineOptions = Array.from(
+    new Set(sortedPlaces.map((p) => p.cuisine).filter((c) => c.trim() !== "")),
+  ).sort();
+
+  async function handleAdd() {
+    if (atCap) return;
+    try {
+      await createPlace({
+        manualId,
+        data: { name: NEW_PLACE_DEFAULT_NAME, cuisine: "Other" },
+      }).unwrap();
+    } catch {
+      showError("I couldn't add that place. Want to try again?");
+    }
+  }
+
+  async function handleConfirmDelete() {
+    const placeId = confirmDeleteId;
+    if (!placeId) return;
+    setConfirmDeleteId(null);
+    try {
+      await deletePlace({ manualId, placeId }).unwrap();
+      showSuccess("Place removed.");
+    } catch {
+      showError("I couldn't remove that place. Want to try again?");
+    }
+  }
+
+  async function handlePlaceSave(
+    placeId: string,
+    changes: {
+      name?: string;
+      cuisine?: string;
+      price_tier?: "$" | "$$" | "$$$" | null;
+      note?: string | null;
+      map_url?: string | null;
+    },
+  ) {
+    try {
+      await updatePlace({ manualId, placeId, ...changes }).unwrap();
+    } catch {
+      showError("I couldn't save that place. Want to try again?");
+    }
+  }
+
+  return (
+    <div className="space-y-3" data-testid="welcome-manual-place-manager">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-foreground">Where to Eat</h2>
+          <p className="text-xs text-muted-foreground">
+            {atCap
+              ? `You've reached the ${WELCOME_MANUAL_MAX_PLACES}-place limit for this manual.`
+              : `${sortedPlaces.length} ${sortedPlaces.length === 1 ? "place" : "places"}`}
+          </p>
+        </div>
+        <LoadingButton
+          variant="secondary"
+          size="sm"
+          isLoading={isAdding}
+          loadingText="Adding…"
+          onClick={handleAdd}
+          disabled={atCap}
+          type="button"
+          data-testid="welcome-manual-place-add-button"
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          Add place
+        </LoadingButton>
+      </div>
+
+      {sortedPlaces.length === 0 ? (
+        <p
+          className="text-sm text-muted-foreground border rounded-lg p-6 text-center"
+          data-testid="welcome-manual-place-empty-state"
+        >
+          No places yet. Add restaurants and spots guests should check out.
+        </p>
+      ) : (
+        <ul className="space-y-2 list-none" data-testid="welcome-manual-place-list">
+          {sortedPlaces.map((place) => (
+            <WelcomeManualPlaceCard
+              key={place.id}
+              place={place}
+              cuisineOptions={cuisineOptions}
+              onDelete={() => setConfirmDeleteId(place.id)}
+              onNameSave={(name) => void handlePlaceSave(place.id, { name })}
+              onCuisineSave={(cuisine) => void handlePlaceSave(place.id, { cuisine })}
+              onPriceTierChange={(price_tier) =>
+                void handlePlaceSave(place.id, { price_tier })
+              }
+              onNoteSave={(note) => void handlePlaceSave(place.id, { note: note || null })}
+              onMapUrlSave={(mapUrl) =>
+                void handlePlaceSave(place.id, { map_url: mapUrl || null })
+              }
+            />
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        open={!!confirmDeleteId}
+        title="Remove this place?"
+        description="The place will be removed from this manual. This can't be undone."
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        variant="danger"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPreview.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualPreview.tsx
@@ -1,11 +1,14 @@
 import Markdown from "@/shared/components/ui/Markdown";
+import type { WelcomeManualPlaceResponse } from "@/shared/types/welcome-manual/welcome-manual-place-response";
 import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+import WelcomeManualPlaceDirectory from "./WelcomeManualPlaceDirectory";
 
 export interface WelcomeManualPreviewProps {
   title: string;
   introText: string | null;
   /** Sections already sorted by display_order. */
   sections: WelcomeManualSectionResponse[];
+  places: WelcomeManualPlaceResponse[];
 }
 
 /**
@@ -22,6 +25,7 @@ export default function WelcomeManualPreview({
   title,
   introText,
   sections,
+  places,
 }: WelcomeManualPreviewProps) {
   return (
     <article
@@ -104,6 +108,8 @@ export default function WelcomeManualPreview({
           Add sections to see them here.
         </p>
       )}
+
+      <WelcomeManualPlaceDirectory places={places} />
     </article>
   );
 }

--- a/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
@@ -31,6 +31,7 @@ import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual
 import WelcomeManualDetailSkeleton from "@/app/features/welcome-manuals/WelcomeManualDetailSkeleton";
 import WelcomeManualSectionCard from "@/app/features/welcome-manuals/WelcomeManualSectionCard";
 import WelcomeManualPreview from "@/app/features/welcome-manuals/WelcomeManualPreview";
+import WelcomeManualPlaceManager from "@/app/features/welcome-manuals/WelcomeManualPlaceManager";
 import WelcomeManualForm from "@/app/features/welcome-manuals/WelcomeManualForm";
 import WelcomeManualEmailDialog from "@/app/features/welcome-manuals/WelcomeManualEmailDialog";
 import DeleteWelcomeManualModal from "@/app/features/welcome-manuals/DeleteWelcomeManualModal";
@@ -304,6 +305,13 @@ export default function WelcomeManualDetail() {
                   Add section
                 </LoadingButton>
               </div>
+
+              <section
+                className="border rounded-lg p-4 space-y-3 bg-card"
+                data-testid="welcome-manual-places-card"
+              >
+                <WelcomeManualPlaceManager manualId={manual.id} places={manual.places ?? []} />
+              </section>
             </div>
 
             <div
@@ -320,6 +328,7 @@ export default function WelcomeManualDetail() {
                   title={manual.title}
                   introText={manual.intro_text}
                   sections={sortedSections}
+                  places={manual.places ?? []}
                 />
               </div>
             </div>

--- a/apps/mybookkeeper/frontend/src/shared/lib/welcome-manual-constants.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/welcome-manual-constants.ts
@@ -37,3 +37,12 @@ export const WELCOME_MANUAL_VIEW_MODE = {
 
 export type WelcomeManualViewMode =
   (typeof WELCOME_MANUAL_VIEW_MODE)[keyof typeof WELCOME_MANUAL_VIEW_MODE];
+
+/** Max "Where to Eat" places allowed per manual. */
+export const WELCOME_MANUAL_MAX_PLACES = 200;
+
+/** Price tiers a place can be tagged with, in ascending order. */
+export const WELCOME_MANUAL_PRICE_TIERS = ["$", "$$", "$$$"] as const;
+
+/** Default name applied to a freshly-added place before the host renames it. */
+export const NEW_PLACE_DEFAULT_NAME = "New place";

--- a/apps/mybookkeeper/frontend/src/shared/store/welcomeManualsApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/welcomeManualsApi.ts
@@ -3,6 +3,7 @@ import type { WelcomeManualCreateRequest } from "@/shared/types/welcome-manual/w
 import type { WelcomeManualEmailRequest } from "@/shared/types/welcome-manual/welcome-manual-email-request";
 import type { WelcomeManualListArgs } from "@/shared/types/welcome-manual/welcome-manual-list-args";
 import type { WelcomeManualListResponse } from "@/shared/types/welcome-manual/welcome-manual-list-response";
+import type { WelcomeManualPlaceResponse } from "@/shared/types/welcome-manual/welcome-manual-place-response";
 import type { WelcomeManualResponse } from "@/shared/types/welcome-manual/welcome-manual-response";
 import type { WelcomeManualSectionCreateRequest } from "@/shared/types/welcome-manual/welcome-manual-section-create-request";
 import type { WelcomeManualSectionFieldResponse } from "@/shared/types/welcome-manual/welcome-manual-section-field-response";
@@ -226,6 +227,67 @@ const welcomeManualsApi = baseApi.injectEndpoints({
         { type: "WelcomeManual", id: arg.manualId },
       ],
     }),
+    // ---- Places (Where to Eat) ----
+    createPlace: builder.mutation<
+      WelcomeManualPlaceResponse,
+      {
+        manualId: string;
+        data: {
+          name: string;
+          cuisine: string;
+          price_tier?: "$" | "$$" | "$$$" | null;
+          note?: string | null;
+          map_url?: string | null;
+        };
+      }
+    >({
+      query: ({ manualId, data }) => ({
+        url: `/welcome-manuals/${manualId}/places`,
+        method: "POST",
+        data,
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+    updatePlace: builder.mutation<
+      WelcomeManualPlaceResponse,
+      {
+        manualId: string;
+        placeId: string;
+        name?: string;
+        cuisine?: string;
+        price_tier?: "$" | "$$" | "$$$" | null;
+        note?: string | null;
+        map_url?: string | null;
+        display_order?: number;
+      }
+    >({
+      query: ({ manualId, placeId, name, cuisine, price_tier, note, map_url, display_order }) => ({
+        url: `/welcome-manuals/${manualId}/places/${placeId}`,
+        method: "PATCH",
+        data: {
+          ...(name !== undefined ? { name } : {}),
+          ...(cuisine !== undefined ? { cuisine } : {}),
+          ...(price_tier !== undefined ? { price_tier } : {}),
+          ...(note !== undefined ? { note } : {}),
+          ...(map_url !== undefined ? { map_url } : {}),
+          ...(display_order !== undefined ? { display_order } : {}),
+        },
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+    deletePlace: builder.mutation<void, { manualId: string; placeId: string }>({
+      query: ({ manualId, placeId }) => ({
+        url: `/welcome-manuals/${manualId}/places/${placeId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
   }),
 });
 
@@ -246,4 +308,7 @@ export const {
   useCreateSectionFieldMutation,
   useUpdateSectionFieldMutation,
   useDeleteSectionFieldMutation,
+  useCreatePlaceMutation,
+  useUpdatePlaceMutation,
+  useDeletePlaceMutation,
 } = welcomeManualsApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-place-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-place-response.ts
@@ -1,0 +1,16 @@
+/**
+ * Mirrors backend `PlaceResponse`. A place is a restaurant recommendation
+ * parented directly to the manual (not to a section) — guests browse the
+ * flat list via the "Where to Eat" directory.
+ */
+export interface WelcomeManualPlaceResponse {
+  id: string;
+  manual_id: string;
+  name: string;
+  cuisine: string;
+  price_tier: "$" | "$$" | "$$$" | null;
+  note: string | null;
+  map_url: string | null;
+  display_order: number;
+  created_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-response.ts
@@ -1,8 +1,10 @@
+import type { WelcomeManualPlaceResponse } from "./welcome-manual-place-response";
 import type { WelcomeManualSectionResponse } from "./welcome-manual-section-response";
 
 /**
  * Mirrors backend `WelcomeManualResponse` — the full detail payload with
- * ordered sections (each carrying its ordered images).
+ * ordered sections (each carrying its ordered images) and the flat list of
+ * "Where to Eat" places parented directly to the manual.
  */
 export interface WelcomeManualResponse {
   id: string;
@@ -12,6 +14,7 @@ export interface WelcomeManualResponse {
   title: string;
   intro_text: string | null;
   sections: WelcomeManualSectionResponse[];
+  places: WelcomeManualPlaceResponse[];
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## What

A filterable **guest-facing dining directory** on welcome manuals. Tenants can search recommendations and filter by **cuisine** and **price** instead of scanning a flat list of links — the original ask ("easily searchable… not just a Google link of a bunch of places").

Places attach directly to the manual (one directory, no section clutter). Filtering is entirely client-side; the backend is plain scoped CRUD.

## Backend

- **`WelcomeManualPlace`** model — child of `welcome_manuals`, cascade-deleted. `price_tier` is an enum enforced via `String(4)` + `CheckConstraint` generated from the shared `WELCOME_MANUAL_PRICE_TIERS` tuple (stays in lockstep with the frontend union). Composite `(manual_id, display_order)` index; UUID pk; tz-aware `created_at`.
- **Routes** `POST` / `PATCH` / `DELETE` `.../{manual_id}/places[/{place_id}]` — org → manual scope re-verified on every operation; `manual_id` immutable post-create (allowlist frozenset). 200-place cap → 409.
- **`map_url`** restricted to `http(s)` at the Pydantic layer (create + update) so a stored `javascript:`/`data:` scheme can never become a guest-facing `href`.
- Explicit `null` `display_order` is dropped (NOT NULL column) rather than surfacing as a 500.
- Alembic migration `wmanualplace260721` (single head, verified).

## Frontend

- **Admin editor** (`WelcomeManualPlaceManager` / `Card`) — blur-save fields, 3-way price toggle, cuisine `<datalist>`, add/edit/delete with confirm. 44px touch targets, `LoadingButton` click-time feedback.
- **Guest directory** (`WelcomeManualPlaceDirectory`) — search + single-select genre chips + price chips, grouped-by-cuisine results, self-hides when empty. `buildMapHref` only emits `http(s)` URLs, else falls back to a name search.
- RTK Query create/update/delete mutations invalidating the parent manual tag.

## Tests

- Backend repo + route tests (incl. `map_url` scheme rejection → 422, null `display_order` no-op, tenant/manual scoping). **193 welcome-manual backend tests pass.**
- Frontend vitest (**35 pass**), tsc + eslint clean.
- E2E layout spec covering the genre/price filter flow.

Pre-commit review (`g-pre-commit`) ran clean after addressing the two real findings (map_url scheme validation, null display_order 500) plus cleanups (removed a dead constant, redundant index, aligned the service to the sibling's no-ORM-import convention).

## Deferred by design

Schema accommodates but not built this PR: **per-place food photos** (future `welcome_manual_place_images` child table) and **must-have dishes** (future additive column/child).

## Follow-up (not in this PR)

After merge + deploy, seed ~53 classified Houston restaurants into the production manual via the authenticated API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FsqAaqcyT2RT4eWZ6LNX4