### PR TITLE
feat(mybookkeeper): PIN-protected shareable link for welcome manuals

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/wmanualshare260721_add_welcome_manual_share.py
+++ b/apps/mybookkeeper/backend/alembic/versions/wmanualshare260721_add_welcome_manual_share.py
@@ -1,0 +1,77 @@
+"""add welcome_manual share link (token + PIN)
+
+Revision ID: wmanualshare260721
+Revises: wmanualplace260721
+Create Date: 2026-07-21
+
+Guest welcome manual — PIN-protected public share link. A host enables a
+public link for a manual; a guest opens ``/guide/<share_token>``, enters the
+PIN, and sees a read-only guest-safe projection of the manual.
+
+Conventions:
+- ``share_token`` is an opaque URL segment (``secrets.token_urlsafe``),
+  UNIQUE — Postgres treats NULLs as distinct so a plain unique constraint is
+  correct even though most manuals never enable sharing.
+- ``share_pin`` is stored as TEXT, encrypted application-side via the
+  ``EncryptedString`` TypeDecorator (Fernet ciphertext is longer than the
+  4-digit plaintext bound) — reversible, NOT a one-way hash, because the host
+  must be able to view/copy the current PIN to re-share it.
+- ``key_version smallint`` lets future key rotation re-encrypt rows
+  non-destructively (same convention as every other EncryptedString table).
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "wmanualshare260721"
+down_revision: Union[str, None] = "wmanualplace260721"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "welcome_manuals",
+        sa.Column("share_token", sa.String(length=48), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_welcome_manuals_share_token",
+        "welcome_manuals",
+        ["share_token"],
+    )
+    op.add_column(
+        "welcome_manuals",
+        # PII-adjacent secret — stored as TEXT, encrypted application-side.
+        sa.Column("share_pin", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "welcome_manuals",
+        sa.Column("key_version", sa.SmallInteger(), nullable=False, server_default="1"),
+    )
+    # Guest-PIN brute-force lockout — per-manual (per share token), NOT per-IP.
+    # Mirrors the account-lockout columns on ``users`` (failed_login_count /
+    # locked_until). Incremented only on a wrong PIN, reset on success.
+    op.add_column(
+        "welcome_manuals",
+        sa.Column(
+            "failed_unlock_count", sa.SmallInteger(), nullable=False, server_default="0",
+        ),
+    )
+    op.add_column(
+        "welcome_manuals",
+        sa.Column("unlock_locked_until", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("welcome_manuals", "unlock_locked_until")
+    op.drop_column("welcome_manuals", "failed_unlock_count")
+    op.drop_column("welcome_manuals", "key_version")
+    op.drop_column("welcome_manuals", "share_pin")
+    op.drop_constraint(
+        "uq_welcome_manuals_share_token",
+        "welcome_manuals",
+        type_="unique",
+    )
+    op.drop_column("welcome_manuals", "share_token")

--- a/apps/mybookkeeper/backend/app/api/public_welcome_manuals.py
+++ b/apps/mybookkeeper/backend/app/api/public_welcome_manuals.py
@@ -1,0 +1,60 @@
+"""Public, unauthenticated routes for the guest welcome-manual share link
+(PIN-protected).
+
+Exposes:
+- ``GET /public/welcome-manuals/{token}`` — gate check. Returns
+  ``{"requires_pin": true}`` and NOTHING else if the token resolves to an
+  active share; 404 for unknown/revoked tokens (indistinguishable).
+- ``POST /public/welcome-manuals/{token}/unlock`` — verifies the PIN (in the
+  body, never the URL) and returns the guest-safe manual projection.
+
+Mirrors ``public_inquiries.py``'s registration style: no ``/api`` prefix
+(Caddy / the Vite dev proxy strip ``/api`` before requests reach FastAPI —
+see the detailed comment in that module), and no ``current_org_member`` /
+auth dependency. Defense-in-depth is the PIN itself plus the per-manual
+unlock lockout in ``welcome_manual_share_service``.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.welcome_manuals.public_welcome_manual_response import (
+    PublicWelcomeManualResponse,
+)
+from app.schemas.welcome_manuals.welcome_manual_share_gate_response import (
+    WelcomeManualShareGateResponse,
+)
+from app.schemas.welcome_manuals.welcome_manual_unlock_request import (
+    WelcomeManualUnlockRequest,
+)
+from app.services.welcome_manuals import welcome_manual_share_service
+
+router = APIRouter(prefix="/public/welcome-manuals", tags=["public-welcome-manuals"])
+
+
+@router.get("/{token}", response_model=WelcomeManualShareGateResponse)
+async def get_share_gate(token: str) -> WelcomeManualShareGateResponse:
+    """Existence check only. 404 for unknown/revoked tokens — never leaks
+    the manual's title or any content before the PIN is verified."""
+    exists = await welcome_manual_share_service.get_public_gate(token)
+    if not exists:
+        raise HTTPException(status_code=404, detail="Guide not found")
+    return WelcomeManualShareGateResponse()
+
+
+@router.post("/{token}/unlock", response_model=PublicWelcomeManualResponse)
+async def unlock_share(
+    token: str,
+    payload: WelcomeManualUnlockRequest,
+) -> PublicWelcomeManualResponse:
+    """Verify the PIN and, on success, return the guest-safe manual
+    projection. Brute-force lockout is per-manual (persisted on the row),
+    not per client IP — see ``welcome_manual_share_service.unlock_public``.
+    A locked manual surfaces as the service's ``HTTPException(429)``, which
+    propagates unchanged."""
+    try:
+        return await welcome_manual_share_service.unlock_public(token, payload.pin)
+    except welcome_manual_share_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Guide not found") from exc
+    except welcome_manual_share_service.IncorrectPinError as exc:
+        raise HTTPException(status_code=401, detail="incorrect_pin") from exc

