### PR TITLE
feat(mga): make THROW optional so placed utility is a complete 3-beat lineup

### DIFF
--- a/apps/mygamingassistant/backend/scripts/ingest_agent.py
+++ b/apps/mygamingassistant/backend/scripts/ingest_agent.py
@@ -16,6 +16,13 @@ Each spans JSON has:
   origin/main + prod, so every agent's abilities resolve with no fixture work.
 - target/stand are COARSE map-zone slugs (the fine callout lives in `title`).
 - side = side_a (attacker) | side_b (defender).
+- spans.throw is OMITTED for PLACED utility (utility_type.placement == 'placed':
+  Cypher's trapwire/spycam, Killjoy's alarmbot/turret, Chamber's trademark,
+  Deadlock's sonic sensor). A mounted device never leaves the player's hands, so
+  those lineups are a complete THREE-beat STAND/AIM/LANDING story rather than a
+  four-beat one missing a beat. Validation enforces this in BOTH directions: a
+  placed row carrying a throw span fails just as loudly as a thrown row missing
+  one, because each means the ability was read wrong or a beat was invented.
 
 Subcommands (MAIN checkout venv, cwd = backend, PG:5433 up):
   plan   — resolve + validate every lineup (zones/utility exist), print, write nothing
@@ -102,7 +109,9 @@ async def _resolve(db, data: dict):
         Map.slug == data["map_slug"], Map.game_id == game_id))).scalar_one()
     zones = {z.slug: z.id for z in (await db.execute(
         select(MapZone).where(MapZone.map_id == vmap.id))).scalars().all()}
