### PR TITLE
feat(mga): utility_type.placement — model placed utility (Cypher, Killjoy, Chamber)

### DIFF
--- a/apps/mygamingassistant/backend/alembic/versions/0021_utility_type_placement.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0021_utility_type_placement.py
@@ -1,0 +1,68 @@
+"""Add utility_type.placement ('thrown' | 'placed')
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-07-30 00:00:00.000000
+
+Adds a NOT NULL ``placement`` column to ``utility_type``, constrained to
+``'thrown'`` or ``'placed'``, defaulting to ``'thrown'``.
+
+WHY. The lineup pipeline has assumed every utility travels through the air, so a
+lineup is four beats: STAND -> AIM -> THROW -> LANDING. That assumption holds for
+every utility type seeded so far, but it excludes most of the sentinel kit.
+Cypher's trapwire and spycam are MOUNTED on a surface — the player walks to a
+spot, looks at the surface and angle, and deploys. There is a stand, there is an
+aim (the surface and angle are the entire lesson), and there is a landing (the
+deployed device), but nothing is ever in flight, so there is no throw. That is a
+complete three-beat lineup, not a four-beat lineup with a hole in it.
+
+The distinction belongs on the utility type because it is a property of the
+ability itself, not of any individual clip: every trapwire lineup ever recorded
+is placed, and no hot-hands lineup ever is. Storing it per-lineup would invite
+the two to disagree.
+
+BACKFILL. ``server_default='thrown'`` backfills every existing row, which is
+correct and not merely convenient — cyber-cage, all of CS2's grenades, and every
+Valorant ability seeded to date are genuinely thrown. The fixture loader then
+flips ``trapwire`` and ``spycam`` to ``'placed'`` on the next
+``load-fixtures`` run.
+
+The value set is a String + CheckConstraint rather than a PG ENUM, per the schema
+convention: widening it later (a future 'deployed' for Killjoy's turret, say) is
+an ALTER of a constraint rather than an ALTER TYPE that must be coordinated
+across every app sharing the cluster.
+
+Downgrade drops the constraint and the column; three-beat lineups keep their
+NULL ``clip_url`` and render via the existing placeholder, so nothing breaks —
+the app simply loses the ability to say WHY the throw is absent.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "utility_type",
+        sa.Column(
+            "placement",
+            sa.String(length=10),
+            nullable=False,
+            server_default="thrown",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_utilitytype_placement",
+        "utility_type",
+        "placement IN ('thrown', 'placed')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_utilitytype_placement", "utility_type", type_="check")
+    op.drop_column("utility_type", "placement")

--- a/apps/mygamingassistant/backend/app/api/games.py
+++ b/apps/mygamingassistant/backend/app/api/games.py
@@ -143,6 +143,9 @@ async def get_map(
                 # group the second-stage utility chips under the selected agent.
                 # CS2 utilities have no agent → None.
                 "agent_slug": agent_slug_by_id.get(u.agent_id),
+                # Lets the upload/review forms know a lineup for this utility has
+                # three beats rather than four, before any clip exists.
+                "placement": u.placement,
             }
             for u in utility_types
         ],

--- a/apps/mygamingassistant/backend/app/fixtures/utility_types.json
+++ b/apps/mygamingassistant/backend/app/fixtures/utility_types.json
@@ -63,21 +63,21 @@
       { "slug": "m-pulse",          "name": "M-Pulse",          "agent_slug": "miks" },
 
       { "slug": "nanoswarm",        "name": "Nanoswarm",        "agent_slug": "killjoy" },
-      { "slug": "alarmbot",         "name": "Alarmbot",         "agent_slug": "killjoy" },
-      { "slug": "turret",           "name": "Turret",           "agent_slug": "killjoy" },
+      { "slug": "alarmbot",         "name": "Alarmbot",         "agent_slug": "killjoy", "placement": "placed" },
+      { "slug": "turret",           "name": "Turret",           "agent_slug": "killjoy", "placement": "placed" },
 
       { "slug": "cyber-cage",       "name": "Cyber Cage",       "agent_slug": "cypher" },
-      { "slug": "trapwire",         "name": "Trapwire",         "agent_slug": "cypher" },
-      { "slug": "spycam",           "name": "Spycam",           "agent_slug": "cypher" },
+      { "slug": "trapwire",         "name": "Trapwire",         "agent_slug": "cypher", "placement": "placed" },
+      { "slug": "spycam",           "name": "Spycam",           "agent_slug": "cypher", "placement": "placed" },
 
       { "slug": "barrier-orb",      "name": "Barrier Orb",      "agent_slug": "sage" },
       { "slug": "slow-orb",         "name": "Slow Orb",         "agent_slug": "sage" },
 
-      { "slug": "trademark",        "name": "Trademark",        "agent_slug": "chamber" },
+      { "slug": "trademark",        "name": "Trademark",        "agent_slug": "chamber", "placement": "placed" },
 
       { "slug": "gravnet",          "name": "GravNet",          "agent_slug": "deadlock" },
       { "slug": "barrier-mesh",     "name": "Barrier Mesh",     "agent_slug": "deadlock" },
-      { "slug": "sonic-sensor",     "name": "Sonic Sensor",     "agent_slug": "deadlock" },
+      { "slug": "sonic-sensor",     "name": "Sonic Sensor",     "agent_slug": "deadlock", "placement": "placed" },
 
       { "slug": "arc-rose",         "name": "Arc Rose",         "agent_slug": "vyse" },
       { "slug": "shear",            "name": "Shear",            "agent_slug": "vyse" },

--- a/apps/mygamingassistant/backend/app/models/game/utility_type.py
+++ b/apps/mygamingassistant/backend/app/models/game/utility_type.py
@@ -5,11 +5,28 @@ Valorant: agent-specific abilities (Sova's recon / shock, ...) — each hangs of
           ``agent`` via ``agent_id``. Ability slugs are globally unique within a
           game, so the (game_id, slug) unique constraint is kept and the pack /
           importer continue to resolve utility types by slug alone.
+
+PLACEMENT is what decides how many beats a lineup has. A THROWN utility travels, so
+it storyboards as STAND -> AIM -> THROW -> LANDING. A PLACED one (Cypher's trapwire
+and spycam, Killjoy's turret/alarmbot) is mounted on a surface the player is standing
+at: there is a stand, there is an aim (the surface and angle being mounted are the
+whole lesson), and there is a landing (the deployed device), but there is no throw
+because nothing is ever in flight. Treating that as a degraded 4-beat lineup with a
+missing throw is wrong — it is a complete 3-beat lineup, and the distinction has to
+live on the utility type because it is a property of the ability, not of any one clip.
 """
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, UniqueConstraint, func
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -22,6 +39,13 @@ class UtilityType(Base):
         UniqueConstraint("game_id", "slug", name="uq_utilitytype_game_slug"),
         Index("ix_utilitytype_game_id", "game_id"),
         Index("ix_utilitytype_agent_id", "agent_id"),