--- a/apps/mybookkeeper/backend/app/api/welcome_manuals.py
+++ b/apps/mybookkeeper/backend/app/api/welcome_manuals.py
@@ -53,6 +53,12 @@ from app.schemas.welcome_manuals.welcome_manual_section_response import (
 from app.schemas.welcome_manuals.welcome_manual_section_update_request import (
     WelcomeManualSectionUpdateRequest,
 )
+from app.schemas.welcome_manuals.welcome_manual_share_pin_update_request import (
+    WelcomeManualSharePinUpdateRequest,
+)
+from app.schemas.welcome_manuals.welcome_manual_share_response import (
+    WelcomeManualShareResponse,
+)
 from app.schemas.welcome_manuals.welcome_manual_update_request import (
     WelcomeManualUpdateRequest,
 )
@@ -63,6 +69,7 @@ from app.services.welcome_manuals import (
     welcome_manual_section_image_service,
     welcome_manual_section_service,
     welcome_manual_service,
+    welcome_manual_share_service,
 )
 
 router = APIRouter(prefix="/welcome-manuals", tags=["welcome-manuals"])
@@ -474,4 +481,58 @@ async def delete_place(
         raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
     except welcome_manual_place_service.PlaceNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Place not found") from exc
+    return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Public share link (PIN-protected)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{manual_id}/share", response_model=WelcomeManualShareResponse)
+async def enable_share(
+    manual_id: uuid.UUID,
+    ctx: RequestContext = Depends(require_write_access),
+) -> WelcomeManualShareResponse:
+    """Enable the public share link. Idempotent — a manual that's already
+    shared returns its existing token + PIN unchanged."""
+    try:
+        return await welcome_manual_share_service.enable_share(
+            ctx.organization_id, ctx.user_id, manual_id,
+        )
+    except welcome_manual_share_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+
+
+@router.patch("/{manual_id}/share", response_model=WelcomeManualShareResponse)
+async def rotate_share_pin(
+    manual_id: uuid.UUID,
+    payload: WelcomeManualSharePinUpdateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> WelcomeManualShareResponse:
+    """Rotate the PIN for an already-shared manual. Body ``pin`` set ->
+    use it (validated digit/length by the schema); omitted/null ->
+    generate a fresh random PIN."""
+    try:
+        return await welcome_manual_share_service.rotate_pin(
+            ctx.organization_id, ctx.user_id, manual_id, payload.pin,
+        )
+    except welcome_manual_share_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+    except welcome_manual_share_service.ShareNotEnabledError as exc:
+        raise HTTPException(status_code=404, detail="Share link is not enabled") from exc
+
+
+@router.delete("/{manual_id}/share", status_code=204)
+async def revoke_share(
+    manual_id: uuid.UUID,
+    ctx: RequestContext = Depends(require_write_access),
+) -> Response:
+    """Revoke the share link — clears both the token and the PIN."""
+    try:
+        await welcome_manual_share_service.revoke_share(
+            ctx.organization_id, ctx.user_id, manual_id,
+        )
+    except welcome_manual_share_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
     return Response(status_code=204)

--- a/apps/mybookkeeper/backend/app/core/audit.py
+++ b/apps/mybookkeeper/backend/app/core/audit.py
@@ -73,6 +73,10 @@ MBK_SENSITIVE_FIELDS: frozenset[str] = frozenset({
     "vehicle_make_model",
     "reference_name",
     "reference_contact",
+    # Guest welcome-manual share PIN — encrypted at rest via EncryptedString.
+    # The audit log must never capture the decrypted PIN (or its ciphertext,
+    # which would leak that a share link is enabled).
+    "share_pin",
     # Hosts may put sensitive context into freeform notes (medical info,
     # personal references, candid character assessments) — mask the column
     # to be safe. Applies to inquiries.notes, applicants.pets context,

--- a/apps/mybookkeeper/backend/app/core/welcome_manual_constants.py
+++ b/apps/mybookkeeper/backend/app/core/welcome_manual_constants.py
@@ -66,3 +66,18 @@ PLACE_CUISINE_MAX_LEN = 50
 PLACE_NOTE_MAX_LEN = 500
 PLACE_MAP_URL_MAX_LEN = 2048
 WELCOME_MANUAL_PRICE_TIERS: tuple[str, ...] = ("$", "$$", "$$$")
+
+# Public PIN-protected share link. ``SHARE_TOKEN_BYTES`` is the
+# ``secrets.token_urlsafe`` input size (not the resulting string length —
+# base64 expands it by ~4/3). ``SHARE_PIN_LENGTH`` is a 4-digit numeric PIN
+# (10,000-value space) gating ALL guest-visible manual content (Wi-Fi,
+# check-in, etc.). ``SHARE_UNLOCK_MAX_ATTEMPTS`` /
+# ``SHARE_UNLOCK_LOCKOUT_WINDOW_SECONDS`` bound the brute-force surface a
+# 10k-space PIN would otherwise present: after this many WRONG PINs the
+# manual (keyed on its share token, persisted on the row — NOT the spoofable
+# client IP) locks for the window; a correct PIN resets the counter. See
+# ``welcome_manual_share_service`` for why the key is the manual, not the IP.
+SHARE_TOKEN_BYTES = 24
+SHARE_PIN_LENGTH = 4
+SHARE_UNLOCK_MAX_ATTEMPTS = 5
+SHARE_UNLOCK_LOCKOUT_WINDOW_SECONDS = 900

--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -32,7 +32,7 @@ from app.db.session import AsyncSessionLocal
 from app.schemas.user.user import UserRead, UserCreate, UserUpdate
 from app.services.storage.bucket_initializer import ensure_bucket
 from app.workers.upload_processor_worker import main as worker_main
-from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_policies, lease_templates, listings, properties, public_inquiries, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, exports, imports, health_dashboard, totp, taxpayer_profiles, welcome_manuals
+from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_policies, lease_templates, listings, properties, public_inquiries, public_welcome_manuals, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, exports, imports, health_dashboard, totp, taxpayer_profiles, welcome_manuals
 
 logging.basicConfig(
     level=logging.INFO,
@@ -198,6 +198,9 @@ app.include_router(inquiries.router)
 # already drop the ``/api`` segment before requests reach FastAPI. See the
 # detailed comment in ``api/public_inquiries.py``.
 app.include_router(public_inquiries.router)
+# Public welcome-manual share link — unauthenticated, PIN-protected. Same
+# no-/api-prefix reasoning as public_inquiries above.
+app.include_router(public_welcome_manuals.router)
 app.include_router(applicants.router)
 app.include_router(lease_templates.router)
 app.include_router(signed_leases.router)

--- a/apps/mybookkeeper/backend/app/models/welcome_manuals/welcome_manual.py
+++ b/apps/mybookkeeper/backend/app/models/welcome_manuals/welcome_manual.py
@@ -1,10 +1,21 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, Text, func, text
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    SmallInteger,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
+from app.core.encrypted_string_type import EncryptedString
 from app.db.base import Base
 
 
@@ -43,6 +54,44 @@ class WelcomeManual(Base):
     # Greeting shown at the top of the emailed PDF / email body. Optional.
     intro_text: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # Public guest share link (PR: PIN-protected share). ``share_token`` is an
+    # opaque, unguessable URL segment (``secrets.token_urlsafe``) — Postgres
+    # UNIQUE treats NULLs as distinct, so a plain ``unique=True`` is correct
+    # even though most manuals never enable sharing. ``share_pin`` is the
+    # short guest-facing access code gating ALL manual content (Wi-Fi,
+    # check-in, etc.) — stored reversibly via ``EncryptedString`` (NOT a
+    # one-way hash) because the host must be able to view/copy the current
+    # PIN in their editor to re-share it. Both are cleared together on revoke.
+    # The UNIQUE constraint is declared in ``__table_args__`` (not ``unique=True``
+    # on the column) so its name matches the migration's
+    # ``uq_welcome_manuals_share_token`` — otherwise SQLAlchemy auto-names it
+    # ``welcome_manuals_share_token_key`` and ``alembic --autogenerate`` reports
+    # spurious constraint churn on every future run.
+    share_token: Mapped[str | None] = mapped_column(String(48), nullable=True)
+    share_pin: Mapped[str | None] = mapped_column(EncryptedString(10), nullable=True)
+    key_version: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=1, server_default="1",
+    )
+
+    # Guest-PIN brute-force lockout — mirrors the platform account-lockout
+    # primitive (``users.failed_login_count`` / ``users.locked_until``) but
+    # keyed on the MANUAL (its share token), NOT the client IP. A per-IP key
+    # is bypassable because Caddy appends a guest-supplied ``X-Forwarded-For``,
+    # so an attacker rotating that header would get a fresh budget per value.
+    # The counter is incremented ONLY on a wrong PIN and reset to 0 on any
+    # successful unlock, so a guest legitimately reopening the guide (v1
+    # re-prompts on every refresh) can never lock themselves out with the
+    # correct code. Once ``failed_unlock_count`` reaches
+    # ``SHARE_UNLOCK_MAX_ATTEMPTS`` the row is locked until
+    # ``unlock_locked_until`` — during which even a correct PIN is rejected,
+    # so there is no timing/oracle side-channel.
+    failed_unlock_count: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=0, server_default="0",
+    )
+    unlock_locked_until: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -59,6 +108,8 @@ class WelcomeManual(Base):
     )
 
     __table_args__ = (
+        # Name aligned to the migration (see share_token comment above).
+        UniqueConstraint("share_token", name="uq_welcome_manuals_share_token"),
         # List view — active manuals for an org, newest first.
         Index(
             "ix_welcome_manuals_org_active",

--- a/apps/mybookkeeper/backend/app/repositories/welcome_manuals/welcome_manual_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/welcome_manuals/welcome_manual_repo.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from sqlalchemy import delete, func, select, update
@@ -149,3 +149,121 @@ async def hard_delete_by_id(
             WelcomeManual.organization_id == organization_id,
         )
     )
+
+
+async def set_share(
+    db: AsyncSession,
+    manual_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    *,
+    share_token: str,
+    share_pin: str,
+) -> WelcomeManual | None:
+    """First-time share enable. Returns None if the manual doesn't exist /
+    is soft-deleted / belongs to a different org."""
+    manual = await get_by_id(db, manual_id, organization_id)
+    if manual is None:
+        return None
+    manual.share_token = share_token
+    manual.share_pin = share_pin
+    await db.flush()
+    return manual
+
+
+async def rotate_pin(
+    db: AsyncSession,
+    manual_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    *,
+    share_pin: str,
+) -> WelcomeManual | None:
+    """Rotate the PIN of an already-shared manual. Returns None if the
+    manual doesn't exist / is soft-deleted / belongs to a different org.
+
+    Does NOT check ``share_token is not None`` — the caller (service layer)
+    is responsible for raising ``ShareNotEnabledError`` before calling this,
+    since that's a distinct 404 case from "manual not found".
+    """
+    manual = await get_by_id(db, manual_id, organization_id)
+    if manual is None:
+        return None
+    manual.share_pin = share_pin
+    await db.flush()
+    return manual
+
+
+async def clear_share(
+    db: AsyncSession,
+    manual_id: uuid.UUID,
+    organization_id: uuid.UUID,
+) -> bool:
+    """Revoke the share link — clears BOTH ``share_token`` and ``share_pin``.
+
+    Returns True if a row was updated (manual existed, was not soft-deleted,
+    and belonged to the org), False otherwise.
+    """
+    result = await db.execute(
+        update(WelcomeManual)
+        .where(
+            WelcomeManual.id == manual_id,
+            WelcomeManual.organization_id == organization_id,
+            WelcomeManual.deleted_at.is_(None),
+        )
+        .values(share_token=None, share_pin=None)
+    )
+    return (result.rowcount or 0) > 0
+
+
+async def record_failed_unlock(
+    db: AsyncSession,
+    manual: WelcomeManual,
+    *,
+    max_attempts: int,
+    lockout_window_seconds: int,
+    now: datetime,
+) -> None:
+    """Register one wrong-PIN unlock attempt on ``manual``.
+
+    Increments ``failed_unlock_count``; once it reaches ``max_attempts`` the
+    manual is locked for ``lockout_window_seconds`` and the counter resets to
+    0 so the next window starts clean. Mutates the already-loaded object (the
+    public unlock path holds it) rather than re-querying — matches the
+    ``set_share`` / ``rotate_pin`` style and keeps the value fresh in-session.
+    """
+    manual.failed_unlock_count += 1
+    if manual.failed_unlock_count >= max_attempts:
+        manual.unlock_locked_until = now + timedelta(seconds=lockout_window_seconds)
+        manual.failed_unlock_count = 0
+    await db.flush()
+
+
+async def reset_unlock_state(
+    db: AsyncSession,
+    manual: WelcomeManual,
+) -> None:
+    """Clear the brute-force lockout counters after a successful unlock, so a
+    guest reopening the guide with the correct PIN never accumulates toward a
+    lockout. No-op (no flush) when already clean to avoid a needless write on
+    the common repeat-visit path."""
+    if manual.failed_unlock_count == 0 and manual.unlock_locked_until is None:
+        return
+    manual.failed_unlock_count = 0
+    manual.unlock_locked_until = None
+    await db.flush()
+
+
+async def get_by_share_token(
+    db: AsyncSession,
+    share_token: str,
+) -> WelcomeManual | None:
+    """Public lookup by share token — deliberately NOT org-scoped (the
+    caller has no organization context yet). Respects soft-delete so a
+    deleted manual's stale token can never resolve.
+    """
+    result = await db.execute(
+        select(WelcomeManual).where(
+            WelcomeManual.share_token == share_token,
+            WelcomeManual.deleted_at.is_(None),
+        )
+    )
+    return result.scalar_one_or_none()

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/public_welcome_manual_place_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/public_welcome_manual_place_response.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class PublicWelcomeManualPlaceResponse(BaseModel):
+    """Guest-safe place (restaurant recommendation) projection. No ``id``,
+    ``manual_id``, or ``created_at``."""
+
+    name: str
+    cuisine: str
+    price_tier: str | None = None
+    note: str | None = None
+    map_url: str | None = None
+    display_order: int
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/public_welcome_manual_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/public_welcome_manual_response.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.welcome_manuals.public_welcome_manual_place_response import (
+    PublicWelcomeManualPlaceResponse,
+)
+from app.schemas.welcome_manuals.public_welcome_manual_section_response import (
+    PublicWelcomeManualSectionResponse,
+)
+
+
+class PublicWelcomeManualResponse(BaseModel):
+    """The guest-safe manual projection returned on a successful PIN unlock.
+
+    DELIBERATELY minimal: ONLY ``title``, ``sections``, and ``places``. Must
+    NEVER contain ``organization_id``, ``user_id``/``property_id``, any
+    owner/user id or email, ``share_token``, ``share_pin``, or any audit
+    field (``created_at``/``updated_at``/``deleted_at``) — this is the
+    unauthenticated response body, readable by anyone who obtains the link.
+    """
+
+    title: str
+    sections: list[PublicWelcomeManualSectionResponse] = []
+    places: list[PublicWelcomeManualPlaceResponse] = []
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/public_welcome_manual_section_field_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/public_welcome_manual_section_field_response.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class PublicWelcomeManualSectionFieldResponse(BaseModel):
+    """Guest-safe field projection — label/value only. No ``id``,
+    ``section_id``, or ``display_order``; ordering is carried by list order."""
+
+    label: str
+    value: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/public_welcome_manual_section_image_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/public_welcome_manual_section_image_response.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class PublicWelcomeManualSectionImageResponse(BaseModel):
+    """Guest-safe image projection.
+
+    Deliberately omits ``id``, ``section_id``, and — most importantly —
+    ``storage_key``: welcome-manual image object keys are partitioned as
+    ``{organization_id}/welcome-manuals/{uuid}/{filename}`` (see
+    ``welcome_manual_section_image_service.upload_images``, which builds the
+    key via ``storage.generate_key(f"{organization_id}/{WELCOME_MANUAL_STORAGE_DOMAIN}", ...)``),
+    so the raw storage key would leak the host's ``organization_id`` to an
+    unauthenticated guest. Only the short-lived presigned URL + caption are
+    exposed — enough to render the image, nothing that identifies the tenant.
+
+    NOTE: the presigned URL itself still embeds the object key (including
+    ``organization_id``) in its path — that residual leak is inherent to the
+    current storage-key partitioning scheme and is NOT fixed here (would
+    require reworking key generation / storage ACLs, out of scope for this
+    PR). See PR description for the flagged follow-up.
+    """
+
+    caption: str | None = None
+    display_order: int
+    presigned_url: str | None = None
+    is_available: bool = True
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/public_welcome_manual_section_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/public_welcome_manual_section_response.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.welcome_manuals.public_welcome_manual_section_field_response import (
+    PublicWelcomeManualSectionFieldResponse,
+)
+from app.schemas.welcome_manuals.public_welcome_manual_section_image_response import (
+    PublicWelcomeManualSectionImageResponse,
+)
+
+
+class PublicWelcomeManualSectionResponse(BaseModel):
+    """Guest-safe section projection — title, body, and its ordered fields /
+    images only. No ``id``, ``manual_id``, or ``display_order``; list order
+    already reflects display order."""
+
+    title: str
+    body: str | None = None
+    fields: list[PublicWelcomeManualSectionFieldResponse] = []
+    images: list[PublicWelcomeManualSectionImageResponse] = []
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_response.py
@@ -23,6 +23,13 @@ class WelcomeManualResponse(BaseModel):
     title: str
     intro_text: str | None = None
 
+    # Public share link — populated only when the host has enabled sharing.
+    # ``share_pin`` is the DECRYPTED plaintext PIN (read via the
+    # ``EncryptedString`` column) so the admin editor can display/copy it.
+    # This is the AUTHENTICATED response — never exposed on the public routes.
+    share_token: str | None = None
+    share_pin: str | None = None
+
     sections: list[WelcomeManualSectionResponse] = []
     places: list[WelcomeManualPlaceResponse] = []
 

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_share_gate_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_share_gate_response.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class WelcomeManualShareGateResponse(BaseModel):
+    """The public gate-check response — deliberately carries NOTHING beyond
+    ``requires_pin``. No title, no content, no metadata leaks before the
+    guest has proven they hold the PIN."""
+
+    requires_pin: bool = True

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_share_pin_update_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_share_pin_update_request.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from app.core.welcome_manual_constants import SHARE_PIN_LENGTH
+
+
+class WelcomeManualSharePinUpdateRequest(BaseModel):
+    """PATCH body for rotating a manual's share PIN.
+
+    ``pin`` omitted/``null`` regenerates a random PIN; an explicit value must
+    be exactly ``SHARE_PIN_LENGTH`` digits.
+    """
+
+    pin: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("pin")
+    @classmethod
+    def _validate_pin(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        if len(value) != SHARE_PIN_LENGTH or not value.isdigit():
+            raise ValueError(f"pin must be exactly {SHARE_PIN_LENGTH} digits")
+        return value

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_share_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_share_response.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class WelcomeManualShareResponse(BaseModel):
+    """Owner-only response for the share-link enable/rotate routes.
+
+    ``share_pin`` is the DECRYPTED plaintext PIN so the host can read/copy it
+    to re-share with a guest — never returned from any public/unauthenticated
+    endpoint.
+    """
+
+    share_token: str
+    share_path: str
+    share_pin: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_unlock_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_unlock_request.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WelcomeManualUnlockRequest(BaseModel):
+    """Body for POST /public/welcome-manuals/{token}/unlock.
+
+    The PIN travels in the body — never the URL or a query string — so it
+    never lands in server access logs or browser history.
+    """
+
+    # ``max_length`` caps a trivial oversized-payload vector cheaply — the
+    # real PIN is ``SHARE_PIN_LENGTH`` (4) digits, and the frontend input
+    # already bounds entry at 12. ``hmac.compare_digest`` handles any value
+    # safely regardless; this just rejects absurd inputs before the service.
+    pin: str = Field(min_length=1, max_length=12)
+
+    model_config = ConfigDict(extra="forbid")

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_share_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_share_service.py
@@ -1,0 +1,287 @@
+"""Welcome-manual public share-link service.
+
+Two audiences:
+  * Owner-scoped (``enable_share`` / ``rotate_pin`` / ``revoke_share``) —
+    org-scoped like every other welcome-manual service, re-verifies the
+    manual belongs to the caller's organization before touching it.
+  * Public/unauthenticated (``get_public_gate`` / ``unlock_public``) — no
+    organization context; the share token IS the lookup key.
+
+Security notes:
+  * ``share_pin`` is stored via ``EncryptedString`` (reversible Fernet
+    ciphertext), never a one-way hash — the host needs to view/copy the
+    current PIN in their editor to re-share it.
+  * Guest-submitted PINs are verified with ``hmac.compare_digest``
+    (constant-time) so a timing side-channel can't narrow down correct
+    digits one at a time.
+  * Brute-force lockout is PER-MANUAL (keyed on the share token, persisted
+    on the row as ``failed_unlock_count`` / ``unlock_locked_until``), NOT
+    per-client-IP. A per-IP key would be bypassable: Caddy appends a
+    guest-supplied ``X-Forwarded-For``, so an attacker rotating that header
+    would earn a fresh attempt budget per spoofed value and could exhaust
+    the 10,000-value PIN space. The DB counter can't be spoofed and survives
+    worker restarts / multi-worker deployments (an in-memory limiter does
+    neither). The counter is incremented ONLY on a wrong PIN and reset on
+    any success — mirroring the platform account-lockout primitive
+    (``users.failed_login_count`` is bumped only on a real password
+    failure) — so a guest legitimately reopening the guide (v1 re-prompts on
+    every refresh) can never self-lock with the correct code. While locked,
+    even a correct PIN is rejected with 429, so there is no oracle.
+  * The PIN itself is never logged.
+"""
+from __future__ import annotations
+
+import hmac
+import secrets
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import HTTPException
+
+from platform_shared.core.auth_messages import RATE_LIMIT_GENERIC_DETAIL
+
+from app.core.welcome_manual_constants import (
+    SHARE_PIN_LENGTH,
+    SHARE_TOKEN_BYTES,
+    SHARE_UNLOCK_LOCKOUT_WINDOW_SECONDS,
+    SHARE_UNLOCK_MAX_ATTEMPTS,
+)
+from app.db.session import AsyncSessionLocal, unit_of_work
+from app.models.welcome_manuals.welcome_manual import WelcomeManual
+from app.repositories import (
+    welcome_manual_place_repo,
+    welcome_manual_repo,
+    welcome_manual_section_field_repo,
+    welcome_manual_section_image_repo,
+    welcome_manual_section_repo,
+)
+from app.schemas.welcome_manuals.public_welcome_manual_place_response import (
+    PublicWelcomeManualPlaceResponse,
+)
+from app.schemas.welcome_manuals.public_welcome_manual_response import (
+    PublicWelcomeManualResponse,
+)
+from app.schemas.welcome_manuals.public_welcome_manual_section_field_response import (
+    PublicWelcomeManualSectionFieldResponse,
+)
+from app.schemas.welcome_manuals.public_welcome_manual_section_image_response import (
+    PublicWelcomeManualSectionImageResponse,
+)
+from app.schemas.welcome_manuals.public_welcome_manual_section_response import (
+    PublicWelcomeManualSectionResponse,
+)
+from app.schemas.welcome_manuals.welcome_manual_section_image_response import (
+    WelcomeManualSectionImageResponse,
+)
+from app.schemas.welcome_manuals.welcome_manual_share_response import (
+    WelcomeManualShareResponse,
+)
+from app.services.welcome_manuals.section_image_response_builder import (
+    attach_presigned_urls,
+)
+from app.services.welcome_manuals.welcome_manual_section_service import (
+    ManualNotFoundError,  # noqa: F401 — re-exported for the route
+)
+
+
+class ShareNotEnabledError(LookupError):
+    """PATCH (rotate) was requested for a manual with no active share link."""
+
+
+class IncorrectPinError(Exception):
+    """The submitted PIN did not match (-> HTTP 401)."""
+
+
+def _generate_pin() -> str:
+    return "".join(secrets.choice("0123456789") for _ in range(SHARE_PIN_LENGTH))
+
+
+def _share_response(manual: WelcomeManual) -> WelcomeManualShareResponse:
+    assert manual.share_token is not None and manual.share_pin is not None
+    return WelcomeManualShareResponse(
+        share_token=manual.share_token,
+        share_path=f"/guide/{manual.share_token}",
+        share_pin=manual.share_pin,
+    )
+
+
+async def enable_share(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+) -> WelcomeManualShareResponse:
+    """Enable the public share link for a manual.
+
+    Idempotent: a manual that's already shared returns its existing token +
+    PIN unchanged rather than rotating them.
+
+    Raises ManualNotFoundError: scope failure.
+    """
+    async with unit_of_work() as db:
+        manual = await welcome_manual_repo.get_by_id(db, manual_id, organization_id)
+        if manual is None:
+            raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
+
+        if manual.share_token is not None:
+            return _share_response(manual)
+
+        token = secrets.token_urlsafe(SHARE_TOKEN_BYTES)
+        pin = _generate_pin()
+        manual = await welcome_manual_repo.set_share(
+            db, manual_id, organization_id, share_token=token, share_pin=pin,
+        )
+        return _share_response(manual)
+
+
+async def rotate_pin(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    pin: str | None,
+) -> WelcomeManualShareResponse:
+    """Rotate a shared manual's PIN.
+
+    Uses ``pin`` if supplied (already digit/length-validated by the
+    schema); otherwise generates a fresh random PIN.
+
+    Raises:
+        ManualNotFoundError: scope failure.
+        ShareNotEnabledError: the manual is not currently shared.
+    """
+    async with unit_of_work() as db:
+        manual = await welcome_manual_repo.get_by_id(db, manual_id, organization_id)
+        if manual is None:
+            raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
+        if manual.share_token is None:
+            raise ShareNotEnabledError(f"Welcome manual {manual_id} is not shared")
+
+        new_pin = pin if pin is not None else _generate_pin()
+        manual = await welcome_manual_repo.rotate_pin(
+            db, manual_id, organization_id, share_pin=new_pin,
+        )
+        return _share_response(manual)
+
+
+async def revoke_share(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+) -> None:
+    """Revoke the share link — clears both the token and PIN.
+
+    Raises ManualNotFoundError: scope failure.
+    """
+    async with unit_of_work() as db:
+        manual = await welcome_manual_repo.get_by_id(db, manual_id, organization_id)
+        if manual is None:
+            raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
+        await welcome_manual_repo.clear_share(db, manual_id, organization_id)
+
+
+async def get_public_gate(token: str) -> bool:
+    """True iff an active (non-revoked, non-deleted) share link exists for
+    ``token``. Reveals nothing about the manual beyond existence — callers
+    must not leak the title or any content before the PIN is verified.
+    """
+    async with AsyncSessionLocal() as db:
+        manual = await welcome_manual_repo.get_by_share_token(db, token)
+    return manual is not None and manual.share_pin is not None
+
+
+async def _assemble_public_response(db, manual: WelcomeManual) -> PublicWelcomeManualResponse:
+    sections = await welcome_manual_section_repo.list_by_manual(db, manual.id)
+    section_ids = [s.id for s in sections]
+    images = await welcome_manual_section_image_repo.list_by_section_ids(db, section_ids)
+    fields = await welcome_manual_section_field_repo.list_by_section_ids(db, section_ids)
+    places = await welcome_manual_place_repo.list_by_manual(db, manual.id)
+
+    authed_images = [WelcomeManualSectionImageResponse.model_validate(img) for img in images]
+    signed = attach_presigned_urls(authed_images)
+    images_by_section: dict[uuid.UUID, list[PublicWelcomeManualSectionImageResponse]] = {}
+    for image in signed:
+        images_by_section.setdefault(image.section_id, []).append(
+            PublicWelcomeManualSectionImageResponse(
+                caption=image.caption,
+                display_order=image.display_order,
+                presigned_url=image.presigned_url,
+                is_available=image.is_available,
+            ),
+        )
+
+    fields_by_section: dict[uuid.UUID, list[PublicWelcomeManualSectionFieldResponse]] = {}
+    for field in fields:
+        fields_by_section.setdefault(field.section_id, []).append(
+            PublicWelcomeManualSectionFieldResponse(label=field.label, value=field.value),
+        )
+
+    section_responses = [
+        PublicWelcomeManualSectionResponse(
+            title=s.title,
+            body=s.body,
+            fields=fields_by_section.get(s.id, []),
+            images=images_by_section.get(s.id, []),
+        )
+        for s in sections
+    ]
+    place_responses = [PublicWelcomeManualPlaceResponse.model_validate(p) for p in places]
+
+    return PublicWelcomeManualResponse(
+        title=manual.title,
+        sections=section_responses,
+        places=place_responses,
+    )
+
+
+async def unlock_public(
+    token: str,
+    pin: str,
+) -> PublicWelcomeManualResponse:
+    """Verify a guest-submitted PIN and, on success, return the guest-safe
+    manual projection.
+
+    Brute-force lockout is per-manual (see the module docstring): the manual
+    is locked once ``SHARE_UNLOCK_MAX_ATTEMPTS`` wrong PINs accumulate, and
+    the counter resets on any success. Ordering mirrors the account-lockout
+    dependency — the lock is checked BEFORE the PIN comparison, so a correct
+    PIN submitted during an active lockout is still rejected with 429 (no
+    oracle), and the failure counter is only ever bumped on a real mismatch.
+
+    Raises:
+        ManualNotFoundError: unknown token, or the manual's share was
+            revoked (indistinguishable from unknown -> HTTP 404).
+        IncorrectPinError: the PIN did not match (-> HTTP 401).
+        fastapi.HTTPException(429): the manual is currently locked out.
+
+    Never logs the submitted or stored PIN.
+    """
+    async with unit_of_work() as db:
+        manual = await welcome_manual_repo.get_by_share_token(db, token)
+        if manual is None or manual.share_pin is None:
+            raise ManualNotFoundError("Share token not found")
+
+        now = datetime.now(timezone.utc)
+        if manual.unlock_locked_until is not None and manual.unlock_locked_until > now:
+            # Locked — reject before comparing, so a correct guess during the
+            # lockout window is indistinguishable from a wrong one.
+            raise HTTPException(status_code=429, detail=RATE_LIMIT_GENERIC_DETAIL)
+
+        if hmac.compare_digest(pin, manual.share_pin):
+            # Correct PIN — clear any accumulated failures so repeat visits
+            # with the right code can never trip the lockout, then return the
+            # projection (clean ``return`` commits the reset).
+            await welcome_manual_repo.reset_unlock_state(db, manual)
+            return await _assemble_public_response(db, manual)
+
+        # Wrong PIN — record the failure and fall through so the transaction
+        # COMMITS the increment. Raising here would let ``unit_of_work`` roll
+        # back on the exception, discarding the increment and defeating the
+        # lockout. The raise happens below, after the write is committed.
+        await welcome_manual_repo.record_failed_unlock(
+            db,
+            manual,
+            max_attempts=SHARE_UNLOCK_MAX_ATTEMPTS,
+            lockout_window_seconds=SHARE_UNLOCK_LOCKOUT_WINDOW_SECONDS,
+            now=now,
+        )
+
+    raise IncorrectPinError("Incorrect PIN")

--- a/apps/mybookkeeper/backend/tests/test_public_welcome_manual_routes.py
+++ b/apps/mybookkeeper/backend/tests/test_public_welcome_manual_routes.py
@@ -1,0 +1,181 @@
+"""HTTP route tests for the public, unauthenticated welcome-manual share link.
+
+Mirrors test_public_inquiries_api.py's style: mocks the service layer for
+status-code/shape contract tests, plus one end-to-end-ish test through the
+real service (patched DB session) to exercise the actual lockout + guest-safe
+projection.
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.welcome_manual_constants import SHARE_UNLOCK_MAX_ATTEMPTS
+from app.main import app
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.welcome_manuals import welcome_manual_repo
+from app.schemas.welcome_manuals.public_welcome_manual_response import (
+    PublicWelcomeManualResponse,
+)
+from app.services.welcome_manuals import welcome_manual_share_service
+
+
+def patch_share_service(name: str, **kwargs):
+    return patch.object(welcome_manual_share_service, name, **kwargs)
+
+
+class TestGate:
+    def test_shared_manual_returns_requires_pin_only(self) -> None:
+        with patch_share_service("get_public_gate", return_value=True):
+            client = TestClient(app)
+            response = client.get("/public/welcome-manuals/some-token")
+        assert response.status_code == 200
+        assert response.json() == {"requires_pin": True}
+
+    def test_unknown_token_404(self) -> None:
+        with patch_share_service("get_public_gate", return_value=False):
+            client = TestClient(app)
+            response = client.get("/public/welcome-manuals/unknown-token")
+        assert response.status_code == 404
+
+
+class TestUnlock:
+    def test_correct_pin_returns_manual(self) -> None:
+        fake = PublicWelcomeManualResponse(title="Cabin Guide", sections=[], places=[])
+        with patch_share_service("unlock_public", return_value=fake):
+            client = TestClient(app)
+            response = client.post(
+                "/public/welcome-manuals/some-token/unlock", json={"pin": "1234"},
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["title"] == "Cabin Guide"
+        assert "organization_id" not in body
+        assert "share_token" not in body
+        assert "share_pin" not in body
+
+    def test_wrong_pin_401(self) -> None:
+        with patch_share_service(
+            "unlock_public",
+            side_effect=welcome_manual_share_service.IncorrectPinError("nope"),
+        ):
+            client = TestClient(app)
+            response = client.post(
+                "/public/welcome-manuals/some-token/unlock", json={"pin": "0000"},
+            )
+        assert response.status_code == 401
+        assert response.json() == {"detail": "incorrect_pin"}
+
+    def test_unknown_token_404(self) -> None:
+        with patch_share_service(
+            "unlock_public",
+            side_effect=welcome_manual_share_service.ManualNotFoundError("nope"),
+        ):
+            client = TestClient(app)
+            response = client.post(
+                "/public/welcome-manuals/unknown-token/unlock", json={"pin": "0000"},
+            )
+        assert response.status_code == 404
+
+    def test_pin_not_in_query_string(self) -> None:
+        """The PIN must travel in the body — a query-string variant is not a
+        registered route at all (422/404, never processed as the PIN)."""
+        client = TestClient(app)
+        response = client.post(
+            "/public/welcome-manuals/some-token/unlock?pin=1234", json={},
+        )
+        # Missing required body field -> 422 (proves query string is ignored).
+        assert response.status_code == 422
+
+
+class TestUnlockEndToEnd:
+    """Real service, real (in-memory) DB, real RateLimiter — exercises the
+    actual lockout behavior through the HTTP layer."""
+
+    @staticmethod
+    def _patch_db(db: AsyncSession):
+        @asynccontextmanager
+        async def _fake():
+            yield db
+
+        return patch.multiple(
+            "app.services.welcome_manuals.welcome_manual_share_service",
+            AsyncSessionLocal=_fake,
+            unit_of_work=_fake,
+        )
+
+    @pytest.mark.asyncio
+    async def test_lockout_returns_429_over_http(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await welcome_manual_repo.create_manual(
+            db, organization_id=test_org.id, user_id=test_user.id,
+            property_id=None, title="Cabin Guide", intro_text=None,
+        )
+        await db.commit()
+
+        with self._patch_db(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+
+            wrong = "0000" if enabled.share_pin != "0000" else "1111"
+            client = TestClient(app)
+            for _ in range(SHARE_UNLOCK_MAX_ATTEMPTS):
+                r = client.post(
+                    f"/public/welcome-manuals/{enabled.share_token}/unlock",
+                    json={"pin": wrong},
+                )
+                assert r.status_code == 401
+
+            locked = client.post(
+                f"/public/welcome-manuals/{enabled.share_token}/unlock",
+                json={"pin": enabled.share_pin},
+            )
+        assert locked.status_code == 429
+
+    @pytest.mark.asyncio
+    async def test_lockout_not_escapable_by_rotating_xforwarded_for(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Regression for the spoofable-lockout finding: the lockout is keyed
+        on the manual (persisted on the row), NOT on the client IP. An
+        attacker rotating ``X-Forwarded-For`` (which Caddy appends, so it's
+        guest-controlled) must NOT earn a fresh attempt budget."""
+        manual = await welcome_manual_repo.create_manual(
+            db, organization_id=test_org.id, user_id=test_user.id,
+            property_id=None, title="Cabin Guide", intro_text=None,
+        )
+        await db.commit()
+
+        with self._patch_db(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+
+            wrong = "0000" if enabled.share_pin != "0000" else "1111"
+            client = TestClient(app)
+            # Exhaust the budget, each request from a DIFFERENT spoofed IP.
+            for i in range(SHARE_UNLOCK_MAX_ATTEMPTS):
+                r = client.post(
+                    f"/public/welcome-manuals/{enabled.share_token}/unlock",
+                    json={"pin": wrong},
+                    headers={"X-Forwarded-For": f"9.9.9.{i}"},
+                )
+                assert r.status_code == 401
+
+            # A brand-new spoofed IP does not reset the budget — still locked.
+            locked = client.post(
+                f"/public/welcome-manuals/{enabled.share_token}/unlock",
+                json={"pin": enabled.share_pin},
+                headers={"X-Forwarded-For": "203.0.113.7"},
+            )
+        assert locked.status_code == 429

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_share_routes.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_share_routes.py
@@ -1,0 +1,178 @@
+"""API route tests for the welcome-manual share-link endpoints (authed side).
+
+Mocks the service layer — same pattern as test_welcome_manual_place_routes.py.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.welcome_manuals.welcome_manual_share_response import (
+    WelcomeManualShareResponse,
+)
+from app.services.welcome_manuals import welcome_manual_share_service
+
+
+def _ctx(org_id: uuid.UUID, user_id: uuid.UUID) -> RequestContext:
+    return RequestContext(organization_id=org_id, user_id=user_id, org_role=OrgRole.OWNER)
+
+
+def _override_auth(org_id: uuid.UUID, user_id: uuid.UUID) -> None:
+    app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+    app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+
+def _share_response(token: str = "tok-abc", pin: str = "1234") -> WelcomeManualShareResponse:
+    return WelcomeManualShareResponse(
+        share_token=token, share_path=f"/guide/{token}", share_pin=pin,
+    )
+
+
+def patch_share_service(name: str, **kwargs):
+    return patch.object(welcome_manual_share_service, name, **kwargs)
+
+
+class TestEnableShare:
+    @pytest.mark.asyncio
+    async def test_enable_200(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_share_service("enable_share", return_value=_share_response()):
+                client = TestClient(app)
+                response = client.post(f"/welcome-manuals/{manual_id}/share")
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 200
+        body = response.json()
+        assert body["share_token"] == "tok-abc"
+        assert body["share_path"] == "/guide/tok-abc"
+        assert body["share_pin"] == "1234"
+
+    @pytest.mark.asyncio
+    async def test_enable_manual_404(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_share_service(
+                "enable_share",
+                side_effect=welcome_manual_share_service.ManualNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.post(f"/welcome-manuals/{manual_id}/share")
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+
+class TestRotatePin:
+    @pytest.mark.asyncio
+    async def test_rotate_200(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_share_service(
+                "rotate_pin", return_value=_share_response(pin="9999"),
+            ):
+                client = TestClient(app)
+                response = client.patch(f"/welcome-manuals/{manual_id}/share", json={})
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 200
+        assert response.json()["share_pin"] == "9999"
+
+    @pytest.mark.asyncio
+    async def test_rotate_with_explicit_pin(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_share_service(
+                "rotate_pin", return_value=_share_response(pin="1111"),
+            ) as mock_rotate:
+                client = TestClient(app)
+                response = client.patch(
+                    f"/welcome-manuals/{manual_id}/share", json={"pin": "1111"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 200
+        assert mock_rotate.call_args.args[-1] == "1111"
+
+    @pytest.mark.asyncio
+    async def test_rotate_invalid_pin_format_422(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            client = TestClient(app)
+            response = client.patch(
+                f"/welcome-manuals/{manual_id}/share", json={"pin": "12"},
+            )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_rotate_manual_404(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_share_service(
+                "rotate_pin",
+                side_effect=welcome_manual_share_service.ManualNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.patch(f"/welcome-manuals/{manual_id}/share", json={})
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_rotate_not_shared_404(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_share_service(
+                "rotate_pin",
+                side_effect=welcome_manual_share_service.ShareNotEnabledError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.patch(f"/welcome-manuals/{manual_id}/share", json={})
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+
+class TestRevoke:
+    @pytest.mark.asyncio
+    async def test_revoke_204(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_share_service("revoke_share", return_value=None):
+                client = TestClient(app)
+                response = client.delete(f"/welcome-manuals/{manual_id}/share")
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_revoke_manual_404(self) -> None:
+        org_id, user_id, manual_id = (uuid.uuid4() for _ in range(3))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_share_service(
+                "revoke_share",
+                side_effect=welcome_manual_share_service.ManualNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.delete(f"/welcome-manuals/{manual_id}/share")
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_share_service.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_share_service.py
@@ -1,0 +1,450 @@
+"""Service-layer tests for welcome_manual_share_service.
+
+Patches ``AsyncSessionLocal`` + ``unit_of_work`` on the service module to
+point at the in-memory SQLite session (same pattern as
+test_welcome_manual_service.py) so the ``EncryptedString`` round-trip and the
+real per-manual DB lockout logic are exercised end-to-end.
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.welcome_manual_constants import SHARE_UNLOCK_MAX_ATTEMPTS
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.welcome_manuals import (
+    welcome_manual_place_repo,
+    welcome_manual_repo,
+    welcome_manual_section_field_repo,
+    welcome_manual_section_repo,
+)
+from app.services.welcome_manuals import welcome_manual_share_service
+
+
+def _patch(db: AsyncSession):
+    @asynccontextmanager
+    async def _fake():
+        yield db
+
+    return patch.multiple(
+        "app.services.welcome_manuals.welcome_manual_share_service",
+        AsyncSessionLocal=_fake,
+        unit_of_work=_fake,
+    )
+
+
+def _wrong_pin(correct: str) -> str:
+    """A 4-digit PIN guaranteed to differ from ``correct`` (avoids the
+    ~1-in-10000 flake risk of a hardcoded guess colliding with the randomly
+    generated real PIN)."""
+    return "0000" if correct != "0000" else "1111"
+
+
+async def _make_manual(db: AsyncSession, org: Organization, user: User, *, title: str = "Cabin Guide"):
+    manual = await welcome_manual_repo.create_manual(
+        db, organization_id=org.id, user_id=user.id,
+        property_id=None, title=title, intro_text="Welcome!",
+    )
+    await db.flush()
+    return manual
+
+
+class TestEnableShare:
+    @pytest.mark.asyncio
+    async def test_enable_returns_token_and_pin(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            resp = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+        assert resp.share_token
+        assert resp.share_path == f"/guide/{resp.share_token}"
+        assert resp.share_pin.isdigit()
+        assert len(resp.share_pin) == 4
+
+    @pytest.mark.asyncio
+    async def test_enable_is_idempotent(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            first = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+            second = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+        assert second.share_token == first.share_token
+        assert second.share_pin == first.share_pin
+
+    @pytest.mark.asyncio
+    async def test_enable_missing_manual_raises(
+        self, db: AsyncSession, test_org: Organization,
+    ) -> None:
+        with _patch(db):
+            with pytest.raises(welcome_manual_share_service.ManualNotFoundError):
+                await welcome_manual_share_service.enable_share(
+                    test_org.id, uuid.uuid4(), uuid.uuid4(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_enable_cross_org_raises(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            with pytest.raises(welcome_manual_share_service.ManualNotFoundError):
+                await welcome_manual_share_service.enable_share(
+                    uuid.uuid4(), test_user.id, manual.id,
+                )
+
+
+class TestRotatePin:
+    @pytest.mark.asyncio
+    async def test_rotate_changes_pin_and_old_pin_then_fails(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+            rotated = await welcome_manual_share_service.rotate_pin(
+                test_org.id, test_user.id, manual.id, None,
+            )
+            await db.commit()
+            assert rotated.share_token == enabled.share_token
+            assert rotated.share_pin != enabled.share_pin
+
+            # Old PIN no longer unlocks.
+            with pytest.raises(welcome_manual_share_service.IncorrectPinError):
+                await welcome_manual_share_service.unlock_public(
+                    rotated.share_token, enabled.share_pin,
+                )
+            # New PIN does.
+            unlocked = await welcome_manual_share_service.unlock_public(
+                rotated.share_token, rotated.share_pin,
+            )
+        assert unlocked.title == manual.title
+
+    @pytest.mark.asyncio
+    async def test_rotate_with_explicit_pin(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+            rotated = await welcome_manual_share_service.rotate_pin(
+                test_org.id, test_user.id, manual.id, "1234",
+            )
+        assert rotated.share_pin == "1234"
+
+    @pytest.mark.asyncio
+    async def test_rotate_not_shared_raises(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            with pytest.raises(welcome_manual_share_service.ShareNotEnabledError):
+                await welcome_manual_share_service.rotate_pin(
+                    test_org.id, test_user.id, manual.id, None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_rotate_missing_manual_raises(
+        self, db: AsyncSession, test_org: Organization,
+    ) -> None:
+        with _patch(db):
+            with pytest.raises(welcome_manual_share_service.ManualNotFoundError):
+                await welcome_manual_share_service.rotate_pin(
+                    test_org.id, uuid.uuid4(), uuid.uuid4(), None,
+                )
+
+
+class TestRevoke:
+    @pytest.mark.asyncio
+    async def test_revoke_clears_token_and_pin_then_gate_and_unlock_404(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+            await welcome_manual_share_service.revoke_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+
+            assert await welcome_manual_share_service.get_public_gate(enabled.share_token) is False
+
+            with pytest.raises(welcome_manual_share_service.ManualNotFoundError):
+                await welcome_manual_share_service.unlock_public(
+                    enabled.share_token, enabled.share_pin,
+                )
+
+    @pytest.mark.asyncio
+    async def test_revoke_missing_manual_raises(
+        self, db: AsyncSession, test_org: Organization,
+    ) -> None:
+        with _patch(db):
+            with pytest.raises(welcome_manual_share_service.ManualNotFoundError):
+                await welcome_manual_share_service.revoke_share(
+                    test_org.id, uuid.uuid4(), uuid.uuid4(),
+                )
+
+
+class TestPublicGate:
+    @pytest.mark.asyncio
+    async def test_gate_true_for_shared_manual(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+            assert await welcome_manual_share_service.get_public_gate(enabled.share_token) is True
+
+    @pytest.mark.asyncio
+    async def test_gate_false_for_unknown_token(self, db: AsyncSession) -> None:
+        with _patch(db):
+            assert await welcome_manual_share_service.get_public_gate("no-such-token") is False
+
+
+class TestUnlockPublic:
+    @pytest.mark.asyncio
+    async def test_correct_pin_returns_sections_and_places(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        section = await welcome_manual_section_repo.create(
+            db, manual_id=manual.id, title="Wi-Fi", body="Connect to GuestNet", display_order=0,
+        )
+        await welcome_manual_section_field_repo.create(
+            db, section_id=section.id, label="Password", value="hunter2", display_order=0,
+        )
+        await welcome_manual_place_repo.create(
+            db, manual_id=manual.id, name="Taco Spot", cuisine="Mexican",
+            price_tier="$$", note=None, map_url=None, display_order=0,
+        )
+        await db.commit()
+
+        with _patch(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+            unlocked = await welcome_manual_share_service.unlock_public(
+                enabled.share_token, enabled.share_pin,
+            )
+
+        assert unlocked.title == manual.title
+        assert len(unlocked.sections) == 1
+        assert unlocked.sections[0].title == "Wi-Fi"
+        assert unlocked.sections[0].fields[0].label == "Password"
+        assert unlocked.sections[0].fields[0].value == "hunter2"
+        assert len(unlocked.places) == 1
+        assert unlocked.places[0].name == "Taco Spot"
+
+    @pytest.mark.asyncio
+    async def test_security_no_sensitive_fields_leak(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The unlock success payload must never carry organization_id,
+        share_token, share_pin, or any owner/user id/email."""
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+            unlocked = await welcome_manual_share_service.unlock_public(
+                enabled.share_token, enabled.share_pin,
+            )
+        dumped = unlocked.model_dump()
+        forbidden = {
+            "organization_id", "user_id", "owner_id", "email",
+            "share_token", "share_pin", "id", "manual_id",
+            "created_at", "updated_at", "deleted_at",
+        }
+        assert forbidden.isdisjoint(dumped.keys())
+        for section in dumped["sections"]:
+            assert forbidden.isdisjoint(section.keys())
+
+    @pytest.mark.asyncio
+    async def test_wrong_pin_raises_incorrect_pin(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+            with pytest.raises(welcome_manual_share_service.IncorrectPinError):
+                await welcome_manual_share_service.unlock_public(
+                    enabled.share_token, _wrong_pin(enabled.share_pin),
+                )
+
+    @pytest.mark.asyncio
+    async def test_unknown_token_raises_manual_not_found(self, db: AsyncSession) -> None:
+        with _patch(db):
+            with pytest.raises(welcome_manual_share_service.ManualNotFoundError):
+                await welcome_manual_share_service.unlock_public(
+                    "no-such-token", "0000",
+                )
+
+    @pytest.mark.asyncio
+    async def test_lockout_after_max_attempts(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+
+            wrong = _wrong_pin(enabled.share_pin)
+            for _ in range(SHARE_UNLOCK_MAX_ATTEMPTS):
+                with pytest.raises(welcome_manual_share_service.IncorrectPinError):
+                    await welcome_manual_share_service.unlock_public(
+                        enabled.share_token, wrong,
+                    )
+
+            # Cap reached — even the CORRECT pin is now rejected until the
+            # lockout window elapses.
+            with pytest.raises(HTTPException) as exc_info:
+                await welcome_manual_share_service.unlock_public(
+                    enabled.share_token, enabled.share_pin,
+                )
+            assert exc_info.value.status_code == 429
+
+    @pytest.mark.asyncio
+    async def test_lockout_is_scoped_per_manual_not_global(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The lockout is keyed on the manual (its share token), persisted on
+        the row — so it can't be escaped by rotating the client IP / any
+        request header (finding #1: a per-IP key was spoofable via
+        ``X-Forwarded-For``), yet it also doesn't spill onto OTHER manuals.
+
+        Lock manual A with wrong PINs; manual B (independent share) is still
+        unlockable, and A stays locked regardless of who's asking."""
+        manual_a = await _make_manual(db, test_org, test_user, title="Guide A")
+        manual_b = await _make_manual(db, test_org, test_user, title="Guide B")
+        await db.commit()
+        with _patch(db):
+            enabled_a = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual_a.id,
+            )
+            enabled_b = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual_b.id,
+            )
+            await db.commit()
+
+            for _ in range(SHARE_UNLOCK_MAX_ATTEMPTS):
+                with pytest.raises(welcome_manual_share_service.IncorrectPinError):
+                    await welcome_manual_share_service.unlock_public(
+                        enabled_a.share_token, _wrong_pin(enabled_a.share_pin),
+                    )
+
+            # A is locked — correct PIN still 429 (spoofing IP can't help; the
+            # key is the token, and there is no IP input anymore).
+            with pytest.raises(HTTPException) as exc_info:
+                await welcome_manual_share_service.unlock_public(
+                    enabled_a.share_token, enabled_a.share_pin,
+                )
+            assert exc_info.value.status_code == 429
+
+            # B is untouched by A's lockout.
+            unlocked_b = await welcome_manual_share_service.unlock_public(
+                enabled_b.share_token, enabled_b.share_pin,
+            )
+        assert unlocked_b.title == manual_b.title
+
+    @pytest.mark.asyncio
+    async def test_successful_unlocks_never_lock_out(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """A guest reopening the guide with the CORRECT PIN can never lock
+        themselves out — successes don't count toward the cap (the failure-
+        only-counting fix; v1 re-prompts on every refresh)."""
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+
+            # Far more correct unlocks than the wrong-PIN cap — all succeed.
+            for _ in range(SHARE_UNLOCK_MAX_ATTEMPTS + 3):
+                unlocked = await welcome_manual_share_service.unlock_public(
+                    enabled.share_token, enabled.share_pin,
+                )
+                assert unlocked.title == manual.title
+
+    @pytest.mark.asyncio
+    async def test_success_resets_failure_counter(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """A correct PIN resets the accumulated failure count, so a guest who
+        fat-fingers the code a few times then gets it right starts fresh — the
+        next run of wrong guesses has the full budget again, never a carried-
+        over 429."""
+        manual = await _make_manual(db, test_org, test_user)
+        await db.commit()
+        with _patch(db):
+            enabled = await welcome_manual_share_service.enable_share(
+                test_org.id, test_user.id, manual.id,
+            )
+            await db.commit()
+            wrong = _wrong_pin(enabled.share_pin)
+
+            # One below the cap, then a correct unlock resets the counter.
+            for _ in range(SHARE_UNLOCK_MAX_ATTEMPTS - 1):
+                with pytest.raises(welcome_manual_share_service.IncorrectPinError):
+                    await welcome_manual_share_service.unlock_public(
+                        enabled.share_token, wrong,
+                    )
+            reset = await welcome_manual_share_service.unlock_public(
+                enabled.share_token, enabled.share_pin,
+            )
+            assert reset.title == manual.title
+
+            # Budget is full again: another (cap - 1) wrong guesses are all
+            # plain 401s, NOT a 429 — proving the counter reset to 0.
+            for _ in range(SHARE_UNLOCK_MAX_ATTEMPTS - 1):
+                with pytest.raises(welcome_manual_share_service.IncorrectPinError):
+                    await welcome_manual_share_service.unlock_public(
+                        enabled.share_token, wrong,
+                    )

--- a/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout-mock.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout-mock.spec.ts
@@ -171,6 +171,8 @@ async function stubDetail(
           updated_at: "2026-01-01T00:00:00Z",
         })),
         places,
+        share_token: null,
+        share_pin: null,
         created_at: "2026-01-01T00:00:00Z",
         updated_at: "2026-01-01T00:00:00Z",
       }),

--- a/apps/mybookkeeper/frontend/src/App.tsx
+++ b/apps/mybookkeeper/frontend/src/App.tsx
@@ -53,6 +53,7 @@ import Security from "@/app/pages/Security";
 import Forbidden from "@/app/pages/Forbidden";
 import OAuthCallback from "@/app/pages/OAuthCallback";
 import PublicInquiryForm from "@/app/pages/PublicInquiryForm";
+import PublicWelcomeManual from "@/app/pages/PublicWelcomeManual";
 
 import PrivacyPolicy from "@/app/pages/PrivacyPolicy";
 import TermsOfService from "@/app/pages/TermsOfService";
@@ -91,6 +92,8 @@ export default function App() {
             <Route path="/verify-email" element={<VerifyEmail />} />
             {/* Public inquiry form (T0) — unauthenticated, no Layout. */}
             <Route path="/apply/:slug" element={<PublicInquiryForm />} />
+            {/* Public PIN-protected welcome manual guide — unauthenticated, no Layout. */}
+            <Route path="/guide/:token" element={<PublicWelcomeManual />} />
             <Route
               path="/onboarding"
               element={

--- a/apps/mybookkeeper/frontend/src/__tests__/PublicWelcomeManual.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/PublicWelcomeManual.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Tests for the public, unauthenticated welcome-manual guide page.
+ *
+ * Covers:
+ * - Gate 200 shows the PIN form.
+ * - Gate 404 (or any gate failure) shows the "not active" state.
+ * - Wrong PIN (401) shows an inline error and clears the field.
+ * - Rate-limited (429) shows the rate-limit message.
+ * - Correct PIN renders the read-only preview + Where to Eat directory.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import PublicWelcomeManual from "@/app/pages/PublicWelcomeManual";
+
+vi.mock("@/shared/lib/api", () => ({
+  default: { get: vi.fn(), post: vi.fn() },
+}));
+
+import api from "@/shared/lib/api";
+
+const mockManual = {
+  title: "Lakeview Welcome Guide",
+  sections: [
+    {
+      title: "Wi-Fi",
+      body: "Network: Lakeview, Password: guest1234",
+      fields: [{ label: "Wi-Fi network", value: "Lakeview" }],
+      images: [],
+    },
+  ],
+  places: [
+    {
+      name: "Taco Spot",
+      cuisine: "Mexican",
+      price_tier: "$",
+      note: "Great al pastor",
+      map_url: null,
+      display_order: 0,
+    },
+  ],
+};
+
+function renderPage(token = "tok-abc123") {
+  return render(
+    <MemoryRouter initialEntries={[`/guide/${token}`]}>
+      <Routes>
+        <Route path="/guide/:token" element={<PublicWelcomeManual />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PublicWelcomeManual — gate", () => {
+  it("shows the PIN form when the gate check succeeds", async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { requires_pin: true } });
+    renderPage();
+    expect(await screen.findByTestId("public-welcome-manual-pin-form")).toBeInTheDocument();
+    expect(api.get).toHaveBeenCalledWith("/public/welcome-manuals/tok-abc123");
+  });
+
+  it("shows the not-active state when the gate check 404s", async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce({ response: { status: 404 } });
+    renderPage("unknown-token");
+    expect(await screen.findByTestId("public-welcome-manual-not-active")).toBeInTheDocument();
+    expect(screen.getByText(/isn't active/i)).toBeInTheDocument();
+  });
+});
+
+describe("PublicWelcomeManual — unlock", () => {
+  it("shows an inline error and clears the field on a wrong PIN", async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { requires_pin: true } });
+    (api.post as ReturnType<typeof vi.fn>).mockRejectedValueOnce({ response: { status: 401 } });
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByTestId("public-welcome-manual-pin-form");
+    const input = screen.getByTestId("public-welcome-manual-pin-input");
+    await user.type(input, "0000");
+    await user.click(screen.getByTestId("public-welcome-manual-pin-submit"));
+
+    expect(await screen.findByTestId("public-welcome-manual-pin-error")).toHaveTextContent(
+      /Incorrect code/i,
+    );
+    await waitFor(() => expect(input).toHaveValue(""));
+  });
+
+  it("shows a rate-limit message on 429", async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { requires_pin: true } });
+    (api.post as ReturnType<typeof vi.fn>).mockRejectedValueOnce({ response: { status: 429 } });
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByTestId("public-welcome-manual-pin-form");
+    await user.type(screen.getByTestId("public-welcome-manual-pin-input"), "1234");
+    await user.click(screen.getByTestId("public-welcome-manual-pin-submit"));
+
+    expect(await screen.findByTestId("public-welcome-manual-pin-error")).toHaveTextContent(
+      /Too many attempts/i,
+    );
+  });
+
+  it("renders the read-only preview and Where to Eat directory on a correct PIN", async () => {
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { requires_pin: true } });
+    (api.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: mockManual });
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByTestId("public-welcome-manual-pin-form");
+    await user.type(screen.getByTestId("public-welcome-manual-pin-input"), "4321");
+    await user.click(screen.getByTestId("public-welcome-manual-pin-submit"));
+
+    expect(await screen.findByTestId("welcome-manual-preview")).toBeInTheDocument();
+    expect(screen.getByText("Lakeview Welcome Guide")).toBeInTheDocument();
+    expect(screen.getByText("Wi-Fi")).toBeInTheDocument();
+    expect(screen.getByTestId("welcome-manual-place-directory")).toBeInTheDocument();
+    expect(screen.getByText("Taco Spot")).toBeInTheDocument();
+    expect(api.post).toHaveBeenCalledWith("/public/welcome-manuals/tok-abc123/unlock", {
+      pin: "4321",
+    });
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualCreateDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualCreateDialog.test.tsx
@@ -45,6 +45,8 @@ const CREATED: WelcomeManualResponse = {
   intro_text: null,
   sections: [],
   places: [],
+  share_token: null,
+  share_pin: null,
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
 };

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualDetail.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualDetail.test.tsx
@@ -35,6 +35,9 @@ vi.mock("@/shared/store/welcomeManualsApi", () => ({
   })),
   useCreateSectionMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useDeleteWelcomeManualMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useEnableWelcomeManualShareMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useUpdateWelcomeManualShareMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useRevokeWelcomeManualShareMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useUpdateSectionMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useDeleteSectionMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useReorderSectionsMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
@@ -77,6 +80,8 @@ function makeManual(sections: WelcomeManualSectionResponse[]): WelcomeManualResp
     intro_text: null,
     sections,
     places: [],
+    share_token: null,
+    share_pin: null,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
   };

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualShareCard.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualShareCard.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for WelcomeManualShareCard.
+ *
+ * Verifies:
+ *   - Unshared state shows only the "Create share link" button.
+ *   - Shared state shows the URL, PIN, copy buttons, regenerate, and revoke.
+ *   - Clicking "Create share link" invokes the enable mutation.
+ *   - Clicking "Revoke link" opens the confirm dialog before actually revoking.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import WelcomeManualShareCard from "@/app/features/welcome-manuals/WelcomeManualShareCard";
+
+const enableShareMock = vi.fn(() => ({ unwrap: () => Promise.resolve({}) }));
+const updateShareMock = vi.fn(() => ({
+  unwrap: () => Promise.resolve({ share_token: "tok", share_path: "/guide/tok", share_pin: "5678" }),
+}));
+const revokeShareMock = vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) }));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+vi.mock("@/shared/store/welcomeManualsApi", () => ({
+  useEnableWelcomeManualShareMutation: () => [enableShareMock, { isLoading: false }],
+  useUpdateWelcomeManualShareMutation: () => [updateShareMock, { isLoading: false }],
+  useRevokeWelcomeManualShareMutation: () => [revokeShareMock, { isLoading: false }],
+}));
+
+describe("WelcomeManualShareCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows only the create button when the manual is not shared", () => {
+    render(<WelcomeManualShareCard manualId="m-1" shareToken={null} sharePin={null} />);
+    expect(screen.getByTestId("create-share-link-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("share-link-url-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("revoke-share-link-button")).not.toBeInTheDocument();
+  });
+
+  it("calls the enable mutation when Create share link is clicked", () => {
+    render(<WelcomeManualShareCard manualId="m-1" shareToken={null} sharePin={null} />);
+    fireEvent.click(screen.getByTestId("create-share-link-button"));
+    expect(enableShareMock).toHaveBeenCalledWith("m-1");
+  });
+
+  it("shows the URL, PIN, copy buttons, regenerate, and revoke once shared", () => {
+    render(<WelcomeManualShareCard manualId="m-1" shareToken="tok-123" sharePin="4321" />);
+    expect(screen.getByTestId("share-link-url-input")).toHaveValue(
+      `${window.location.origin}/guide/tok-123`,
+    );
+    expect(screen.getByTestId("share-pin-input")).toHaveValue("4321");
+    expect(screen.getByTestId("copy-share-link-button")).toBeInTheDocument();
+    expect(screen.getByTestId("copy-share-pin-button")).toBeInTheDocument();
+    expect(screen.getByTestId("regenerate-share-pin-button")).toBeInTheDocument();
+    expect(screen.getByTestId("revoke-share-link-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("create-share-link-button")).not.toBeInTheDocument();
+  });
+
+  it("calls the regenerate mutation when Regenerate code is clicked", () => {
+    render(<WelcomeManualShareCard manualId="m-1" shareToken="tok-123" sharePin="4321" />);
+    fireEvent.click(screen.getByTestId("regenerate-share-pin-button"));
+    expect(updateShareMock).toHaveBeenCalledWith({ manualId: "m-1", data: {} });
+  });
+
+  it("opens the confirm dialog instead of revoking immediately", () => {
+    render(<WelcomeManualShareCard manualId="m-1" shareToken="tok-123" sharePin="4321" />);
+    fireEvent.click(screen.getByTestId("revoke-share-link-button"));
+    expect(revokeShareMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/Revoke this share link\?/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    expect(revokeShareMock).toHaveBeenCalledWith("m-1");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/PublicWelcomeManualGateSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/PublicWelcomeManualGateSkeleton.tsx
@@ -1,0 +1,16 @@
+/** Mirrors the loaded PIN-form card while the public gate check is in flight. */
+export default function PublicWelcomeManualGateSkeleton() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-muted px-4">
+      <div
+        className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm space-y-4 animate-pulse"
+        data-testid="public-welcome-manual-gate-skeleton"
+      >
+        <div className="h-6 w-2/3 mx-auto bg-muted-foreground/20 rounded" />
+        <div className="h-4 w-full bg-muted-foreground/10 rounded" />
+        <div className="h-11 w-full bg-muted-foreground/10 rounded-md" />
+        <div className="h-11 w-full bg-muted-foreground/20 rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/PublicWelcomeManualPinForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/PublicWelcomeManualPinForm.tsx
@@ -1,0 +1,95 @@
+import { useRef, useState } from "react";
+import { LoadingButton } from "@platform/ui";
+
+export type PublicWelcomeManualUnlockError = "invalid" | "rate-limited" | "unknown";
+
+export interface PublicWelcomeManualUnlockResult {
+  success: boolean;
+  error?: PublicWelcomeManualUnlockError;
+}
+
+export interface PublicWelcomeManualPinFormProps {
+  onSubmit: (pin: string) => Promise<PublicWelcomeManualUnlockResult>;
+}
+
+const ERROR_MESSAGES: Record<PublicWelcomeManualUnlockError, string> = {
+  invalid: "Incorrect code — try again.",
+  "rate-limited": "Too many attempts. Try again in a few minutes.",
+  unknown: "Something went wrong. Please try again.",
+};
+
+/**
+ * PIN entry gate for the public welcome-manual guide page. The code is never
+ * put in the URL — it's submitted via POST so it doesn't leak into browser
+ * history, referrer headers, or server access logs.
+ */
+export default function PublicWelcomeManualPinForm({ onSubmit }: PublicWelcomeManualPinFormProps) {
+  const [pin, setPin] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = pin.trim();
+    if (!trimmed || submitting) return;
+
+    setSubmitting(true);
+    setError(null);
+    const result = await onSubmit(trimmed);
+    setSubmitting(false);
+
+    if (!result.success) {
+      setError(ERROR_MESSAGES[result.error ?? "unknown"]);
+      setPin("");
+      inputRef.current?.focus();
+    }
+  }
+
+  return (
+    <div
+      className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm"
+      data-testid="public-welcome-manual-pin-form"
+    >
+      <h1 className="text-xl font-semibold mb-2 text-center">Enter your access code</h1>
+      <p className="text-sm text-muted-foreground mb-6 text-center">
+        Your host gave you a short code along with this link.
+      </p>
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        <input
+          ref={inputRef}
+          type="text"
+          autoComplete="off"
+          autoFocus
+          maxLength={12}
+          value={pin}
+          onChange={(e) => setPin(e.target.value)}
+          placeholder="Access code"
+          aria-label="Access code"
+          disabled={submitting}
+          className="w-full border rounded-md px-3 py-2 text-center text-lg tracking-widest font-mono min-h-[44px]"
+          data-testid="public-welcome-manual-pin-input"
+        />
+        {error ? (
+          <p
+            className="text-sm text-red-600 text-center"
+            role="alert"
+            data-testid="public-welcome-manual-pin-error"
+          >
+            {error}
+          </p>
+        ) : null}
+        <LoadingButton
+          type="submit"
+          className="w-full"
+          isLoading={submitting}
+          loadingText="Checking..."
+          disabled={!pin.trim() || submitting}
+          data-testid="public-welcome-manual-pin-submit"
+        >
+          Unlock
+        </LoadingButton>
+      </form>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualShareCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualShareCard.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import { Copy } from "lucide-react";
+import { LoadingButton, ConfirmDialog } from "@platform/ui";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import {
+  useEnableWelcomeManualShareMutation,
+  useUpdateWelcomeManualShareMutation,
+  useRevokeWelcomeManualShareMutation,
+} from "@/shared/store/welcomeManualsApi";
+
+export interface WelcomeManualShareCardProps {
+  manualId: string;
+  shareToken: string | null;
+  sharePin: string | null;
+}
+
+/**
+ * Lets a host create, rotate, or revoke a PIN-protected public share link
+ * for a welcome manual (`/guide/:token`). The manual holds Wi-Fi / check-in
+ * details, so guests must enter the current PIN before anything renders.
+ */
+export default function WelcomeManualShareCard({
+  manualId,
+  shareToken,
+  sharePin,
+}: WelcomeManualShareCardProps) {
+  const [showRevokeConfirm, setShowRevokeConfirm] = useState(false);
+  const [enableShare, { isLoading: isEnabling }] = useEnableWelcomeManualShareMutation();
+  const [updateShare, { isLoading: isRegenerating }] = useUpdateWelcomeManualShareMutation();
+  const [revokeShare, { isLoading: isRevoking }] = useRevokeWelcomeManualShareMutation();
+
+  const shareUrl = shareToken ? `${window.location.origin}/guide/${shareToken}` : null;
+
+  async function copyToClipboard(value: string, label: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      showSuccess(`${label} copied to clipboard.`);
+    } catch {
+      showError(`Couldn't copy — try selecting the ${label.toLowerCase()} manually.`);
+    }
+  }
+
+  async function handleEnable() {
+    try {
+      await enableShare(manualId).unwrap();
+      showSuccess("Share link created.");
+    } catch {
+      showError("I couldn't create a share link. Want to try again?");
+    }
+  }
+
+  async function handleRegenerate() {
+    try {
+      const result = await updateShare({ manualId, data: {} }).unwrap();
+      showSuccess(`New code: ${result.share_pin}`);
+    } catch {
+      showError("I couldn't regenerate the code. Want to try again?");
+    }
+  }
+
+  async function handleRevoke() {
+    try {
+      await revokeShare(manualId).unwrap();
+      showSuccess("Share link revoked.");
+      setShowRevokeConfirm(false);
+    } catch {
+      showError("I couldn't revoke the link. Want to try again?");
+    }
+  }
+
+  return (
+    <section
+      className="border rounded-lg p-4 bg-card space-y-3"
+      data-testid="welcome-manual-share-card"
+    >
+      <h2 className="text-sm font-medium">Share link</h2>
+
+      {!shareToken ? (
+        <>
+          <p className="text-xs text-muted-foreground">
+            Create a PIN-protected link guests can open without an account.
+          </p>
+          <LoadingButton
+            variant="secondary"
+            size="sm"
+            isLoading={isEnabling}
+            loadingText="Creating..."
+            onClick={() => void handleEnable()}
+            data-testid="create-share-link-button"
+          >
+            Create share link
+          </LoadingButton>
+        </>
+      ) : (
+        <>
+          <p className="text-xs text-muted-foreground">
+            Give guests the link + this code. Rotate it per guest below.
+          </p>
+
+          <div className="flex items-stretch gap-2 flex-wrap">
+            <input
+              readOnly
+              value={shareUrl ?? ""}
+              className="flex-1 min-w-0 border rounded-md px-3 py-2 text-sm bg-muted/40 font-mono"
+              aria-label="Share link URL"
+              data-testid="share-link-url-input"
+            />
+            <LoadingButton
+              variant="secondary"
+              size="sm"
+              isLoading={false}
+              onClick={() => void copyToClipboard(shareUrl ?? "", "Link")}
+              data-testid="copy-share-link-button"
+            >
+              <Copy className="h-4 w-4 mr-1" aria-hidden="true" />
+              Copy link
+            </LoadingButton>
+          </div>
+
+          <div className="flex items-stretch gap-2 flex-wrap">
+            <input
+              readOnly
+              value={sharePin ?? ""}
+              className="flex-1 min-w-0 border rounded-md px-3 py-2 text-sm bg-muted/40 font-mono"
+              aria-label="Share access code"
+              data-testid="share-pin-input"
+            />
+            <LoadingButton
+              variant="secondary"
+              size="sm"
+              isLoading={false}
+              onClick={() => void copyToClipboard(sharePin ?? "", "Code")}
+              data-testid="copy-share-pin-button"
+            >
+              <Copy className="h-4 w-4 mr-1" aria-hidden="true" />
+              Copy code
+            </LoadingButton>
+          </div>
+
+          <div className="flex gap-2 flex-wrap">
+            <LoadingButton
+              variant="secondary"
+              size="sm"
+              isLoading={isRegenerating}
+              loadingText="Regenerating..."
+              onClick={() => void handleRegenerate()}
+              data-testid="regenerate-share-pin-button"
+            >
+              Regenerate code
+            </LoadingButton>
+            <LoadingButton
+              variant="secondary"
+              size="sm"
+              isLoading={false}
+              className="text-red-600 border-red-200 hover:bg-red-50"
+              onClick={() => setShowRevokeConfirm(true)}
+              data-testid="revoke-share-link-button"
+            >
+              Revoke link
+            </LoadingButton>
+          </div>
+
+          <ConfirmDialog
+            open={showRevokeConfirm}
+            title="Revoke this share link?"
+            description="Anyone with the current link + code will lose access."
+            confirmLabel="Revoke"
+            cancelLabel="Cancel"
+            variant="danger"
+            isLoading={isRevoking}
+            onConfirm={handleRevoke}
+            onCancel={() => setShowRevokeConfirm(false)}
+          />
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/public-welcome-manual-gate-phase.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/public-welcome-manual-gate-phase.ts
@@ -1,0 +1,13 @@
+/**
+ * Gate phases for the public welcome-manual guest page (before the manual
+ * content is unlocked). Extracted to an `as const` map rather than an inline
+ * string-literal union so the phase values live in one place instead of being
+ * repeated as magic strings across comparisons.
+ */
+export const GATE_PHASE = {
+  LOADING: "loading",
+  LOCKED: "locked",
+  NOT_ACTIVE: "not-active",
+} as const;
+
+export type GatePhase = (typeof GATE_PHASE)[keyof typeof GATE_PHASE];

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/public-welcome-manual-preview-mapper.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/public-welcome-manual-preview-mapper.ts
@@ -1,0 +1,63 @@
+import type { PublicWelcomeManualPlace } from "@/shared/types/welcome-manual/public-welcome-manual-place";
+import type { PublicWelcomeManualSection } from "@/shared/types/welcome-manual/public-welcome-manual-section";
+import type { WelcomeManualPlaceResponse } from "@/shared/types/welcome-manual/welcome-manual-place-response";
+import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+
+/**
+ * The public guide endpoint returns a trimmed shape (no ids, manual/section
+ * parent ids, or timestamps — a guest never needs them). These mappers pad
+ * that trimmed shape back out to the full admin response types so the guest
+ * page can reuse `WelcomeManualPreview` unmodified. Synthesized ids/orders
+ * are index-based and only used as React keys / prop values the preview
+ * doesn't otherwise interpret.
+ */
+export function mapPublicSectionsToPreview(
+  sections: PublicWelcomeManualSection[],
+): WelcomeManualSectionResponse[] {
+  return sections.map((section, sectionIndex) => {
+    const sectionId = `section-${sectionIndex}`;
+    return {
+      id: sectionId,
+      manual_id: "public",
+      title: section.title,
+      body: section.body,
+      display_order: sectionIndex,
+      fields: section.fields.map((field, fieldIndex) => ({
+        id: `${sectionId}-field-${fieldIndex}`,
+        section_id: sectionId,
+        label: field.label,
+        value: field.value,
+        display_order: fieldIndex,
+        created_at: "",
+      })),
+      images: section.images.map((image) => ({
+        id: image.id,
+        section_id: sectionId,
+        storage_key: "",
+        caption: image.caption,
+        display_order: image.display_order,
+        created_at: "",
+        presigned_url: image.presigned_url,
+        is_available: image.is_available,
+      })),
+      created_at: "",
+      updated_at: "",
+    };
+  });
+}
+
+export function mapPublicPlacesToPreview(
+  places: PublicWelcomeManualPlace[],
+): WelcomeManualPlaceResponse[] {
+  return places.map((place, index) => ({
+    id: `place-${index}`,
+    manual_id: "public",
+    name: place.name,
+    cuisine: place.cuisine,
+    price_tier: place.price_tier,
+    note: place.note,
+    map_url: place.map_url,
+    display_order: place.display_order,
+    created_at: "",
+  }));
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/PublicWelcomeManual.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/PublicWelcomeManual.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import api from "@/shared/lib/api";
+import type { PublicWelcomeManualResponse } from "@/shared/types/welcome-manual/public-welcome-manual-response";
+import WelcomeManualPreview from "@/app/features/welcome-manuals/WelcomeManualPreview";
+import PublicWelcomeManualPinForm, {
+  type PublicWelcomeManualUnlockResult,
+} from "@/app/features/welcome-manuals/PublicWelcomeManualPinForm";
+import PublicWelcomeManualGateSkeleton from "@/app/features/welcome-manuals/PublicWelcomeManualGateSkeleton";
+import {
+  mapPublicPlacesToPreview,
+  mapPublicSectionsToPreview,
+} from "@/app/features/welcome-manuals/public-welcome-manual-preview-mapper";
+import {
+  GATE_PHASE,
+  type GatePhase,
+} from "@/app/features/welcome-manuals/public-welcome-manual-gate-phase";
+
+function unlockErrorKind(err: unknown): "invalid" | "rate-limited" | "unknown" {
+  const status = (err as { response?: { status?: number } })?.response?.status;
+  if (status === 401) return "invalid";
+  if (status === 429) return "rate-limited";
+  return "unknown";
+}
+
+/**
+ * Public, unauthenticated guest page for a shared welcome manual. The manual
+ * holds Wi-Fi / check-in details, so nothing beyond the PIN form renders
+ * until the guest submits the correct code. v1 intentionally has no guest
+ * session — a page refresh re-prompts for the PIN.
+ */
+export default function PublicWelcomeManual() {
+  const { token = "" } = useParams<{ token: string }>();
+  const [phase, setPhase] = useState<GatePhase>(GATE_PHASE.LOADING);
+  const [manual, setManual] = useState<PublicWelcomeManualResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .get(`/public/welcome-manuals/${token}`)
+      .then(() => {
+        if (!cancelled) setPhase(GATE_PHASE.LOCKED);
+      })
+      .catch(() => {
+        if (!cancelled) setPhase(GATE_PHASE.NOT_ACTIVE);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  async function handleUnlock(pin: string): Promise<PublicWelcomeManualUnlockResult> {
+    try {
+      const { data } = await api.post<PublicWelcomeManualResponse>(
+        `/public/welcome-manuals/${token}/unlock`,
+        { pin },
+      );
+      setManual(data);
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: unlockErrorKind(err) };
+    }
+  }
+
+  if (manual) {
+    return (
+      <div className="min-h-screen bg-muted py-6 sm:py-12">
+        <div className="mx-auto max-w-2xl px-4">
+          <WelcomeManualPreview
+            title={manual.title}
+            introText={null}
+            sections={mapPublicSectionsToPreview(manual.sections)}
+            places={mapPublicPlacesToPreview(manual.places)}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === GATE_PHASE.LOADING) {
+    return <PublicWelcomeManualGateSkeleton />;
+  }
+
+  if (phase === GATE_PHASE.NOT_ACTIVE) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-muted px-4">
+        <div
+          className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm text-center"
+          data-testid="public-welcome-manual-not-active"
+        >
+          <h1 className="text-xl font-semibold mb-2">This guide link isn't active</h1>
+          <p className="text-sm text-muted-foreground">Ask your host for an updated link.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-muted px-4">
+      <PublicWelcomeManualPinForm onSubmit={handleUnlock} />
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
@@ -32,6 +32,7 @@ import WelcomeManualDetailSkeleton from "@/app/features/welcome-manuals/WelcomeM
 import WelcomeManualSectionCard from "@/app/features/welcome-manuals/WelcomeManualSectionCard";
 import WelcomeManualPreview from "@/app/features/welcome-manuals/WelcomeManualPreview";
 import WelcomeManualPlaceManager from "@/app/features/welcome-manuals/WelcomeManualPlaceManager";
+import WelcomeManualShareCard from "@/app/features/welcome-manuals/WelcomeManualShareCard";
 import WelcomeManualForm from "@/app/features/welcome-manuals/WelcomeManualForm";
 import WelcomeManualEmailDialog from "@/app/features/welcome-manuals/WelcomeManualEmailDialog";
 import DeleteWelcomeManualModal from "@/app/features/welcome-manuals/DeleteWelcomeManualModal";
@@ -260,6 +261,12 @@ export default function WelcomeManualDetail() {
                   </div>
                 ) : null}
               </section>
+
+              <WelcomeManualShareCard
+                manualId={manual.id}
+                shareToken={manual.share_token}
+                sharePin={manual.share_pin}
+              />
 
               {hasSections ? (
                 <DndContext

--- a/apps/mybookkeeper/frontend/src/shared/lib/api.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/api.ts
@@ -23,7 +23,16 @@ api.interceptors.request.use((config) => {
 // third-party integration refresh token that has been revoked). A 401 from
 // these routes must NOT force a logout — it should surface as a normal error
 // so the user can self-serve (e.g. disconnect and reconnect Gmail).
-const BUSINESS_401_URL_PREFIXES: readonly string[] = ["/integrations/gmail/sync"];
+//
+// `/public/welcome-manuals` is the guest PIN gate: a wrong PIN returns 401.
+// Those requests carry no JWT (public page), but a host previewing their own
+// share link in the same browser IS authed — without this exclusion a
+// mistyped PIN would wipe their token and navigate them away before the
+// inline "Incorrect code" error could render, breaking the retry UX.
+const BUSINESS_401_URL_PREFIXES: readonly string[] = [
+  "/integrations/gmail/sync",
+  "/public/welcome-manuals",
+];
 
 function isBusinessLevel401(url: string | undefined): boolean {
   if (!url) return false;

--- a/apps/mybookkeeper/frontend/src/shared/store/welcomeManualsApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/welcomeManualsApi.ts
@@ -11,6 +11,8 @@ import type { WelcomeManualSectionImageResponse } from "@/shared/types/welcome-m
 import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
 import type { WelcomeManualSectionUpdateRequest } from "@/shared/types/welcome-manual/welcome-manual-section-update-request";
 import type { WelcomeManualSendResponse } from "@/shared/types/welcome-manual/welcome-manual-send-response";
+import type { WelcomeManualShareResponse } from "@/shared/types/welcome-manual/welcome-manual-share-response";
+import type { WelcomeManualShareUpdateRequest } from "@/shared/types/welcome-manual/welcome-manual-share-update-request";
 import type { WelcomeManualUpdateRequest } from "@/shared/types/welcome-manual/welcome-manual-update-request";
 
 const welcomeManualsApi = baseApi.injectEndpoints({
@@ -66,6 +68,26 @@ const welcomeManualsApi = baseApi.injectEndpoints({
         data,
       }),
       invalidatesTags: [{ type: "WelcomeManualSend", id: "LIST" }],
+    }),
+    // ---- Share link ----
+    enableWelcomeManualShare: builder.mutation<WelcomeManualShareResponse, string>({
+      query: (manualId) => ({ url: `/welcome-manuals/${manualId}/share`, method: "POST" }),
+      invalidatesTags: (_result, _err, manualId) => [{ type: "WelcomeManual", id: manualId }],
+    }),
+    updateWelcomeManualShare: builder.mutation<
+      WelcomeManualShareResponse,
+      { manualId: string; data: WelcomeManualShareUpdateRequest }
+    >({
+      query: ({ manualId, data }) => ({
+        url: `/welcome-manuals/${manualId}/share`,
+        method: "PATCH",
+        data,
+      }),
+      invalidatesTags: (_result, _err, arg) => [{ type: "WelcomeManual", id: arg.manualId }],
+    }),
+    revokeWelcomeManualShare: builder.mutation<void, string>({
+      query: (manualId) => ({ url: `/welcome-manuals/${manualId}/share`, method: "DELETE" }),
+      invalidatesTags: (_result, _err, manualId) => [{ type: "WelcomeManual", id: manualId }],
     }),
     // ---- Sections ----
     createSection: builder.mutation<
@@ -298,6 +320,9 @@ export const {
   useUpdateWelcomeManualMutation,
   useDeleteWelcomeManualMutation,
   useEmailWelcomeManualMutation,
+  useEnableWelcomeManualShareMutation,
+  useUpdateWelcomeManualShareMutation,
+  useRevokeWelcomeManualShareMutation,
   useCreateSectionMutation,
   useUpdateSectionMutation,
   useDeleteSectionMutation,

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/index.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/index.ts
@@ -12,5 +12,7 @@ export type { WelcomeManualSectionResponse } from "./welcome-manual-section-resp
 export type { WelcomeManualSectionUpdateRequest } from "./welcome-manual-section-update-request";
 export type { WelcomeManualSendResponse } from "./welcome-manual-send-response";
 export type { WelcomeManualSendStatus } from "./welcome-manual-send-status";
+export type { WelcomeManualShareResponse } from "./welcome-manual-share-response";
+export type { WelcomeManualShareUpdateRequest } from "./welcome-manual-share-update-request";
 export type { WelcomeManualSummary } from "./welcome-manual-summary";
 export type { WelcomeManualUpdateRequest } from "./welcome-manual-update-request";

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-gate-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-gate-response.ts
@@ -1,0 +1,8 @@
+/**
+ * Response from the public gate check (``GET /public/welcome-manuals/:token``).
+ * A 404 (unknown/revoked token) is handled as a request failure, not a value
+ * of this type — every successful response requires a PIN.
+ */
+export interface PublicWelcomeManualGateResponse {
+  requires_pin: true;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-place.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-place.ts
@@ -1,0 +1,9 @@
+/** A "Where to Eat" place as returned by the public (unauthenticated) guide endpoint. */
+export interface PublicWelcomeManualPlace {
+  name: string;
+  cuisine: string;
+  price_tier: "$" | "$$" | "$$$" | null;
+  note: string | null;
+  map_url: string | null;
+  display_order: number;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-response.ts
@@ -1,0 +1,14 @@
+import type { PublicWelcomeManualPlace } from "./public-welcome-manual-place";
+import type { PublicWelcomeManualSection } from "./public-welcome-manual-section";
+
+/**
+ * Body returned by ``POST /public/welcome-manuals/:token/unlock`` on a
+ * correct PIN — the read-only guest view of a welcome manual. Intentionally
+ * excludes every admin-only field (ids, organization/user/property ids,
+ * timestamps) since a guest never needs them.
+ */
+export interface PublicWelcomeManualResponse {
+  title: string;
+  sections: PublicWelcomeManualSection[];
+  places: PublicWelcomeManualPlace[];
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-section-field.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-section-field.ts
@@ -1,0 +1,5 @@
+/** A section field as returned by the public (unauthenticated) guide endpoint. */
+export interface PublicWelcomeManualSectionField {
+  label: string;
+  value: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-section-image.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-section-image.ts
@@ -1,0 +1,12 @@
+/**
+ * A section image as returned by the public (unauthenticated) guide
+ * endpoint — the same shape `WelcomeManualPreview` already renders
+ * (presigned URL, caption, availability), minus the admin-only storage key.
+ */
+export interface PublicWelcomeManualSectionImage {
+  id: string;
+  caption: string | null;
+  presigned_url: string | null;
+  is_available: boolean;
+  display_order: number;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-section.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-section.ts
@@ -1,0 +1,10 @@
+import type { PublicWelcomeManualSectionField } from "./public-welcome-manual-section-field";
+import type { PublicWelcomeManualSectionImage } from "./public-welcome-manual-section-image";
+
+/** A section as returned by the public (unauthenticated) guide endpoint. */
+export interface PublicWelcomeManualSection {
+  title: string;
+  body: string | null;
+  fields: PublicWelcomeManualSectionField[];
+  images: PublicWelcomeManualSectionImage[];
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-unlock-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/public-welcome-manual-unlock-request.ts
@@ -1,0 +1,4 @@
+/** Body for ``POST /public/welcome-manuals/:token/unlock``. */
+export interface PublicWelcomeManualUnlockRequest {
+  pin: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-response.ts
@@ -15,6 +15,10 @@ export interface WelcomeManualResponse {
   intro_text: string | null;
   sections: WelcomeManualSectionResponse[];
   places: WelcomeManualPlaceResponse[];
+  /** Non-null once a PIN-protected public share link has been created. */
+  share_token: string | null;
+  /** Current access PIN for the share link. Null when not shared. */
+  share_pin: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-share-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-share-response.ts
@@ -1,0 +1,11 @@
+/**
+ * Response from creating, rotating, or reading a welcome manual's share
+ * link. ``share_path`` is the app-relative guest path (``/guide/<token>``);
+ * the frontend joins it with ``window.location.origin`` to build the full
+ * copyable URL.
+ */
+export interface WelcomeManualShareResponse {
+  share_token: string;
+  share_path: string;
+  share_pin: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-share-update-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-share-update-request.ts
@@ -1,0 +1,7 @@
+/**
+ * Body for rotating a welcome manual's share PIN. Omitting the field (or
+ * sending ``null``) tells the backend to regenerate a random PIN.
+ */
+export interface WelcomeManualShareUpdateRequest {
+  pin?: string | null;
+}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -624,7 +624,13 @@
         "backend/alembic/versions/wmanual260530_add_welcome_manuals_domain.py",
         "backend/alembic/versions/wmanualimg260530_add_welcome_manual_section_images.py",
         "backend/alembic/versions/wmanualfld260720_add_welcome_manual_section_fields.py",
-        "backend/alembic/versions/wmanualsend260530_add_welcome_manual_sends.py"
+        "backend/alembic/versions/wmanualsend260530_add_welcome_manual_sends.py",
+        "frontend/src/app/pages/WelcomeManualDetail.tsx",
+        "frontend/src/app/pages/PublicWelcomeManual.tsx",
+        "frontend/src/app/features/welcome-manuals/",
+        "frontend/src/shared/store/welcomeManualsApi.ts",
+        "frontend/src/shared/types/welcome-manual/",
+        "frontend/src/shared/lib/welcome-manual-constants.ts"
       ],
       "backend_tests": [
         "test_welcome_manual_image_routes.py",
@@ -638,8 +644,14 @@
         "test_welcome_manual_email_routes.py",
         "test_welcome_manual_send_audit_masking.py"
       ],
-      "frontend_tests": [],
-      "e2e_specs": []
+      "frontend_tests": [
+        "WelcomeManualDetail.test.tsx",
+        "WelcomeManualShareCard.test.tsx",
+        "PublicWelcomeManual.test.tsx"
+      ],
+      "e2e_specs": [
+        "welcome-manuals-layout-mock.spec.ts"
+      ]
     },
     "leases": {
       "source_paths": [


### PR DESCRIPTION
## What

Hosts can enable a **public guest link** for a welcome manual. A guest opens `/guide/<token>`, enters a short **PIN**, and sees a read-only, guest-safe projection of the manual — title, sections, labeled fields, images, and the restaurant directory. Because the manual holds Wi-Fi + check-in details, **nothing beyond the PIN form renders** until the correct code is entered.

- **Owner-scoped** (authed): `POST` / `PATCH` / `DELETE /welcome-manuals/{id}/share` → enable (idempotent), rotate PIN, revoke.
- **Public** (unauthenticated): `GET /public/welcome-manuals/{token}` → gate (returns only `{requires_pin: true}`, 404s on unknown/revoked); `POST .../unlock` → verify PIN, return the guest-safe projection.

## Security

- `share_token` = `secrets.token_urlsafe(24)` (192-bit, unguessable), UNIQUE.
- `share_pin` stored via `EncryptedString` (reversible Fernet + `key_version`) so the host can view/copy it to re-share; masked in audit logs; never logged.
- PIN travels in the POST **body**, never the URL/query string. `hmac.compare_digest` constant-time comparison.
- **Brute-force lockout is per-manual, DB-persisted** (`failed_unlock_count` / `unlock_locked_until`), mirroring the platform account-lockout primitive. Keyed on the **share token, not the client IP** — a per-IP key was bypassable because Caddy appends a guest-supplied `X-Forwarded-For`. Incremented **only on a wrong PIN**, reset on any success — so a guest reopening the guide (v1 re-prompts on refresh) can never self-lock. While locked, even a correct PIN returns 429 (no oracle).
- Public projection schemas expose **only content** — no `organization_id`, `user_id`, ids, timestamps, `share_token`, or `share_pin`.
- Wrong-PIN 401 on the public route is excluded from the global logout-on-401 interceptor, so a mistyped PIN no longer logs out a host previewing their own link.

## Pre-commit review

Ran a full pre-commit review + self-review. Both Critical findings — the `X-Forwarded-For`-spoofable lockout and the 401-logout interaction — are **fixed here**. Also fixed: PIN `max_length` bound, model↔migration UNIQUE-constraint-name drift, and extracting the guest-gate phase strings to a constants module.

**Known follow-up (out of scope):** presigned image URLs embed `organization_id` in the storage-key path (opaque UUID, only after unlock). Tracked separately.

## Migration

Adds `share_token`, `share_pin`, `key_version`, `failed_unlock_count`, `unlock_locked_until` to `welcome_manuals`. Single head `wmanualshare260721` (→ `wmanualplace260721`); reversible; additive with server defaults — no operational migration required.

## Tests

Backend: per-manual lockout scoping, success-never-locks, success-resets-counter, HTTP 429 incl. an `X-Forwarded-For`-rotation regression, guest-safe/no-leak projection, enable/rotate/revoke scoping (244 welcome-manual/share tests pass). Frontend: gate/unlock/skeleton + share-card tests; `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FsqAaqcyT2RT4eWZ6LNX4