### PR TITLE
fix(mga): map page blank bottom-half + pin-click navigate/expand

### DIFF
--- a/apps/mygamingassistant/frontend/src/__tests__/LineupListBoard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupListBoard.test.tsx
@@ -6,8 +6,16 @@
  */
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
 import LineupListBoard from "@/components/lineup/LineupListBoard";
 import type { Lineup, Game } from "@/types/game";
+
+// LineupListBoard reads ?lineup / writes ?edit via useSearchParams, so every
+// render needs a router context.
+function renderInRouter(ui: ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 const GAME: Game = {
   id: "g1",
@@ -99,7 +107,7 @@ afterEach(() => {
 
 describe("LineupListBoard", () => {
   it("renders the skeleton when isFetching is true", () => {
-    const { container } = render(
+    const { container } = renderInRouter(
       <LineupListBoard
         lineups={[]}
         isFetching={true}
@@ -114,7 +122,7 @@ describe("LineupListBoard", () => {
   });
 
   it("renders the unfiltered empty state when no lineups", () => {
-    render(
+    renderInRouter(
       <LineupListBoard
         lineups={[]}
         isFetching={false}
@@ -128,7 +136,7 @@ describe("LineupListBoard", () => {
   });
 
   it("renders the filtered empty state hint when side/util filters are active", () => {
-    render(
+    renderInRouter(
       <LineupListBoard
         lineups={[]}
         isFetching={false}
@@ -156,7 +164,7 @@ describe("LineupListBoard", () => {
         target_zone: { id: "z2", slug: "a-site", name: "A Site", polygon_points: [] },
       }),
     ];
-    render(
+    renderInRouter(
       <LineupListBoard
         lineups={lineups}
         isFetching={false}
@@ -184,7 +192,7 @@ describe("LineupListBoard", () => {
   });
 
   it("does not mount any GlanceBoardTile when all rows are collapsed", () => {
-    render(
+    renderInRouter(
       <LineupListBoard
         lineups={[makeLineup(), makeLineup({ id: "l2" })]}
         isFetching={false}

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupListBoard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupListBoard.tsx
@@ -13,6 +13,7 @@
  * this drops idle browser CPU from ~10% to near zero.
  */
 import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import type { Lineup, Game } from "@/types/game";
 import { zoneAnchorId } from "./glanceBoardUtils";
 import LineupListRow from "./LineupListRow";
@@ -139,6 +140,25 @@ export default function LineupListBoard({
   editingLineupId = null,
 }: LineupListBoardProps) {
   const groups = useMemo(() => groupByZone(lineups), [lineups]);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // ?lineup=<id> — set by a minimap pin click (MapSpatialSidebar). The matching
+  // row auto-expands + scrolls into view: "navigate to the lineup and expanded".
+  const focusedLineupId = searchParams.get("lineup");
+
+  // Superuser pin editing is now a deliberate action from the expanded row's
+  // "Adjust pin" button, not a side effect of every pin click. Only wired when
+  // operator overlays are on (i.e. the viewer is the superuser).
+  function handleEditPin(lineupId: string) {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("edit", lineupId);
+        return next;
+      },
+      { replace: true },
+    );
+  }
 
   if (isFetching) {
     return <LineupListSkeleton />;
@@ -185,6 +205,8 @@ export default function LineupListBoard({
                 showOperatorOverlays={showOperatorOverlays}
                 onHover={onLineupHover}
                 isEditing={lineup.id === editingLineupId}
+                isFocused={lineup.id === focusedLineupId}
+                onEditPin={showOperatorOverlays ? handleEditPin : undefined}
               />
             ))}
           </div>

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupListRow.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupListRow.tsx
@@ -25,7 +25,7 @@
  * simultaneously and the operator chooses freely.
  */
 import { useEffect, useRef, useState } from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Crosshair } from "lucide-react";
 import type { Lineup } from "@/types/game";
 import type { Game } from "@/types/game";
 import { lineupUtilDisplay } from "@/constants/agentDisplay";
@@ -47,6 +47,14 @@ interface LineupListRowProps {
    *  Highlights the row, badges it "EDITING", and scrolls it into view so the
    *  operator can see which list row the editor panel is bound to. */
   isEditing?: boolean;
+  /** True when a minimap pin click focused this lineup (?lineup=<id>). The row
+   *  auto-expands its storyboard and scrolls into view — the "navigate to the
+   *  lineup and expanded" pin-click behaviour. */
+  isFocused?: boolean;
+  /** Superuser only — when provided, the expanded row shows an "Adjust pin"
+   *  button that opens the pin editor for this lineup. Undefined for public
+   *  viewers (no button). */
+  onEditPin?: (lineupId: string) => void;
 }
 
 export default function LineupListRow({
@@ -56,6 +64,8 @@ export default function LineupListRow({
   showOperatorOverlays = false,
   onHover,
   isEditing = false,
+  isFocused = false,
+  onEditPin,
 }: LineupListRowProps) {
   const [expanded, setExpanded] = useState(false);
   const rowRef = useRef<HTMLDivElement>(null);
@@ -68,6 +78,15 @@ export default function LineupListRow({
       rowRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   }, [isEditing]);
+
+  // When a pin click focuses this lineup (?lineup=<id>), open it and bring it
+  // into view — the "navigate to the lineup and expanded" pin-click behaviour.
+  useEffect(() => {
+    if (isFocused) {
+      setExpanded(true);
+      rowRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [isFocused]);
 
   const target = lineup.target_zone?.name ?? "Unknown";
   const stand = lineup.stand_zone?.name ?? null;
@@ -207,6 +226,21 @@ export default function LineupListRow({
               showOperatorOverlays={showOperatorOverlays}
             />
           </div>
+          {/* Deliberate pin-edit entry — replaces editor-on-every-pin-click.
+              Rendered only when onEditPin is supplied (superusers); opens
+              PinEditPanel via ?edit=<id>. */}
+          {onEditPin && (
+            <div className="mt-2 flex justify-end">
+              <button
+                type="button"
+                onClick={() => onEditPin(lineup.id)}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors min-h-[44px]"
+              >
+                <Crosshair className="w-3.5 h-3.5" aria-hidden />
+                Adjust pin
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/mygamingassistant/frontend/src/components/lineup/MapSpatialSidebar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/MapSpatialSidebar.tsx
@@ -7,16 +7,18 @@
  *      overlay (MapLineupPins) when a pin mode is active
  *   3. PinEditPanel        — operator-only nudge surface (?edit=<id>)
  *
- * Pin selection routing:
- *   - Superuser  → select the lineup for editing (opens PinEditPanel)
- *   - Public     → smooth-scroll the board to that lineup's target-zone
- *     section, reusing the existing zoneAnchorId scroll anchors.
+ * Pin selection routing (both superuser and public):
+ *   Clicking a pin focuses that lineup — sets ?lineup=<id>, which the list
+ *   board's LineupListRow reads to scroll the matching row into view and
+ *   expand its storyboard. A pin click is always a "show me this lineup"
+ *   action; superusers open the pin editor deliberately from the expanded
+ *   row's "Adjust pin" button (?edit=<id>), not on every pin click.
  */
+import { useSearchParams } from "react-router-dom";
 import GlanceBoardMinimapSidebar from "./GlanceBoardMinimapSidebar";
 import PinModeToggle from "./PinModeToggle";
 import PinEditPanel from "./PinEditPanel";
 import { usePinEditor } from "@/hooks/usePinEditor";
-import { zoneAnchorId } from "./glanceBoardUtils";
 import type { PinMode } from "./MapLineupPins";
 import type { Lineup, MapZone, ZoneDensity } from "@/types/game";
 
@@ -48,20 +50,21 @@ export default function MapSpatialSidebar({
   highlightedLineupId = null,
 }: Props) {
   const editor = usePinEditor({ lineups, isSuperuser });
+  const [, setSearchParams] = useSearchParams();
 
   function handlePinSelect(lineupId: string) {
-    if (isSuperuser) {
-      editor.setSelected(lineupId);
-      return;
-    }
-    // Public viewer — jump the board to the lineup's target-zone section.
-    const l = lineups.find((x) => x.id === lineupId);
-    const slug = l?.target_zone?.slug;
-    if (slug) {
-      document
-        .getElementById(zoneAnchorId(slug))
-        ?.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
+    // Focus the clicked lineup: ?lineup=<id> tells LineupListRow to scroll its
+    // row into view and expand the storyboard. Clear ?edit so a pin click also
+    // exits any open pin editor — clicking a pin is a "view", not an "edit".
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("lineup", lineupId);
+        next.delete("edit");
+        return next;
+      },
+      { replace: true },
+    );
   }
 
   return (

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -387,8 +387,8 @@ export default function MapPage() {
         />
       )}
 
-      {/* ── Full-height flex container ──────────────────────────────────── */}
-      <div className="flex flex-col min-h-screen">
+      {/* ── Board container — scrolls inside AppShell's <main>; NOT min-h-screen (no blank 100vh under short lists) and no nested scroller ── */}
+      <div className="flex flex-col">
 
         <MapPageTopBar
           gameSlug={gameSlug!}
@@ -416,12 +416,12 @@ export default function MapPage() {
         />
 
         {/* ── Body: sidebar + main ─────────────────────────────────────── */}
-        <div className="flex flex-1 min-h-0">
+        <div className="flex">
 
           {/* Minimap sidebar — polygon clicks now set the zone filter via
               handleZoneClick. The active zone (if any) is highlighted. */}
           <aside
-            className="hidden lg:block w-[440px] shrink-0 p-3 border-r overflow-y-auto sticky top-10 h-[calc(100vh-40px)]"
+            className="hidden lg:block w-[440px] shrink-0 p-3 border-r sticky top-10 self-start max-h-[calc(100vh-40px)] overflow-y-auto"
             aria-label="Map zone navigation"
           >
             <MapSpatialSidebar
@@ -438,8 +438,8 @@ export default function MapPage() {
             />
           </aside>
 
-          {/* Main scrollable area */}
-          <main className="flex-1 min-w-0 p-4 lg:p-6 overflow-y-auto">
+          {/* Main board column — scrolls as part of AppShell's <main> */}
+          <main className="flex-1 min-w-0 p-4 lg:p-6">
 
             {/* Active zone-filter chip — only when a zone is selected.
                 Click the × to clear; clicking the active zone polygon on


### PR DESCRIPTION
Fixes two operator-reported bugs on the MGA map/glance-board page (reported on `/valorant/ascent?agent=sova&side=side_a&util=recon&pins=both`).

## 1. Blank bottom half of the page
MapPage wrapped its board in `min-h-screen` plus a nested `overflow-y-auto` `<main>`, but it already renders **inside AppShell's own scrolling `<main>`**. Two consequences:
- `min-h-screen` forced the container to a full `100vh`, so a **short filtered list** (e.g. `?util=recon` narrows Sova to a handful of lineups) padded the page with a blank `100vh` region — the "bottom half is blank."
- The nested scroller fought AppShell's scroller, and the `sticky` minimap sidebar detached once you scrolled past its containing block.

**Fix:** drop `min-h-screen`, drop the inner `overflow-y-auto`, and make the sidebar `self-start` + `max-h-[calc(100vh-40px)]` so the whole page scrolls in **one** context and the sidebar stays pinned. Class-name-only change — **MapPage LOC unchanged (512)**, so the no-growth file-size guard passes.

Verified locally: `scrollHeight === clientHeight` when content is short (no forced blank), single scroll context when long, sidebar stays pinned at the top on scroll.

## 2. Pin click → navigate to the lineup and expand it
Clicking a minimap pin previously opened the pin editor (superuser) or scrolled to the target-zone section (public). It now sets `?lineup=<id>`, which the matching `LineupListRow` reads to **scroll into view and auto-expand its storyboard** — same behaviour for both roles.

Superuser pin editing is preserved but moves to a **deliberate "Adjust pin" button** in the expanded row (`?edit=<id>`), so it stays reachable without hijacking every pin click.

`LineupListRow` stays a pure presentational leaf (`isFocused` / `onEditPin` props); the `?lineup` read + `?edit` write live in `LineupListBoard`, so only its tests needed a router wrapper.

Verified locally: navigating with `?lineup=<id>` auto-expands the matching row with the full STAND/AIM/THROW/LANDING storyboard.

## Tests
- `npm run typecheck` clean.
- Frontend unit tests pass (439/440); the one failure, `MicroClipShiftOverlay.test.tsx`, is **pre-existing** — it fails identically on a clean tree without these changes and is unrelated (that component isn't touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)