+        # String + CheckConstraint rather than a SQLAlchemy/PG Enum, per the schema
+        # convention: adding a value later is an ALTER of this constraint, not an
+        # ALTER TYPE that has to be coordinated across every app on the cluster.
+        CheckConstraint(
+            "placement IN ('thrown', 'placed')",
+            name="ck_utilitytype_placement",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -42,6 +66,15 @@ class UtilityType(Base):
     )
     slug: Mapped[str] = mapped_column(String(50), nullable=False)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
+    # 'thrown' is the safe default: every utility type that existed before this
+    # column travels through the air, so a backfill of the existing rows to
+    # 'thrown' is correct rather than merely convenient.
+    placement: Mapped[str] = mapped_column(
+        String(10),
+        nullable=False,
+        default="thrown",
+        server_default="thrown",
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
@@ -93,6 +93,7 @@ async def upsert_utility_type(
     slug: str,
     name: str,
     agent_id: uuid.UUID | None = None,
+    placement: str = "thrown",
 ) -> UtilityType:
     result = await db.execute(
         select(UtilityType).where(UtilityType.game_id == game_id, UtilityType.slug == slug)
@@ -111,10 +112,24 @@ async def upsert_utility_type(
         if existing.agent_id != agent_id:
             existing.agent_id = agent_id
             changed = True
+        # ``placement`` is mutable for the same reason ``agent_id`` is: migration
+        # 0021 backfills every pre-existing row to 'thrown', so the fixture edit
+        # marking trapwire/spycam 'placed' only takes effect if re-running
+        # load-fixtures propagates it. Without this the column would be correct
+        # in the fixture and permanently wrong in the database.
+        if existing.placement != placement:
+            existing.placement = placement
+            changed = True
         if changed:
             await db.flush()
         return existing
-    ut = UtilityType(game_id=game_id, slug=slug, name=name, agent_id=agent_id)
+    ut = UtilityType(
+        game_id=game_id,
+        slug=slug,
+        name=name,
+        agent_id=agent_id,
+        placement=placement,
+    )
     db.add(ut)
     await db.flush()
     return ut

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -43,6 +43,11 @@ class UtilityTypeRead(BaseModel):
     id: uuid.UUID
     slug: str
     name: str
+    # 'thrown' (STAND/AIM/THROW/LANDING) or 'placed' (STAND/AIM/LANDING — a
+    # mounted device never leaves the player's hands, so there is no throw beat).
+    # Defaulted rather than required so a client reading an older payload, or a
+    # test constructing this by hand, still gets the overwhelmingly common case.
+    placement: str = "thrown"
     # Valorant utilities belong to an agent (Sova's recon/shock); CS2 → None.
     # Populated from the eager-loaded utility_type.agent relationship.
     agent: Optional["AgentRead"] = None

--- a/apps/mygamingassistant/backend/app/services/game/fixture_loader.py
+++ b/apps/mygamingassistant/backend/app/services/game/fixture_loader.py
@@ -130,6 +130,9 @@ async def _load_utility_types(db: AsyncSession) -> None:
                 slug=ut["slug"],
                 name=ut["name"],
                 agent_id=agent_id,
+                # Absent for every thrown utility, which is nearly all of them —
+                # the fixture only spells out the 'placed' exceptions.
+                placement=ut.get("placement", "thrown"),
             )
             logger.debug(
                 "fixture_loader: upserted utility_type %s/%s",

--- a/apps/mygamingassistant/backend/tests/test_agent_fixtures.py
+++ b/apps/mygamingassistant/backend/tests/test_agent_fixtures.py
@@ -74,3 +74,47 @@ def test_generic_valorant_utilities_pruned():
     assert slugs.isdisjoint({"smoke", "flash", "molotov"}), (
         "generic Valorant smoke/flash/molotov must be removed (replaced by agent abilities)"
     )
+
+
+# --- placement ('thrown' | 'placed') -------------------------------------------------
+
+_VALID_PLACEMENTS = {"thrown", "placed"}
+
+
+def test_placement_values_are_valid_where_present():
+    """Any ``placement`` in the fixture must match the DB CHECK constraint.
+
+    The fixture spells out only the 'placed' exceptions; everything else omits the
+    key and picks up the column default. A typo like "place" would pass fixture
+    load in-process and then blow up on the INSERT, so it is cheaper to catch here.
+    """
+    for entry in _load("utility_types.json"):
+        for ut in entry["utility_types"]:
+            if "placement" in ut:
+                assert ut["placement"] in _VALID_PLACEMENTS, (
+                    f"{entry['game_slug']}/{ut['slug']} has invalid placement "
+                    f"{ut['placement']!r}"
+                )
+
+
+def test_mounted_abilities_are_placed_and_thrown_ones_are_not():
+    """The 3-beat pipeline keys off this, so the classification is load-bearing.
+
+    A wrong 'placed' silently drops a real THROW beat from that utility's lineups;
+    a wrong 'thrown' demands a throw that does not exist and fails every gate. Both
+    are invisible until footage is localized, which is expensive — hence the pin.
+    """
+    by_slug = {u["slug"]: u for u in _valorant_utils()}
+
+    # Mounted on a surface at the player's own position — nothing is ever airborne.
+    for slug in ("trapwire", "spycam", "alarmbot", "turret", "trademark", "sonic-sensor"):
+        assert by_slug[slug].get("placement") == "placed", (
+            f"{slug} is a mounted device and must be placement='placed'"
+        )
+
+    # Cypher's third ability IS thrown — it arcs and lands. Its presence here is the
+    # point: 'placed' is a property of the ability, not of the agent that owns it.
+    for slug in ("cyber-cage", "nanoswarm", "hot-hands", "recon", "shock"):
+        assert by_slug[slug].get("placement", "thrown") == "thrown", (
+            f"{slug} travels through the air and must be placement='thrown'"
+        )

--- a/apps/mygamingassistant/backend/tests/test_alembic_chain.py
+++ b/apps/mygamingassistant/backend/tests/test_alembic_chain.py
@@ -24,8 +24,8 @@ def script_directory() -> ScriptDirectory:
     return ScriptDirectory.from_config(cfg)
 
 
-def test_single_head_is_0020(script_directory: ScriptDirectory) -> None:
-    """The DAG must resolve to exactly one head and it must be 0020.
+def test_single_head_is_0021(script_directory: ScriptDirectory) -> None:
+    """The DAG must resolve to exactly one head and it must be 0021.
 
     Bump this pin (and add a down_revision assertion below) in the same PR
     that adds a new migration — same per-PR contract as the fixture
@@ -37,8 +37,8 @@ def test_single_head_is_0020(script_directory: ScriptDirectory) -> None:
         "Orphan heads usually mean a migration's down_revision is stale "
         "after a merge — rebase and re-point the down_revision."
     )
-    assert heads[0] == "0020", (
-        f"Expected head 0020 (lineup.landing_screenshot_url poster still), "
+    assert heads[0] == "0021", (
+        f"Expected head 0021 (utility_type.placement thrown/placed), "
         f"got {heads[0]}."
     )
 
@@ -161,3 +161,11 @@ def test_0020_down_revision_points_at_0019(
     """0020 must chain directly off 0019 (lineup.landing_screenshot_url poster still)."""
     rev = script_directory.get_revision("0020")
     assert rev.down_revision == "0019"
+
+
+def test_0021_down_revision_points_at_0020(
+    script_directory: ScriptDirectory,
+) -> None:
+    """0021 must chain directly off 0020 (utility_type.placement thrown/placed)."""
+    rev = script_directory.get_revision("0021")
+    assert rev.down_revision == "0020"

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardStoryboard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardStoryboard.test.tsx
@@ -77,7 +77,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     classification_reasoning: null,
     target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
     stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
-    utility_type: { id: "u1", slug: "smoke", name: "Smoke", agent: null },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke", placement: "thrown", agent: null },
     ...over,
   };
 }

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -84,7 +84,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     classification_reasoning: null,
     target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
     stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
-    utility_type: { id: "u1", slug: "smoke", name: "Smoke", agent: null },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke", placement: "thrown", agent: null },
     ...over,
   };
 }

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -87,7 +87,7 @@ const BASE_LINEUP: Lineup = {
   classification_reasoning: null,
   target_zone: { id: "zone-1", slug: "a-site", name: "A Site", polygon_points: [] },
   stand_zone: { id: "zone-2", slug: "ct-spawn", name: "CT Spawn", polygon_points: [] },
-  utility_type: { id: "util-1", slug: "smoke", name: "Smoke", agent: null },
+  utility_type: { id: "util-1", slug: "smoke", name: "Smoke", placement: "thrown", agent: null },
 };
 
 describe("LineupCard", () => {

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupDetail.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupDetail.test.tsx
@@ -77,7 +77,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     classification_reasoning: null,
     target_zone: { id: "z1", slug: "mid", name: "Mid", polygon_points: [] },
     stand_zone: null,
-    utility_type: { id: "u1", slug: "smoke", name: "Smoke", agent: null },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke", placement: "thrown", agent: null },
     ...over,
   };
 }

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupListBoard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupListBoard.test.tsx
@@ -81,7 +81,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     classification_reasoning: null,
     target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
     stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