-    utils = {u.slug: u.id for u in (await db.execute(
+    # Whole objects, not just ids — the pipeline needs `placement` to decide
+    # whether a THROW beat is expected at all (placed utility has none).
+    utils = {u.slug: u for u in (await db.execute(
         select(UtilityType).where(UtilityType.game_id == game_id))).scalars().all()}
     return game_id, vmap, zones, utils
 
@@ -122,7 +131,25 @@ def _validate(data: dict, zones: dict, utils: dict) -> None:
                 errs.append(f"cs={ln['cs']} {zk} zone {ln[zk]!r} not in map zones {sorted(zones)}")
         if ln["side"] not in ("side_a", "side_b"):
             errs.append(f"cs={ln['cs']} bad side {ln['side']!r}")
-        for ev in ("stand", "aim", "throw", "landing"):
+
+        # Placed utility (trapwire, spycam, alarmbot, turret, trademark, sonic
+        # sensor) is mounted, not lobbed, so its story is a complete 3-beat
+        # STAND/AIM/LANDING. Demanding a throw span there would fail every one
+        # of those rows; accepting one silently would mean the localizer
+        # invented a beat that does not exist on screen, or read the ability
+        # wrong. Both are worth failing loudly on, in opposite directions.
+        placed = ln["ability"] in utils and utils[ln["ability"]].placement == "placed"
+        events = ("stand", "aim", "landing") if placed else ("stand", "aim", "throw", "landing")
+        if placed and "throw" in ln["spans"]:
+            errs.append(
+                f"cs={ln['cs']} ability {ln['ability']!r} is placed utility but a "
+                f"'throw' span was supplied — placed utility never leaves the hands. "
+                f"Either the ability is misread or the throw beat is invented."
+            )
+        for ev in events:
+            if ev not in ln["spans"]:
+                errs.append(f"cs={ln['cs']} missing {ev!r} span")
+                continue
             s, e = ln["spans"][ev]
             if not (e > s):
                 errs.append(f"cs={ln['cs']} {ev}: end {e} must be > start {s}")
@@ -138,8 +165,9 @@ async def cmd_plan(agent: str, pack: str) -> None:
         print(f"{agent} / {data['map_slug']} — {len(data['lineups'])} lineups, video {data['video_id']}")
         for ln in data["lineups"]:
             sp = ln["spans"]
+            beat = f"thr={sp['throw'][0]:.2f}" if "throw" in sp else "PLACED    "
             print(f"  cs={ln['cs']:4} {ln['ability']:14} {ln['stand']:7}->{ln['target']:7} "
-                  f"{ln['side']} thr={sp['throw'][0]:.2f} :: {ln['title']}")
+                  f"{ln['side']} {beat} :: {ln['title']}")
         print("validation OK (all utilities + zones resolve).")
 
 
@@ -163,7 +191,7 @@ async def cmd_create(agent: str, pack: str) -> None:
             if ln["cs"] in existing:
                 print(f"  SKIP cs={ln['cs']} (exists)"); continue
             row = Lineup(
-                game_id=game_id, map_id=vmap.id, utility_type_id=utils[ln["ability"]],
+                game_id=game_id, map_id=vmap.id, utility_type_id=utils[ln["ability"]].id,
                 title=ln["title"], chapter_title=ln["title"], chapter_start_seconds=ln["cs"],
                 youtube_video_id=vid, attribution_url=url, attribution_author=data["author"],
                 source_id=src_id, technique=ln["technique"],
@@ -184,6 +212,13 @@ def cmd_recut(agent: str, pack: str) -> None:
 
     async def _ids():
         async with AsyncSessionLocal() as db:
+            # Validate here too, not just in plan/create/accept. recut is the one
+            # subcommand that writes MEDIA, and a missing 'throw' span is
+            # ambiguous on its face: legitimate for placed utility, a truncated
+            # pack for anything else. Only the utility's `placement` separates
+            # them, and that needs the DB — so resolve before cutting anything.
+            _, _, zones, utils = await _resolve(db, data)
+            _validate(data, zones, utils)
             rows = (await db.execute(select(Lineup).where(Lineup.youtube_video_id == vid))).scalars().all()
             return {r.chapter_start_seconds: str(r.id)[:8] for r in rows}
     id_by_cs = asyncio.run(_ids())
@@ -197,8 +232,12 @@ def cmd_recut(agent: str, pack: str) -> None:
         cmd = [py, recut, id8,
                "--stand", str(sp["stand"][0]), str(sp["stand"][1]),
                "--aim", str(sp["aim"][0]), str(sp["aim"][1]),
-               "--throw", str(sp["throw"][0]), str(sp["throw"][1]),
                "--landing", str(sp["landing"][0]), str(sp["landing"][1])]
+        # Absent for placed utility — recut then skips the tight throw cut and
+        # leaves clip_url NULL. _validate ran above, so a missing throw span
+        # here is established as placed, not as a truncated pack.
+        if "throw" in sp:
+            cmd += ["--throw", str(sp["throw"][0]), str(sp["throw"][1])]
         r = subprocess.run(cmd, capture_output=True, text=True)
         if r.returncode == 0:
             print(f"  RECUT cs={ln['cs']:4} id8={id8} OK"); ok += 1
@@ -223,7 +262,7 @@ async def cmd_accept(agent: str, pack: str) -> None:
                 print(f"  NO ROW cs={ln['cs']}"); continue
             await accept_lineup(db, row, {
                 "game_id": game_id, "map_id": vmap.id,
-                "utility_type_id": utils[ln["ability"]],
+                "utility_type_id": utils[ln["ability"]].id,
                 "target_zone_id": zones[ln["target"]], "stand_zone_id": zones[ln["stand"]],
                 "side": ln["side"],
             })

--- a/apps/mygamingassistant/backend/scripts/recut_lineup_clips.py
+++ b/apps/mygamingassistant/backend/scripts/recut_lineup_clips.py
@@ -1,6 +1,15 @@
-"""Re-cut all 4 storyboard clips (STAND / AIM / THROW / LANDING) for ONE lineup
+"""Re-cut the storyboard clips (STAND / AIM / THROW / LANDING) for ONE lineup
 from OPERATOR-CONFIRMED frame-study spans — a DB/MinIO data-fix, NO pipeline,
 NO Claude, NO localizer.
+
+THROW is OPTIONAL. Placed utility (Cypher's trapwire/spycam, Killjoy's
+alarmbot/turret, Chamber's trademark, Deadlock's sonic sensor) is mounted, not
+lobbed: it never leaves the player's hands, so there is no throw beat to cut.
+Those lineups are a complete THREE-beat STAND/AIM/LANDING story, not a degraded
+four-beat one. Omit ``--throw`` and the tight throw clip is skipped and
+``clip_url`` stays NULL — but the throw WIDE source is still cut and persisted
+via ``set_clip_url_original``, because it is the shared source that the STAND
+and AIM offsets index into and the shift editors open against.
 
 Initiative 7 (MGA lineup-localization accuracy sweep). The spans are the
 operator's frame-study determinations (see auto-memory
@@ -12,6 +21,7 @@ indistinguishable from a fresh pipeline cut at those instants:
   - THROW   : cut tight [s,e] -> overwrite ``{cs}-clip.mp4``; cut+upload the
               wide source ``{cs}-clip-source.mp4`` ([cs-7.5, ce+7.5]); persist
               clip_url + clip_url_original + trim offsets via set_clip_url.
+              Without ``--throw``: wide source only, via set_clip_url_original.
   - LANDING : same shape against the ``-landing`` / ``-landing-source`` keys.
   - STAND   : cut tight [s,e] -> overwrite ``{cs}-stand-micro.mp4``; persist
               stand_clip_url + stand_clip_offset_s (offset INTO the shared THROW
@@ -31,6 +41,10 @@ out of the clip-recut scope).
 Run via the MAIN checkout venv, cwd = backend:
   python scripts/recut_lineup_clips.py 45d89ec3 \
     --stand 28.4 30.0 --aim 38.0 39.4 --throw 38.7 40.2 --landing 72.3 74.3
+
+  # placed utility (trapwire / spycam / turret / trademark / sonic sensor):
+  python scripts/recut_lineup_clips.py 45d89ec3 \
+    --stand 28.4 30.0 --aim 38.0 39.4 --landing 72.3 74.3
 """
 import argparse
 import asyncio
@@ -70,11 +84,19 @@ VIDEO_DIR = Path(os.environ["TEMP"]) / "mga-debug-source"
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("id8", help="lineup id8 prefix (e.g. 45d89ec3)")
-    for pane in ("stand", "aim", "throw", "landing"):
+    for pane in ("stand", "aim", "landing"):
         p.add_argument(
             f"--{pane}", nargs=2, type=float, metavar=("START", "END"),
             required=True, help=f"{pane.upper()} span [start end] in source seconds",
         )
+    # Optional on purpose — placed utility has no throw beat. See module docstring.
+    p.add_argument(
+        "--throw", nargs=2, type=float, metavar=("START", "END"), default=None,
+        help="THROW span [start end] in source seconds. OMIT for placed utility "
+             "(trapwire/spycam/alarmbot/turret/trademark/sonic-sensor): the tight "
+             "throw clip is skipped and clip_url stays NULL, but the shared wide "
+             "source is still cut so the STAND/AIM offsets remain valid.",
+    )
     p.add_argument(
         "--dry-run", action="store_true",
         help="print the plan + computed offsets, write nothing",
@@ -85,6 +107,11 @@ def _parse_args() -> argparse.Namespace:
              "shared wide source; does NOT affect the tight served clips)",
     )
     return p.parse_args()
+
+
+def _fmt(v: float | None) -> str:
+    """2dp, or 'None'. Trim columns are legitimately NULL on the placed path."""
+    return "None" if v is None else f"{v:.2f}"
 
 
 async def _cut_and_upload_tight(storage, video: Path, key: str,
@@ -102,8 +129,10 @@ async def main() -> None:
     args = _parse_args()
     spans = {
         "stand": tuple(args.stand), "aim": tuple(args.aim),
-        "throw": tuple(args.throw), "landing": tuple(args.landing),
+        "landing": tuple(args.landing),
     }
+    if args.throw is not None:
+        spans["throw"] = tuple(args.throw)
     for pane, (s, e) in spans.items():
         if e <= s:
             raise SystemExit(f"{pane}: end {e} must be > start {s}")
@@ -137,7 +166,7 @@ async def main() -> None:
         print(f"  vid={vid} chapter=[{cs:.2f}, {ce:.2f}] (next_cs={next_cs}) "
               f"technique={lineup.technique!r}")
         print(f"  spans: stand={spans['stand']} aim={spans['aim']} "
-              f"throw={spans['throw']} landing={spans['landing']}")
+              f"throw={spans.get('throw', 'PLACED — none')} landing={spans['landing']}")
         print("  BEFORE:")
         print(f"    stand_clip={lineup.stand_clip_url} off={lineup.stand_clip_offset_s}")
         print(f"    aim_clip  ={lineup.aim_clip_url} off={lineup.aim_clip_offset_s}")
@@ -177,14 +206,24 @@ async def main() -> None:
             raise SystemExit(f"LANDING wide source failed: {land_wide.error_codes}")
 
         # ---- THROW tight + persist (clip_url + original + trim) -------------
-        ts0, ts1 = spans["throw"]
-        n = await _cut_and_upload_tight(storage, video, pending_clip_key(vid, cs), ts0, ts1)
-        tr_s, tr_e = tight_offsets_within_source(
-            tight_start=ts0, tight_duration=ts1 - ts0, source_start=wide_start)
-        await lineup_repo.set_clip_url(
-            db, lineup, pending_clip_key(vid, cs),
-            source_key=throw_wide.source_key, trim_start_s=tr_s, trim_end_s=tr_e)
-        print(f"  THROW   tight=[{ts0:.2f},{ts1:.2f}] ({n}B) trim=[{tr_s:.2f},{tr_e:.2f}]")
+        # Placed utility has no throw beat, so there is nothing to cut tight.
+        # The WIDE source is still persisted (set_clip_url_original writes only
+        # clip_url_original, leaving clip_url NULL) because the STAND and AIM
+        # offsets below are measured from its start — drop it and both shift
+        # editors lose their frame of reference.
+        if "throw" in spans:
+            ts0, ts1 = spans["throw"]
+            n = await _cut_and_upload_tight(storage, video, pending_clip_key(vid, cs), ts0, ts1)
+            tr_s, tr_e = tight_offsets_within_source(
+                tight_start=ts0, tight_duration=ts1 - ts0, source_start=wide_start)
+            await lineup_repo.set_clip_url(
+                db, lineup, pending_clip_key(vid, cs),
+                source_key=throw_wide.source_key, trim_start_s=tr_s, trim_end_s=tr_e)
+            print(f"  THROW   tight=[{ts0:.2f},{ts1:.2f}] ({n}B) trim=[{tr_s:.2f},{tr_e:.2f}]")
+        else:
+            await lineup_repo.set_clip_url_original(db, lineup, throw_wide.source_key)
+            print("  THROW   PLACED — no throw beat; clip_url left NULL, "
+                  f"wide source persisted as {throw_wide.source_key}")
 
         # ---- LANDING tight + persist ----------------------------------------
         ls0, ls1 = spans["landing"]
@@ -216,11 +255,13 @@ async def main() -> None:
         print("  AFTER:")
         print(f"    stand_clip={lineup.stand_clip_url} off={lineup.stand_clip_offset_s}")
         print(f"    aim_clip  ={lineup.aim_clip_url} off={lineup.aim_clip_offset_s}")
+        # Trims are NULL on the placed path (no tight throw clip), so format
+        # defensively rather than blowing up on None.__format__('.2f').
         print(f"    throw_clip={lineup.clip_url} orig={lineup.clip_url_original} "
-              f"trim=[{lineup.clip_trim_start_s:.2f},{lineup.clip_trim_end_s:.2f}]")
+              f"trim=[{_fmt(lineup.clip_trim_start_s)},{_fmt(lineup.clip_trim_end_s)}]")
         print(f"    landing   ={lineup.landing_clip_url} orig={lineup.landing_clip_url_original} "
-              f"trim=[{lineup.landing_clip_trim_start_s:.2f},{lineup.landing_clip_trim_end_s:.2f}]")
-        print("DONE — 4 clips re-cut from operator-confirmed spans.")
+              f"trim=[{_fmt(lineup.landing_clip_trim_start_s)},{_fmt(lineup.landing_clip_trim_end_s)}]")
+        print(f"DONE — {len(spans)} clips re-cut from operator-confirmed spans.")
 
 
 asyncio.run(main())

--- a/apps/mygamingassistant/backend/tests/test_ingest_agent_placed_validation.py
+++ b/apps/mygamingassistant/backend/tests/test_ingest_agent_placed_validation.py
@@ -1,0 +1,89 @@
+"""``ingest_agent._validate`` must treat a missing THROW span as meaningful.
+
+A spans pack with no ``throw`` entry is ambiguous on its face. For placed
+utility (Cypher's trapwire/spycam, Killjoy's alarmbot/turret, Chamber's
+trademark, Deadlock's sonic sensor) it is CORRECT — a mounted device never
+leaves the player's hands, so the lineup is a complete three-beat
+STAND/AIM/LANDING story. For thrown utility it means the pack is truncated
+and the recut would silently produce a lineup missing its central beat.
+
+Only ``utility_type.placement`` separates the two, so the validator has to be
+strict in BOTH directions. This is the guard the whole placed-utility pipeline
+rests on: a wrong ``placed`` drops a real throw clip, a wrong ``thrown``
+demands a beat that does not exist on screen and fails every row.
+
+``_validate`` is pure (no DB), so it is tested directly against stub utility
+objects rather than through the driver's subcommands.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "ingest_agent.py"
+
+
+def _load_driver():
+    """Import scripts/ingest_agent.py by path — scripts/ is not a package."""
+    spec = importlib.util.spec_from_file_location("_ingest_agent_under_test", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Util:
+    """Minimal stand-in for UtilityType — _validate only reads ``placement``."""
+
+    def __init__(self, placement: str) -> None:
+        self.placement = placement
+
+
+UTILS = {"trapwire": _Util("placed"), "recon": _Util("thrown")}
+ZONES = {"a-main": "z1", "a-site": "z2"}
+
+
+def _pack(ability: str, spans: dict) -> dict:
+    return {
+        "lineups": [
+            {
+                "cs": 12,
+                "title": "A Site Trip",
+                "ability": ability,
+                "target": "a-site",
+                "stand": "a-main",
+                "side": "side_a",
+                "spans": spans,
+            }
+        ]
+    }
+
+
+THREE = {"stand": [1.0, 2.0], "aim": [3.0, 4.0], "landing": [8.0, 9.0]}
+FOUR = {**THREE, "throw": [5.0, 6.0]}
+
+
+def test_placed_utility_validates_without_a_throw_span():
+    """The whole point: three beats is COMPLETE for a mounted device."""
+    _load_driver()._validate(_pack("trapwire", THREE), ZONES, UTILS)
+
+
+def test_thrown_utility_still_requires_a_throw_span():
+    """Dropping the throw requirement wholesale would let truncated packs
+    through and silently produce lineups missing their central beat."""
+    with pytest.raises(SystemExit) as exc:
+        _load_driver()._validate(_pack("recon", THREE), ZONES, UTILS)
+    assert "missing 'throw' span" in str(exc.value)
+
+
+def test_placed_utility_rejects_a_supplied_throw_span():
+    """A throw span on placed utility means the localizer either misread the
+    ability or invented a beat. Accepting it silently would bake that error in,
+    so it fails as loudly as the missing-span case."""
+    with pytest.raises(SystemExit) as exc:
+        _load_driver()._validate(_pack("trapwire", FOUR), ZONES, UTILS)
+    assert "placed utility" in str(exc.value)
+
+
+def test_thrown_utility_validates_with_all_four_beats():
+    """Regression guard — the common path must be untouched by the above."""
+    _load_driver()._validate(_pack("recon", FOUR), ZONES, UTILS)

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -255,6 +255,22 @@ describe("LineupCard", () => {
     expect(document.querySelector("video")).toBeNull();
   });
 
+  it("expanded variant THROW pane distinguishes placed utility from a missing clip", () => {
+    // Both cases have clip_url === null, but they mean opposite things: a
+    // thrown lineup is INCOMPLETE (clip still owed), a placed one is COMPLETE
+    // (there is no throw beat to film). If the copy doesn't separate them, the
+    // operator has no way to tell a finished Cypher trapwire from a Sova dart
+    // whose clip never generated.
+    const placed: Lineup = {
+      ...BASE_LINEUP,
+      utility_type: { ...BASE_LINEUP.utility_type!, slug: "trapwire", placement: "placed" },
+    };
+    render(<LineupCard lineup={placed} variant="expanded" />);
+    expect(screen.getByText("Placed — no throw")).toBeInTheDocument();
+    expect(screen.queryByText("No clip yet")).not.toBeInTheDocument();
+    expect(document.querySelector("video")).toBeNull();
+  });
+
   it("expanded variant THROW pane renders ClipView when clip_url is set", () => {
     const lineup: Lineup = { ...BASE_LINEUP, clip_url: "https://ex.com/clip.mp4" };
     render(<LineupCard lineup={lineup} variant="expanded" />);

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardStoryboard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardStoryboard.tsx
@@ -160,7 +160,7 @@ export default function GlanceBoardStoryboard({
               title={lineup.title}
             />
           ) : (
-            <ThrowPlaceholder />
+            <ThrowPlaceholder placement={lineup.utility_type?.placement} />
           )}
         </PaneSlot>
         <PaneSlot

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
@@ -149,7 +149,7 @@ export default function LineupCard({
               title={lineup.title}
             />
           ) : (
-            <ThrowPlaceholder />
+            <ThrowPlaceholder placement={lineup.utility_type?.placement} />
           )}
           <LandingPane
             targetZoneName={lineup.target_zone?.name ?? null}

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
@@ -11,6 +11,7 @@
  * flex row container.
  */
 import { useEffect, useRef, useState } from "react";
+import type { UtilityPlacement } from "../../types/game";
 
 // ---------------------------------------------------------------------------
 // Aim anchor dot — 12px red filled circle, white outline, drop shadow.
@@ -330,15 +331,37 @@ export function AimPane({
 
 // ---------------------------------------------------------------------------
 // ThrowPlaceholder — empty state for the bottom-left pane when clip_url is
-// null (no clip generated yet). Same dimensions + corner-label posture as
-// ScreenshotHalf — reads as "this pane belongs to throw motion; nothing
-// captured yet" rather than as a load failure.
+// null. Same dimensions + corner-label posture as ScreenshotHalf, so it reads
+// as "this pane belongs to throw motion" rather than as a load failure.
+//
+// A null clip_url means one of two very different things, and the copy has to
+// tell them apart or the operator cannot tell a complete lineup from a broken
+// one:
+//
+//   thrown utility — the clip genuinely has not been generated yet. This is a
+//     gap; "No clip yet" is an accurate to-do.
+//   placed utility — trapwire, spycam, alarmbot, turret, trademark, sonic
+//     sensor. Mounted at the player's own position, so nothing is ever in
+//     flight and there is no throw beat to film. The lineup is COMPLETE at
+//     three beats; "No clip yet" would be a standing lie about missing work.
 // ---------------------------------------------------------------------------
-export function ThrowPlaceholder() {
+export function ThrowPlaceholder({
+  placement = "thrown",
+}: {
+  placement?: UtilityPlacement;
+}) {
+  const isPlaced = placement === "placed";
   return (
     <div className="flex-1 min-w-0 relative bg-muted/20 aspect-video overflow-hidden">
-      <div className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
-        No clip yet
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-0.5 px-2 text-center">
+        <span className="text-xs text-muted-foreground">
+          {isPlaced ? "Placed — no throw" : "No clip yet"}
+        </span>
+        {isPlaced ? (
+          <span className="text-[10px] text-muted-foreground/70">
+            Mounted in place
+          </span>
+        ) : null}
       </div>
       <CornerLabel>THROW</CornerLabel>
     </div>


### PR DESCRIPTION
Step 2 of the Cypher / placed-utility work. #1009 added `utility_type.placement` and marked six abilities `placed` — Cypher's trapwire + spycam, Killjoy's alarmbot + turret, Chamber's trademark, Deadlock's sonic sensor. Nothing downstream read it yet, so the pipeline still demanded four beats from every lineup and **no placed lineup could be ingested at all**.

A mounted device never leaves the player's hands, so nothing is ever in flight and there is no throw beat to film. Those lineups are **complete at three beats — STAND / AIM / LANDING** — not four-beat lineups missing one. Everything below follows from treating them that way rather than as a degraded case.

### `recut_lineup_clips.py`

`--throw` is now optional. Without it the tight throw clip is skipped and `clip_url` stays NULL.

The throw **wide source is still cut and persisted**, via `set_clip_url_original` (which writes only `clip_url_original`). It is the shared source the STAND and AIM offsets are measured from — `stand_off = ss0 - wide_start` — so dropping it would leave both shift editors with no frame of reference. Trim columns are legitimately NULL on this path, so the summary formats them defensively rather than calling `None.__format__('.2f')`.

### `ingest_agent.py`

Validation is strict in **both** directions, because a missing throw span is ambiguous on its face and only `placement` disambiguates it:

| pack | ability | verdict |
|---|---|---|
| 3 beats | placed | ✅ correct — complete lineup |
| 3 beats | thrown | ❌ truncated pack; recut would silently drop the central beat |
| 4 beats | placed | ❌ ability misread, or the beat was invented |
| 4 beats | thrown | ✅ the common path, unchanged |

`_resolve` now returns whole `UtilityType` objects rather than bare ids so `placement` is available to decide this. `cmd_recut` validates too, not just plan/create/accept — it is the subcommand that writes **media**, so it must not act on an ambiguous pack.

### Localize workflow (`~/.claude/workflows`, local-only — not in this diff)

Placed rows get a 3-event schema (`throw` drops out of `required`), an explicit override telling the subagent that the instruction file's THROW section does not apply and that fabricating a span is a hard failure, and a **separate adversarial gate**.

The gate needed its own text rather than a patch: the 4-event criterion *"the actual RELEASE visible … a drawn bow with NO loose = FAIL"* is precisely what a correct placed lineup can never satisfy, so leaving it in would fail every correct row. The placed gate also polices the fabrication directly — any throw span at all fails the row, and the value is surfaced to the judge.

### Frontend

A null `clip_url` now means two different things, and `ThrowPlaceholder` has to separate them or the operator cannot tell a finished Cypher trapwire from a Sova dart whose clip never generated.

- thrown → "No clip yet" (an accurate to-do)
- placed → "Placed — no throw" / "Mounted in place"

`placement` was already plumbed end-to-end by #1009, so both call sites just pass it through.

### Verification

- **4 new backend tests** over `_validate` covering all four rows of the table above; 12 pass together with `test_agent_fixtures`.
- **New frontend test** asserting the two null-`clip_url` cases render different copy; 41 pass across `LineupCard` + `GlanceBoardStoryboard`. `tsc --noEmit` clean.
- **Workflow harness** stubbing the runtime globals: 14 assertions over the placed/thrown branches — schema required-set, localize prompt text, gate criteria, fabricated-span policing, and the per-item `placed` override. All hold.
- **recut dry-run on a real lineup** in both modes; `--landing` still required when omitted.

### Not in this PR

Step 3 — sub-chapter segmentation, turning one topic-section chapter (`"A Site Trip Wires" [13s→123s]`) into N single-placement windows. That is what actually unlocks bulk Cypher/Killjoy ingest; this PR unblocks the beat model it depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)