### PR TITLE
feat(mga): pin-editor UX — hover-to-locate pins, row↔editor link, landing reference

### DIFF
--- a/apps/mygamingassistant/frontend/src/__tests__/LineupListRow.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupListRow.test.tsx
@@ -1,9 +1,8 @@
 /**
  * LineupListRow unit tests — compact-list-row primitive.
  *
- * Stub IntersectionObserver + HTMLMediaElement methods because the expanded
- * state mounts GlanceBoardTile, and further expanding THAT mounts
- * GlanceBoardStoryboard's <video>-bearing panes.
+ * Stub IntersectionObserver + HTMLMediaElement methods because a single row
+ * click mounts GlanceBoardStoryboard's <video>-bearing panes directly.
  */
 import { render, screen, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -172,7 +171,7 @@ describe("LineupListRow", () => {
     expect(thumbs).toContain("https://ex.com/landing-thumb.png");
   });
 
-  it("expands on click and mounts the GlanceBoardTile summary (STAND + LANDING, no AIM/THROW yet)", () => {
+  it("expands on click and mounts the full 4-pane storyboard directly (STAND / AIM / THROW / LANDING)", () => {
     render(<LineupListRow lineup={makeLineup()} game={GAME} />);
     const button = screen.getByRole("button", { name: /click to expand/i });
     expect(button).toHaveAttribute("aria-expanded", "false");
@@ -180,23 +179,30 @@ describe("LineupListRow", () => {
     fireEvent.click(button);
     expect(button).toHaveAttribute("aria-expanded", "true");
 
-    // The mounted tile is the 2-still summary, not the full storyboard.
+    // A single row click now mounts the full storyboard directly — all four
+    // panes, no intermediate summary-tile step.
     expect(screen.getByText("STAND")).toBeInTheDocument();
-    expect(screen.getByText("LANDING")).toBeInTheDocument();
-    expect(screen.queryByText("AIM")).not.toBeInTheDocument();
-    expect(screen.queryByText("THROW")).not.toBeInTheDocument();
-  });
-
-  it("expanding the row then expanding the mounted tile reveals the full storyboard", () => {
-    render(<LineupListRow lineup={makeLineup()} game={GAME} />);
-    fireEvent.click(screen.getByRole("button", { name: /click to expand/i }));
-    // Second, independent expand toggle owned by GlanceBoardTile itself.
-    fireEvent.click(screen.getByRole("button", { name: /^expand/i }));
     expect(screen.getByText("AIM")).toBeInTheDocument();
     expect(screen.getByText("THROW")).toBeInTheDocument();
+    expect(screen.getByText("LANDING")).toBeInTheDocument();
   });
 
-  it("collapses on second click — unmounts the summary tile", () => {
+  it("fires onHover with the lineup id on pointer-enter and null on leave", () => {
+    const onHover = vi.fn();
+    const lineup = makeLineup();
+    const { container } = render(
+      <LineupListRow lineup={lineup} game={GAME} onHover={onHover} />,
+    );
+    const row = container.firstChild as HTMLElement;
+
+    fireEvent.mouseEnter(row);
+    expect(onHover).toHaveBeenLastCalledWith(lineup.id);
+
+    fireEvent.mouseLeave(row);
+    expect(onHover).toHaveBeenLastCalledWith(null);
+  });
+
+  it("collapses on second click — unmounts the storyboard", () => {
     render(<LineupListRow lineup={makeLineup()} game={GAME} />);
     const button = screen.getByRole("button", { name: /click to expand/i });
     fireEvent.click(button);

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardMinimapSidebar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardMinimapSidebar.tsx
@@ -43,6 +43,9 @@ interface Props {
   lineups?: Lineup[];
   pinMode?: PinMode | null;
   selectedLineupId?: string | null;
+  /** Lineup hovered in the list — forwarded to MapLineupPins so its pin(s)
+   *  get a hover halo. Null when nothing is hovered. */
+  highlightedLineupId?: string | null;
   onPinSelect?: (lineupId: string) => void;
 }
 
@@ -84,6 +87,7 @@ export default function GlanceBoardMinimapSidebar({
   lineups,
   pinMode = null,
   selectedLineupId = null,
+  highlightedLineupId = null,
   onPinSelect,
 }: Props) {
   const [minimapFailed, setMinimapFailed] = useState(false);
@@ -230,6 +234,7 @@ export default function GlanceBoardMinimapSidebar({
           lineups={lineups}
           mode={pinMode}
           selectedLineupId={selectedLineupId}
+          highlightedLineupId={highlightedLineupId}
           onPinSelect={onPinSelect}
           viewBoxSize={viewBoxSize}
         />

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupListBoard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupListBoard.tsx
@@ -30,6 +30,13 @@ interface LineupListBoardProps {
   game?: Game | null;
   knobs?: DesignKnobs;
   showOperatorOverlays?: boolean;
+  /** Fired with a lineup id when a row is hovered, null on leave — lets
+   *  MapPage highlight the matching minimap pin(s). */
+  onLineupHover?: (lineupId: string | null) => void;
+  /** Lineup currently open in the pin editor (?edit=<id>). The matching row
+   *  highlights + scrolls into view so the operator can see which lineup the
+   *  editor panel is bound to. Null when no lineup is being edited. */
+  editingLineupId?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -128,6 +135,8 @@ export default function LineupListBoard({
   game,
   knobs = DEFAULT_KNOBS,
   showOperatorOverlays = false,
+  onLineupHover,
+  editingLineupId = null,
 }: LineupListBoardProps) {
   const groups = useMemo(() => groupByZone(lineups), [lineups]);
 
@@ -174,6 +183,8 @@ export default function LineupListBoard({
                 game={game}
                 knobs={knobs}
                 showOperatorOverlays={showOperatorOverlays}
+                onHover={onLineupHover}
+                isEditing={lineup.id === editingLineupId}
               />
             ))}
           </div>

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupListRow.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupListRow.tsx
@@ -1,9 +1,8 @@
 /**
  * LineupListRow — compact one-line row for the list-view rendering of the
- * glance board. Click anywhere on the row to expand the GlanceBoardTile
- * summary tile (2-still STAND/LANDING, no motion) inline below the row —
- * the tile's own expand toggle reveals the full 4-pane storyboard from
- * there, same as it does on the grid glance board.
+ * glance board. Click anywhere on the row to expand the full 4-pane
+ * GlanceBoardStoryboard (STAND / AIM / THROW / LANDING) inline below the
+ * row directly — a single click, no intermediate summary-tile step.
  *
  * Why the list view exists: the default card-grid renders every lineup
  * card as a full 4-pane storyboard, which mounts up to 4 simultaneous
@@ -19,20 +18,19 @@
  *   ┌─────────────────────────────────────────────────────────────────┐
  *   │ [icon] [stand→landing thumbs] Target ← Stand  · Side · Util  [▾]│
  *   └─────────────────────────────────────────────────────────────────┘
- *   (expanded below: GlanceBoardTile — the 2-still summary tile, which
- *   itself has its own expand toggle for the full 4-pane storyboard)
+ *   (expanded below: GlanceBoardStoryboard — the full 4-pane storyboard)
  *
  * Expansion state lives in this component (useState) — the board does
  * NOT track which rows are expanded; multiple rows can be expanded
  * simultaneously and the operator chooses freely.
  */
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
 import type { Lineup } from "@/types/game";
 import type { Game } from "@/types/game";
 import { lineupUtilDisplay } from "@/constants/agentDisplay";
 import { sideDisplay } from "@/constants/sideDisplay";
-import GlanceBoardTile from "./GlanceBoardTile";
+import GlanceBoardStoryboard from "./GlanceBoardStoryboard";
 import { MiniPosterThumb } from "./LineupStillPreview";
 import type { DesignKnobs } from "@/hooks/useDesignKnobs";
 import { DEFAULT_KNOBS } from "@/hooks/useDesignKnobs";
@@ -42,6 +40,13 @@ interface LineupListRowProps {
   game?: Game | null;
   knobs?: DesignKnobs;
   showOperatorOverlays?: boolean;
+  /** Fired with this lineup's id on pointer-enter and null on pointer-leave,
+   *  so the parent can highlight the matching minimap pin(s). */
+  onHover?: (lineupId: string | null) => void;
+  /** True when this lineup is the one open in the pin editor (?edit=<id>).
+   *  Highlights the row, badges it "EDITING", and scrolls it into view so the
+   *  operator can see which list row the editor panel is bound to. */
+  isEditing?: boolean;
 }
 
 export default function LineupListRow({
@@ -49,8 +54,20 @@ export default function LineupListRow({
   game,
   knobs = DEFAULT_KNOBS,
   showOperatorOverlays = false,
+  onHover,
+  isEditing = false,
 }: LineupListRowProps) {
   const [expanded, setExpanded] = useState(false);
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  // When this row becomes the edited lineup, scroll it into the middle of the
+  // viewport so the operator's eye lands on it right after the editor panel
+  // opens on the left. Only fires on the isEditing→true transition.
+  useEffect(() => {
+    if (isEditing) {
+      rowRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [isEditing]);
 
   const target = lineup.target_zone?.name ?? "Unknown";
   const stand = lineup.stand_zone?.name ?? null;
@@ -70,14 +87,35 @@ export default function LineupListRow({
   })();
 
   return (
-    <div className="border-b last:border-b-0">
+    <div
+      ref={rowRef}
+      className={[
+        "border-b last:border-b-0 scroll-mt-16",
+        // Strong, unmistakable highlight when this row is the one bound to the
+        // open pin editor — left accent bar + tinted background.
+        isEditing && "border-l-4 border-l-primary bg-primary/10",
+      ].filter(Boolean).join(" ")}
+      onMouseEnter={() => onHover?.(lineup.id)}
+      onMouseLeave={() => onHover?.(null)}
+    >
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        aria-label={`${target}${stand ? ` from ${stand}` : ""} — ${util.chipLabel} — ${sideCfg.label} side. Click to ${expanded ? "collapse" : "expand"} storyboard.`}
-        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/30 transition-colors min-h-[44px]"
+        aria-label={`${target}${stand ? ` from ${stand}` : ""} — ${util.chipLabel} — ${sideCfg.label} side.${isEditing ? " Currently open in the pin editor." : ""} Click to ${expanded ? "collapse" : "expand"} storyboard.`}
+        className={[
+          "w-full flex items-center gap-2 px-3 py-2 text-left transition-colors min-h-[44px]",
+          isEditing ? "hover:bg-primary/15" : "hover:bg-muted/30",
+        ].join(" ")}
       >
+        {/* "EDITING" pill — only on the row bound to the open pin editor, so
+            the editor panel ("Editing pin — <title>") and this list row are
+            unmistakably the same lineup. */}
+        {isEditing && (
+          <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold tracking-wide uppercase bg-primary text-primary-foreground">
+            Editing
+          </span>
+        )}
         {/* Utility color dot — reuses the badge tokens from utilDisplay so
             row color-coding matches the storyboard tile's header chip. */}
         <span
@@ -154,17 +192,21 @@ export default function LineupListRow({
         />
       </button>
 
-      {/* Inline expanded storyboard — only mounts (and therefore only
-          attaches video decoders) when the row is expanded. Collapse
-          unmounts the tile so the decoders are released. This is the
-          whole point of the list view. */}
+      {/* Inline expanded storyboard — a single row click opens the full
+          4-pane storyboard (STAND / AIM / THROW / LANDING) directly, no
+          intermediate summary-tile step. Only mounts (and therefore only
+          attaches video decoders) when the row is expanded; collapse
+          unmounts it so the decoders are released. This is the whole point
+          of the list view — decoding is still deferred to clicked rows. */}
       {expanded && (
         <div className="px-3 pb-3 pt-1">
-          <GlanceBoardTile
-            lineup={lineup}
-            knobs={knobs}
-            showOperatorOverlays={showOperatorOverlays}
-          />
+          <div className="rounded-lg border bg-card overflow-hidden">
+            <GlanceBoardStoryboard
+              lineup={lineup}
+              knobs={knobs}
+              showOperatorOverlays={showOperatorOverlays}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupStillPreview.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupStillPreview.tsx
@@ -99,19 +99,20 @@ export default function LineupStillPreview({ lineup }: LineupStillPreviewProps) 
 }
 
 // ---------------------------------------------------------------------------
-// MiniPosterThumb — ~32x18px (16:9) thumbnail for LineupListRow's compact
-// text row. Always aria-hidden: the row's own aria-label already states the
-// target/stand zone names, so a redundant accessible name here would just
-// be noise for screen-reader users.
+// MiniPosterThumb — 128x72px (16:9) thumbnail for LineupListRow's compact
+// text row. Large enough to actually read the stand/landing framing at a
+// glance without expanding the row. Always aria-hidden: the row's own
+// aria-label already states the target/stand zone names, so a redundant
+// accessible name here would just be noise for screen-reader users.
 // ---------------------------------------------------------------------------
 export function MiniPosterThumb({ url }: { url: string | null }) {
   if (!url) {
     return (
       <span
         aria-hidden
-        className="inline-flex items-center justify-center w-8 h-[18px] shrink-0 rounded-sm bg-muted/40"
+        className="inline-flex items-center justify-center w-32 h-[72px] shrink-0 rounded bg-muted/40"
       >
-        <ImageOff className="w-3 h-3 text-muted-foreground/50" />
+        <ImageOff className="w-5 h-5 text-muted-foreground/50" />
       </span>
     );
   }
@@ -120,7 +121,7 @@ export function MiniPosterThumb({ url }: { url: string | null }) {
       src={url}
       alt=""
       aria-hidden
-      className="w-8 h-[18px] shrink-0 rounded-sm object-cover"
+      className="w-32 h-[72px] shrink-0 rounded object-cover"
       draggable={false}
       loading="lazy"
       decoding="async"

--- a/apps/mygamingassistant/frontend/src/components/lineup/MapBoardBody.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/MapBoardBody.tsx
@@ -1,0 +1,102 @@
+/**
+ * MapBoardBody — the main content region of MapPage: picks between the
+ * filtered-empty state, the list-view board, and the grid glance board.
+ *
+ * Extracted from MapPage so the page component stays under the file-size
+ * budget; the three-way choice is self-contained and only needs the visible
+ * lineup set, the current filter/view params, and a clear-filters callback.
+ */
+import GlanceBoard from "@/components/lineup/GlanceBoard";
+import LineupListBoard from "@/components/lineup/LineupListBoard";
+import type { Lineup, Game } from "@/types/game";
+import type { DesignKnobs } from "@/hooks/useDesignKnobs";
+
+interface Props {
+  lineups: Lineup[];
+  isFetching: boolean;
+  mapName: string;
+  filteredUtils: string[];
+  side: string;
+  sideA: string;
+  sideB: string;
+  activeZoneName: string | null;
+  /** True when any filter (util/side/zone/agent) is narrowing the set — drives
+   *  the "no matches, clear filters" empty state vs the truly-empty map. */
+  hasActiveFilter: boolean;
+  viewMode: "list" | "grid";
+  game?: Game | null;
+  knobs?: DesignKnobs;
+  showOperatorOverlays: boolean;
+  /** Hovered list row → highlight its pin(s) on the minimap. */
+  onLineupHover: (lineupId: string | null) => void;
+  /** Lineup open in the pin editor (?edit=) → highlight + scroll its row. */
+  editingLineupId: string | null;
+  onClearFilters: () => void;
+}
+
+export default function MapBoardBody({
+  lineups,
+  isFetching,
+  mapName,
+  filteredUtils,
+  side,
+  sideA,
+  sideB,
+  activeZoneName,
+  hasActiveFilter,
+  viewMode,
+  game,
+  knobs,
+  showOperatorOverlays,
+  onLineupHover,
+  editingLineupId,
+  onClearFilters,
+}: Props) {
+  if (lineups.length === 0 && !isFetching && hasActiveFilter) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-3">
+        <p className="text-sm text-muted-foreground text-center">
+          No{filteredUtils.length > 0 ? ` ${filteredUtils.join("/")}` : ""} lineups
+          {side !== "any" ? ` for ${side === "side_a" ? sideA : sideB}` : ""}
+          {activeZoneName ? ` in ${activeZoneName}` : ""}.
+        </p>
+        <button
+          type="button"
+          onClick={onClearFilters}
+          className="text-sm text-primary hover:underline"
+        >
+          Clear filters
+        </button>
+      </div>
+    );
+  }
+
+  if (viewMode === "list") {
+    return (
+      <LineupListBoard
+        lineups={lineups}
+        isFetching={isFetching}
+        mapName={mapName}
+        filteredUtils={filteredUtils}
+        side={side}
+        game={game}
+        knobs={knobs}
+        showOperatorOverlays={showOperatorOverlays}
+        onLineupHover={onLineupHover}
+        editingLineupId={editingLineupId}
+      />
+    );
+  }
+
+  return (
+    <GlanceBoard
+      lineups={lineups}
+      isFetching={isFetching}
+      mapName={mapName}
+      filteredUtils={filteredUtils}
+      side={side}
+      knobs={knobs}
+      showOperatorOverlays={showOperatorOverlays}
+    />
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/lineup/MapLineupPins.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/MapLineupPins.tsx
@@ -25,6 +25,12 @@ interface Props {
   mode: PinMode;
   selectedLineupId: string | null;
   onPinSelect: (lineupId: string) => void;
+  /** Lineup currently hovered in the list — its pin(s) get a steady halo +
+   *  enlargement so the operator can see where a row lands on the map without
+   *  clicking. Distinct from ``selectedLineupId`` (the click-select ping):
+   *  hover is a transient pointer cue, selection is a committed choice, and
+   *  both can be active at once. Null when nothing is hovered. */
+  highlightedLineupId?: string | null;
   /** viewBox dimensions — defaults to 1000 (matches MapZoneOverlay). */
   viewBoxSize?: number;
 }
@@ -35,6 +41,14 @@ const CLUSTER_THRESHOLD = 30;
 const STAND_FILL = "#3b82f6"; // blue-500
 const TARGET_FILL = "#f97316"; // orange-500
 const MIXED_FILL = "#71717a"; // zinc-500 when a cluster spans both modes
+
+// Hover-highlight accent. Deliberately NOT the pin's own fill (a same-color
+// halo blends into the dot and is invisible) — a bright high-contrast yellow
+// reads against blue pins, orange pins, and the map underneath alike.
+const HIGHLIGHT_ACCENT = "#fde047"; // yellow-300
+// Opacity every non-hovered pin drops to while a row is hovered, so the
+// matching pin pops out of the crowd instead of being one dot among many.
+const DIMMED_OPACITY = 0.2;
 
 type PinKind = "stand" | "target";
 
@@ -149,11 +163,17 @@ export default function MapLineupPins({
   mode,
   selectedLineupId,
   onPinSelect,
+  highlightedLineupId = null,
   viewBoxSize = 1000,
 }: Props) {
   const pins = useMemo(() => buildPins(lineups, mode, viewBoxSize), [lineups, mode, viewBoxSize]);
   const clusters = useMemo(() => buildClusters(pins), [pins]);
   const [openClusterIndex, setOpenClusterIndex] = useState<number | null>(null);
+
+  // When any row is hovered, every non-matching pin dims so the highlighted
+  // one stands out. Cheap "spotlight" effect that reads far better than a
+  // per-pin halo alone.
+  const anyHighlighted = highlightedLineupId != null;
 
   if (pins.length === 0) return null;
 
@@ -169,6 +189,7 @@ export default function MapLineupPins({
           if (cluster.pins.length === 1) {
             const p = cluster.pins[0];
             const isSelected = p.lineupId === selectedLineupId;
+            const isHighlighted = p.lineupId === highlightedLineupId;
             const fill = pinFill(p.kind);
             return (
               <g
@@ -176,7 +197,8 @@ export default function MapLineupPins({
                 tabIndex={0}
                 role="button"
                 aria-label={`Open lineup: ${p.title}`}
-                className="pointer-events-auto cursor-pointer focus:outline-none"
+                className="pointer-events-auto cursor-pointer focus:outline-none transition-opacity duration-150"
+                style={{ opacity: anyHighlighted && !isHighlighted ? DIMMED_OPACITY : 1 }}
                 onClick={() => onPinSelect(p.lineupId)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
@@ -186,7 +208,7 @@ export default function MapLineupPins({
                 }}
               >
                 <circle cx={p.x} cy={p.y} r={22} fill="transparent" />
-                {p.isGuess && (
+                {p.isGuess && !isHighlighted && (
                   <circle
                     cx={p.x}
                     cy={p.y}
@@ -197,6 +219,29 @@ export default function MapLineupPins({
                     strokeDasharray="4 3"
                     opacity={0.5}
                   />
+                )}
+                {/* Hover highlight — a bright yellow glow + ring in a color
+                    the pin ISN'T, so it can't blend in. Pulses (opacity only,
+                    no expansion) to catch the eye and stay distinct from the
+                    click-select ping below (which expands + fades). */}
+                {isHighlighted && (
+                  <>
+                    <circle
+                      cx={p.x}
+                      cy={p.y}
+                      r={26}
+                      fill={HIGHLIGHT_ACCENT}
+                      className="opacity-30 animate-pulse"
+                    />
+                    <circle
+                      cx={p.x}
+                      cy={p.y}
+                      r={20}
+                      fill="none"
+                      stroke={HIGHLIGHT_ACCENT}
+                      strokeWidth={5}
+                    />
+                  </>
                 )}
                 {isSelected && (
                   <circle
@@ -212,11 +257,11 @@ export default function MapLineupPins({
                 <circle
                   cx={p.x}
                   cy={p.y}
-                  r={isSelected ? 12 : 10}
+                  r={isHighlighted ? 16 : isSelected ? 12 : 10}
                   fill={fill}
-                  stroke="white"
-                  strokeWidth={2}
-                  className="transition-transform duration-150"
+                  stroke={isHighlighted ? HIGHLIGHT_ACCENT : "white"}
+                  strokeWidth={isHighlighted ? 4 : 2}
+                  className="transition-all duration-150"
                 />
               </g>
             );
@@ -228,10 +273,17 @@ export default function MapLineupPins({
           const containsSelected =
             selectedLineupId != null &&
             cluster.pins.some((p) => p.lineupId === selectedLineupId);
+          const containsHighlighted =
+            highlightedLineupId != null &&
+            cluster.pins.some((p) => p.lineupId === highlightedLineupId);
           const isOpen = openClusterIndex === i;
 
           return (
-            <g key={`cluster-${i}`} className="pointer-events-auto">
+            <g
+              key={`cluster-${i}`}
+              className="pointer-events-auto transition-opacity duration-150"
+              style={{ opacity: anyHighlighted && !containsHighlighted ? DIMMED_OPACITY : 1 }}
+            >
               <g
                 tabIndex={0}
                 role="button"
@@ -248,6 +300,28 @@ export default function MapLineupPins({
                 }}
               >
                 <circle cx={cluster.cx} cy={cluster.cy} r={22} fill="transparent" />
+                {/* Hover highlight when a hovered row's pin lives inside this
+                    cluster — bright yellow glow + ring, same language as the
+                    single pin so a stacked target is just as easy to spot. */}
+                {containsHighlighted && (
+                  <>
+                    <circle
+                      cx={cluster.cx}
+                      cy={cluster.cy}
+                      r={28}
+                      fill={HIGHLIGHT_ACCENT}
+                      className="opacity-30 animate-pulse"
+                    />
+                    <circle
+                      cx={cluster.cx}
+                      cy={cluster.cy}
+                      r={22}
+                      fill="none"
+                      stroke={HIGHLIGHT_ACCENT}
+                      strokeWidth={5}
+                    />
+                  </>
+                )}
                 {containsSelected && (
                   <circle
                     cx={cluster.cx}
@@ -262,10 +336,10 @@ export default function MapLineupPins({
                 <circle
                   cx={cluster.cx}
                   cy={cluster.cy}
-                  r={14}
+                  r={containsHighlighted ? 17 : 14}
                   fill={fill}
-                  stroke="white"
-                  strokeWidth={2}
+                  stroke={containsHighlighted ? HIGHLIGHT_ACCENT : "white"}
+                  strokeWidth={containsHighlighted ? 4 : 2}
                 />
                 <text
                   x={cluster.cx}

--- a/apps/mygamingassistant/frontend/src/components/lineup/MapSpatialSidebar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/MapSpatialSidebar.tsx
@@ -30,6 +30,9 @@ interface Props {
   pinMode: PinMode | null;
   onPinModeChange: (next: PinMode | null) => void;
   isSuperuser: boolean;
+  /** Lineup hovered in the list board — forwarded to the minimap so its
+   *  pin(s) highlight. Null when nothing is hovered. */
+  highlightedLineupId?: string | null;
 }
 
 export default function MapSpatialSidebar({
@@ -42,6 +45,7 @@ export default function MapSpatialSidebar({
   pinMode,
   onPinModeChange,
   isSuperuser,
+  highlightedLineupId = null,
 }: Props) {
   const editor = usePinEditor({ lineups, isSuperuser });
 
@@ -73,10 +77,16 @@ export default function MapSpatialSidebar({
         lineups={lineups}
         pinMode={pinMode}
         selectedLineupId={editor.selectedLineupId}
+        highlightedLineupId={highlightedLineupId}
         onPinSelect={handlePinSelect}
       />
 
-      {isSuperuser && pinMode && (
+      {/* Show the editor whenever a lineup is selected for editing (via an
+          ?edit= deep link or a pin click) — NOT only when the Pins toggle is
+          on. Arriving at ?edit=<id> should open the editor directly; requiring
+          the operator to first flip the Pins toggle off "Off" was a hidden
+          gate that made deep links appear to do nothing. */}
+      {isSuperuser && (pinMode || editor.selectedLineup) && (
         <PinEditPanel editor={editor} minimapUrl={minimapUrl} />
       )}
     </div>

--- a/apps/mygamingassistant/frontend/src/components/lineup/PinEditPanel.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/PinEditPanel.tsx
@@ -76,6 +76,98 @@ export default function PinEditPanel({ editor, minimapUrl }: Props) {
         </button>
       </div>
 
+      {/* Save actions — placed directly under the header so they're visible the
+          instant the panel opens, no scrolling past the (tall) in-game frame +
+          map. The operator drags the pin below, then scrolls back here to Save.
+          Sticky-at-bottom was unreliable in the scrollable sidebar. */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => save(false)}
+          disabled={isSaving}
+          className="flex-1 inline-flex items-center justify-center gap-1.5 h-9 rounded-md bg-primary px-2 text-xs font-semibold text-primary-foreground hover:enabled:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          {isSaving ? (
+            "Saving…"
+          ) : (
+            <>
+              <Check className="w-4 h-4" aria-hidden />
+              Save
+            </>
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => save(true)}
+          disabled={isSaving || !hasNext}
+          title={hasNext ? "Save and jump to the next unplaced pin" : "No more unplaced pins"}
+          className="flex-1 inline-flex items-center justify-center h-9 rounded-md border border-input bg-background px-2 text-xs font-medium hover:enabled:bg-muted/40 disabled:opacity-50 transition-colors"
+        >
+          {isSaving ? "Saving…" : "Save & Next"}
+        </button>
+      </div>
+
+      {/* In-game stand frame — the operator places the reference pin by
+          reading the white player marker off the in-game minimap (top-left of
+          this frame). Zoomed to that corner so the marker is legible in the
+          narrow sidebar. Without this the operator was placing blind against
+          the clean reference map. */}
+      {selectedLineup.stand_screenshot_url && (
+        <div className="space-y-1">
+          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            In-game minimap — white marker = player's stand
+          </p>
+          <div
+            className="w-full overflow-hidden rounded-lg border bg-black"
+            style={{ maxWidth: 280, aspectRatio: "1 / 1" }}
+          >
+            <img
+              src={selectedLineup.stand_screenshot_url}
+              alt="In-game stand frame (minimap in the top-left corner)"
+              draggable={false}
+              className="block select-none"
+              style={{ width: "380%", maxWidth: "none" }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Landing frame — reference for the orange Target pin. This is a
+          first-person shot of where the utility lands (NOT a minimap), so it's
+          shown full-frame, unlike the corner-zoomed stand frame above. Without
+          it the operator had no cue for where on the map the lineup lands. */}
+      {selectedLineup.landing_screenshot_url && (
+        <div className="space-y-1">
+          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Where it lands — set the orange Target pin at this spot on the map
+          </p>
+          <div
+            className="w-full overflow-hidden rounded-lg border bg-black"
+            style={{ maxWidth: 280 }}
+          >
+            <img
+              src={selectedLineup.landing_screenshot_url}
+              alt="Landing frame — where the utility ends up"
+              draggable={false}
+              className="block w-full select-none"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* How-to line — the editor has no explicit "set" button (dragging IS
+          the set), and "Reset stand/target" reads like a commit when it's
+          actually an undo. Spell out the flow so the operator isn't guessing. */}
+      <p className="text-[11px] leading-snug text-muted-foreground">
+        Drag the <span className="font-medium text-foreground">blue Stand pin</span> onto
+        the white marker (from the in-game frame), and the{" "}
+        <span className="font-medium text-foreground">orange Target pin</span> to where it
+        lands, then <span className="font-medium text-foreground">Save</span>.
+        <span className="block text-muted-foreground/70">
+          “Reset” just snaps a pin back to the auto/default spot — you don’t need it to save.
+        </span>
+      </p>
+
       <MinimapPinEditor
         lineup={selectedLineup}
         minimapUrl={minimapUrl}
@@ -89,33 +181,6 @@ export default function PinEditPanel({ editor, minimapUrl }: Props) {
         onResetTarget={onResetTarget}
         disabled={isSaving}
       />
-
-      <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={() => save(false)}
-          disabled={isSaving}
-          className="flex-1 inline-flex items-center justify-center gap-1.5 h-8 rounded-md border border-input bg-background px-2 text-xs font-medium hover:enabled:bg-muted/40 disabled:opacity-50 transition-colors"
-        >
-          {isSaving ? (
-            "Saving…"
-          ) : (
-            <>
-              <Check className="w-3.5 h-3.5" aria-hidden />
-              Save
-            </>
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={() => save(true)}
-          disabled={isSaving || !hasNext}
-          title={hasNext ? "Save and jump to the next unplaced pin" : "No more unplaced pins"}
-          className="flex-1 inline-flex items-center justify-center h-8 rounded-md bg-primary px-2 text-xs font-medium text-primary-foreground hover:enabled:bg-primary/90 disabled:opacity-50 transition-colors"
-        >
-          {isSaving ? "Saving…" : "Save & Next"}
-        </button>
-      </div>
     </div>
   );
 }

--- a/apps/mygamingassistant/frontend/src/components/review/MinimapPinEditor.tsx
+++ b/apps/mygamingassistant/frontend/src/components/review/MinimapPinEditor.tsx
@@ -297,7 +297,7 @@ export default function MinimapPinEditor({
           onClick={onResetStand}
           disabled={!standResetEnabled}
           className="flex-1 h-7 rounded border border-input bg-background px-2 text-xs text-muted-foreground disabled:opacity-40 hover:enabled:bg-muted/40 transition-colors"
-          title="Reset stand pin to zone centroid"
+          title="Undo — snap the stand pin back to the auto/default spot (you don't need this to save)"
         >
           Reset stand
         </button>
@@ -306,7 +306,7 @@ export default function MinimapPinEditor({
           onClick={onResetTarget}
           disabled={!targetResetEnabled}
           className="flex-1 h-7 rounded border border-input bg-background px-2 text-xs text-muted-foreground disabled:opacity-40 hover:enabled:bg-muted/40 transition-colors"
-          title="Reset target pin to zone centroid"
+          title="Undo — snap the target pin back to the auto/default spot (you don't need this to save)"
         >
           Reset target
         </button>

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -36,8 +36,7 @@ import { useGetLineupsQuery, useGetZoneDensityQuery } from "@/store/lineupsApi";
 import { countUnplaceableLineups } from "@/components/lineup/MapLineupPins";
 import type { PinMode } from "@/components/lineup/MapLineupPins";
 import KeyboardShortcutsHelp from "@/components/lineup/KeyboardShortcutsHelp";
-import GlanceBoard from "@/components/lineup/GlanceBoard";
-import LineupListBoard from "@/components/lineup/LineupListBoard";
+import MapBoardBody from "@/components/lineup/MapBoardBody";
 import MapSpatialSidebar from "@/components/lineup/MapSpatialSidebar";
 import MapPageTopBar from "@/components/map/MapPageTopBar";
 import MapPageSkeleton from "@/components/map/MapPageSkeleton";
@@ -463,54 +462,32 @@ export default function MapPage() {
               </div>
             )}
 
-            {visibleLineups.length === 0 && !allMapFetching && (
-              effectiveUtils.length > 0 || side !== "any" || zoneFilter || selectedAgent
-            ) ? (
-              /* Filtered empty state */
-              <div className="flex flex-col items-center justify-center py-20 gap-3">
-                <p className="text-sm text-muted-foreground text-center">
-                  No{effectiveUtils.length > 0 ? ` ${effectiveUtils.join("/")}` : ""} lineups
-                  {side !== "any" ? ` for ${side === "side_a" ? sideA : sideB}` : ""}
-                  {activeZone ? ` in ${activeZone.name}` : ""}.
-                </p>
-                <button
-                  type="button"
-                  onClick={() => {
-                    handleSideChange("any");
-                    handleUtilToggle([]);
-                    clearLoadout();
-                    updateParam("zone", null);
-                    onAgentChange("");
-                  }}
-                  className="text-sm text-primary hover:underline"
-                >
-                  Clear filters
-                </button>
-              </div>
-            ) : viewMode === "list" ? (
-              <LineupListBoard
-                lineups={visibleLineups}
-                isFetching={allMapFetching}
-                mapName={mapDetail.name}
-                filteredUtils={effectiveUtils}
-                side={side}
-                game={game}
-                knobs={knobs}
-                showOperatorOverlays={isSuperuser}
-                onLineupHover={setHoveredLineupId}
-                editingLineupId={isSuperuser ? editingLineupId : null}
-              />
-            ) : (
-              <GlanceBoard
-                lineups={visibleLineups}
-                isFetching={allMapFetching}
-                mapName={mapDetail.name}
-                filteredUtils={effectiveUtils}
-                side={side}
-                knobs={knobs}
-                showOperatorOverlays={isSuperuser}
-              />
-            )}
+            <MapBoardBody
+              lineups={visibleLineups}
+              isFetching={allMapFetching}
+              mapName={mapDetail.name}
+              filteredUtils={effectiveUtils}
+              side={side}
+              sideA={sideA}
+              sideB={sideB}
+              activeZoneName={activeZone?.name ?? null}
+              hasActiveFilter={
+                effectiveUtils.length > 0 || side !== "any" || !!zoneFilter || !!selectedAgent
+              }
+              viewMode={viewMode}
+              game={game}
+              knobs={knobs}
+              showOperatorOverlays={isSuperuser}
+              onLineupHover={setHoveredLineupId}
+              editingLineupId={isSuperuser ? editingLineupId : null}
+              onClearFilters={() => {
+                handleSideChange("any");
+                handleUtilToggle([]);
+                clearLoadout();
+                updateParam("zone", null);
+                onAgentChange("");
+              }}
+            />
 
             {/* Add lineup CTA at bottom if completely empty (no lineups AND
                 no filters applied) — the truly-empty-map state. */}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -77,10 +77,17 @@ export default function MapPage() {
     pinModeParam === "stand" || pinModeParam === "target" || pinModeParam === "both"
       ? pinModeParam
       : null;
+  // Lineup currently open in the pin editor (?edit=<id>). Superuser-only —
+  // same param usePinEditor reads. Passed to the list board so the matching
+  // row highlights + scrolls into view, giving an unmistakable link between
+  // the editor panel ("Editing pin — <title>") and the actual lineup row.
+  const editingLineupId    = searchParams.get("edit");
 
   const [showShortcutsHelp,   setShowShortcutsHelp]   = useState(false);
   const [storageUnavailableToast, setStorageUnavailableToast] = useState(false);
   const [showMinimapUpload,   setShowMinimapUpload]    = useState(false);
+  // Lineup hovered in the list → highlight its pin(s) on the minimap.
+  const [hoveredLineupId,     setHoveredLineupId]      = useState<string | null>(null);
   // Card cycling — used by round mode + keyboard shortcuts
   const [activeCardIndex,     setActiveCardIndex]      = useState(0);
 
@@ -428,6 +435,7 @@ export default function MapPage() {
               pinMode={pinMode}
               onPinModeChange={(m) => updateParam("pins", m)}
               isSuperuser={isSuperuser}
+              highlightedLineupId={hoveredLineupId}
             />
           </aside>
 
@@ -489,6 +497,8 @@ export default function MapPage() {
                 game={game}
                 knobs={knobs}
                 showOperatorOverlays={isSuperuser}
+                onLineupHover={setHoveredLineupId}
+                editingLineupId={isSuperuser ? editingLineupId : null}
               />
             ) : (
               <GlanceBoard


### PR DESCRIPTION
Operator-facing improvements to the Valorant/CS2 lineup pin editor, split out from the Ascent anchor-placement work (which shipped separately in #997).

## What changed
- **Hover-to-locate:** hovering a list row gives its pin(s) a bright-yellow halo + enlargement on the minimap while every other pin dims — see where a row lands without clicking. (`MapLineupPins` spotlight, forwarded via `highlightedLineupId` through `GlanceBoardMinimapSidebar` / `MapSpatialSidebar`.)
- **Row ↔ editor link:** `?edit=<id>` now highlights + scrolls the matching list row into view, tying the "Editing pin — <title>" panel to the actual row.
- **Landing reference:** `PinEditPanel` shows the landing frame ("Where it lands — set the orange Target pin at this spot") so the target pin has a visual reference; de-jargoned copy.
- **Legible thumbnails:** list-row poster thumbnails bumped to 128×72 so stand/landing framing reads at a glance.

## Scope notes
- **Hotkeys deliberately untouched** — the earlier hotkey-removal sweep was dropped per operator; `useMapKeyboardShortcuts` / `KeyboardShortcutsHelp` remain intact.
- Does **not** touch `lineup_library.json` (anchors shipped in #997).
- An orthogonal dark-mode dropdown-readability fix (`AgentSelect.tsx`) is held back for its own PR.

## Verification
- `tsc --noEmit` clean.
- `LineupListRow` + `useMapKeyboardShortcuts` test suites pass (24 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)