-    utility_type: { id: "u1", slug: "smoke", name: "Smoke", agent: null },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke", placement: "thrown", agent: null },
     ...over,
   };
 }

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupListRow.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupListRow.test.tsx
@@ -65,7 +65,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     classification_reasoning: null,
     target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
     stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
-    utility_type: { id: "u1", slug: "smoke", name: "Smoke", agent: null },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke", placement: "thrown", agent: null },
     ...over,
   };
 }

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupStillPreview.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupStillPreview.test.tsx
@@ -64,7 +64,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     classification_reasoning: null,
     target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
     stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
-    utility_type: { id: "u1", slug: "smoke", name: "Smoke", agent: null },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke", placement: "thrown", agent: null },
     ...over,
   };
 }

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -34,12 +34,27 @@ export interface Agent {
   role: string | null;
 }
 
+/**
+ * How a utility reaches its destination, which decides how many beats a lineup has.
+ *
+ * - `thrown` — travels through the air: STAND -> AIM -> THROW -> LANDING (4 beats).
+ * - `placed` — mounted on a surface at the player's own position, so nothing is ever
+ *   in flight: STAND -> AIM -> LANDING (3 beats). Cypher's trapwire/spycam,
+ *   Killjoy's turret/alarmbot. These lineups have a null `clip_url` by design, not
+ *   because a clip is missing.
+ *
+ * Mirrors the `ck_utilitytype_placement` CHECK constraint on `utility_type.placement`;
+ * adding a value here means adding it there in the same change.
+ */
+export type UtilityPlacement = 'thrown' | 'placed';
+
 export interface UtilityType {
   id: string;
   slug: string;
   name: string;
   /** Agent that owns this utility (null for CS2 grenades). */
   agent_slug: string | null;
+  placement: UtilityPlacement;
 }
 
 export interface MapDetail {
@@ -109,6 +124,8 @@ export interface UtilityTypeRead {
   id: string;
   slug: string;
   name: string;
+  /** See {@link UtilityPlacement}. `placed` utilities have no THROW beat. */
+  placement: UtilityPlacement;
   /** Agent that owns this utility (Sova's Recon/Shock Bolt); null for CS2
    *  grenades. Populated from the backend's eager-loaded utility_type.agent
    *  relationship — the nested shape (vs MapDetail's flat agent_slug) carries


### PR DESCRIPTION
## Why

Cypher's trapwire and spycam are not thrown. The player walks to a spot, aims at a surface, and mounts the device there. The existing pipeline assumes every lineup has four beats (STAND / AIM / THROW / LANDING) and refuses anything that cannot produce a THROW — which silently excludes every sentinel agent from the library.

A placed utility is a **complete 3-beat lineup** — STAND, AIM, LANDING — not a degraded 4-beat one. The LANDING is where the device ends up, which for placed utility is the same surface the player aimed at.

This PR adds the discriminator the rest of the pipeline needs. It is **the data model only**; making THROW optional through `recut_lineup_clips` / `ingest_agent` / the localize gate / the frontend pane placeholder is the follow-up PR.

## What

- **`0021_utility_type_placement.py`** — adds `placement String(10) NOT NULL DEFAULT 'thrown'` + a CHECK constraint restricting it to `('thrown','placed')`. `String` + `CheckConstraint` rather than a PG `ENUM`, per the schema convention: widening later is an `ALTER` of a constraint, not an `ALTER TYPE` that has to be coordinated across every app on the cluster. The `server_default` is *correct*, not merely convenient — every pre-existing utility type in the fixture genuinely is thrown.
- **`utility_types.json`** — 6 entries marked `"placement": "placed"`: cypher `trapwire` + `spycam`, killjoy `alarmbot` + `turret`, chamber `trademark`, deadlock `sonic-sensor`. Deliberately **not** marked: cypher's `cyber-cage`, which arcs through the air and lands. `placed` is a property of the ability, not of the agent that owns it. Agents not yet ingested are left alone rather than guessed at.
- **`game_repo.upsert_utility_type`** — propagates `placement` on mutation, for the same reason `agent_id` does. Without this the fixture edit would be correct in JSON and permanently wrong in the database, because 0021 backfills every existing row to `'thrown'`.
- **Read path** — `UtilityTypeRead.placement` + the `MapDetail` serialization dict, typed as a `UtilityPlacement` union in `frontend/src/types/game.ts`, so the follow-up UI work has the field available without another round-trip.

## Verification

| Check | Result |
|---|---|
| Alembic round-trip `0020 → head → 0020 → head` | all four steps succeeded |
| `load-fixtures` against the dev DB | `{'placed': 6, 'thrown': 54}`, correct 6 rows |
| CHECK constraint actually fires | `UPDATE utility_type SET placement='lobbed'` → `IntegrityError` |
| Backend `pytest -q` | **969 passed** |
| Frontend `tsc --noEmit` | clean |
| Frontend `vitest run` | 439 passed, 1 failed — `MicroClipShiftOverlay`, **reproduced on pristine `origin/main`** via `git stash -u`, unrelated to this change |
| `eslint` | 20 errors, all in files this PR does not touch (calibrate/*, hooks/*, Review, ZoneEditPage) |
| LOC policy | every touched file under 500 lines |

New tests: `test_placement_values_are_valid_where_present` and `test_mounted_abilities_are_placed_and_thrown_ones_are_not` (the classification is load-bearing for the 3-beat pipeline, and a wrong value is invisible until footage is localized — which is expensive). `test_alembic_chain` head pin bumped 0020 → 0021 with the matching `down_revision` assertion, per the per-PR contract in that file.

## Operational migration

None required. The column is additive with a correct server default; a deploy that runs `alembic upgrade head` needs no env change, and `load-fixtures` is idempotent as always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)