### PR TITLE
feat(mbk): utility plan tracking with renewal alerts

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/utilplan260807_add_utility_plans.py
+++ b/apps/mybookkeeper/backend/alembic/versions/utilplan260807_add_utility_plans.py
@@ -1,0 +1,147 @@
+"""add utility_plans
+
+Records the contract behind a utility account — rate, term, and the date the
+term ends — so a lapsed fixed-rate plan rolling onto a holdover variable rate
+becomes visible instead of silent.
+
+Revision ID: utilplan260807
+Revises: wmanualshare260721
+Create Date: 2026-08-07
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "utilplan260807"
+down_revision = "wmanualshare260721"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "utility_plans",
+        sa.Column(
+            "id", postgresql.UUID(as_uuid=True), primary_key=True,
+            server_default=sa.text("gen_random_uuid()"), nullable=False,
+        ),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("property_id", postgresql.UUID(as_uuid=True), nullable=False),
+
+        sa.Column("service_type", sa.String(length=20), nullable=False),
+        sa.Column("provider_name", sa.String(length=255), nullable=False),
+        sa.Column("account_number", sa.String(length=100), nullable=True),
+        sa.Column("plan_name", sa.String(length=255), nullable=True),
+        sa.Column("rate_type", sa.String(length=20), nullable=False),
+
+        # Numeric, not integer cents: a TDU charge of 5.3509 ¢/kWh has four
+        # decimal places that integer cents cannot represent.
+        sa.Column("energy_charge_cents_per_kwh", sa.Numeric(9, 4), nullable=True),
+        sa.Column("tdu_charge_cents_per_kwh", sa.Numeric(9, 4), nullable=True),
+        sa.Column("avg_price_cents_per_kwh_at_1000", sa.Numeric(9, 4), nullable=True),
+        sa.Column("monthly_base_charge_cents", sa.BigInteger(), nullable=True),
+
+        sa.Column("term_months", sa.SmallInteger(), nullable=True),
+        sa.Column("service_start_date", sa.Date(), nullable=True),
+        sa.Column("term_end_date", sa.Date(), nullable=True),
+        sa.Column("early_termination_fee_cents", sa.BigInteger(), nullable=True),
+
+        sa.Column(
+            "has_bill_credit", sa.Boolean(), nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("bill_credit_amount_cents", sa.BigInteger(), nullable=True),
+        sa.Column("bill_credit_threshold_kwh", sa.Integer(), nullable=True),
+        sa.Column("min_usage_fee_cents", sa.BigInteger(), nullable=True),
+        sa.Column("min_usage_threshold_kwh", sa.Integer(), nullable=True),
+
+        sa.Column("notes", sa.Text(), nullable=True),
+
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.text("now()"),
+        ),
+
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], ondelete="CASCADE",
+            name="fk_utility_plans_user_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE",
+            name="fk_utility_plans_organization_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["property_id"], ["properties.id"], ondelete="CASCADE",
+            name="fk_utility_plans_property_id",
+        ),
+        sa.CheckConstraint(
+            "service_type IN ('electricity', 'internet', 'natural_gas', 'water')",
+            name="chk_utility_plan_service_type",
+        ),
+        sa.CheckConstraint(
+            "rate_type IN ('fixed', 'indexed', 'regulated', 'variable')",
+            name="chk_utility_plan_rate_type",
+        ),
+        sa.CheckConstraint(
+            "length(provider_name) > 0",
+            name="chk_utility_plan_provider_nonempty",
+        ),
+        sa.CheckConstraint(
+            "service_start_date IS NULL"
+            " OR term_end_date IS NULL"
+            " OR term_end_date >= service_start_date",
+            name="chk_utility_plan_term_order",
+        ),
+        sa.CheckConstraint(
+            "has_bill_credit IS FALSE"
+            " OR (bill_credit_amount_cents IS NOT NULL"
+            " AND bill_credit_threshold_kwh IS NOT NULL)",
+            name="chk_utility_plan_bill_credit_complete",
+        ),
+    )
+
+    # PostgreSQL does not auto-index FKs; these carry the CASCADE deletes.
+    op.create_index("ix_utility_plans_user_id", "utility_plans", ["user_id"])
+    op.create_index(
+        "ix_utility_plans_organization_id", "utility_plans", ["organization_id"],
+    )
+    op.create_index("ix_utility_plans_property_id", "utility_plans", ["property_id"])
+
+    # Current-plan resolution: newest start per property + service.
+    op.create_index(
+        "ix_utility_plans_property_service_start_active",
+        "utility_plans",
+        ["property_id", "service_type", "service_start_date"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    # Expiring-soon sweeps, per org and across orgs.
+    op.create_index(
+        "ix_utility_plans_org_term_end_active",
+        "utility_plans",
+        ["organization_id", "term_end_date"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_index(
+        "ix_utility_plans_term_end_active",
+        "utility_plans",
+        ["term_end_date"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_utility_plans_term_end_active", table_name="utility_plans")
+    op.drop_index("ix_utility_plans_org_term_end_active", table_name="utility_plans")
+    op.drop_index(
+        "ix_utility_plans_property_service_start_active", table_name="utility_plans",
+    )
+    op.drop_index("ix_utility_plans_property_id", table_name="utility_plans")
+    op.drop_index("ix_utility_plans_organization_id", table_name="utility_plans")
+    op.drop_index("ix_utility_plans_user_id", table_name="utility_plans")
+    op.drop_table("utility_plans")

--- a/apps/mybookkeeper/backend/app/api/utility_plans.py
+++ b/apps/mybookkeeper/backend/app/api/utility_plans.py
@@ -1,0 +1,139 @@
+"""HTTP routes for utility plans.
+
+Route prefix: /utility-plans.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.core.utility_plan_constants import EXPIRING_SOON_DAYS
+from app.schemas.properties.utility_plan_create_request import UtilityPlanCreateRequest
+from app.schemas.properties.utility_plan_list_response import UtilityPlanListResponse
+from app.schemas.properties.utility_plan_renewal_alert_response import (
+    UtilityPlanRenewalAlertResponse,
+)
+from app.schemas.properties.utility_plan_response import UtilityPlanResponse
+from app.schemas.properties.utility_plan_update_request import UtilityPlanUpdateRequest
+from app.services.properties import utility_plan_service
+
+router = APIRouter(prefix="/utility-plans", tags=["utility-plans"])
+
+_NOT_FOUND_DETAIL = "Utility plan not found"
+
+
+@router.post("", response_model=UtilityPlanResponse, status_code=201)
+async def create_plan(
+    payload: UtilityPlanCreateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> UtilityPlanResponse:
+    return await utility_plan_service.create_plan(
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
+        fields=payload.model_dump(),
+    )
+
+
+@router.get("", response_model=UtilityPlanListResponse)
+async def list_plans(
+    property_id: uuid.UUID | None = Query(None),
+    service_type: str | None = Query(None),
+    expiring_before: _dt.date | None = Query(None),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    ctx: RequestContext = Depends(current_org_member),
+) -> UtilityPlanListResponse:
+    return await utility_plan_service.list_plans(
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
+        property_id=property_id,
+        service_type=service_type,
+        expiring_before=expiring_before,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/renewal-alerts", response_model=UtilityPlanRenewalAlertResponse)
+async def get_renewal_alerts(
+    window_days: int = Query(EXPIRING_SOON_DAYS, ge=1, le=365),
+    ctx: RequestContext = Depends(current_org_member),
+) -> UtilityPlanRenewalAlertResponse:
+    """Current plans whose term has lapsed or lapses within ``window_days``.
+
+    Declared before ``/{plan_id}`` so the literal path is not swallowed by the
+    UUID route.
+    """
+    return await utility_plan_service.get_renewal_alerts(
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
+        window_days=window_days,
+    )
+
+
+@router.get("/{plan_id}", response_model=UtilityPlanResponse)
+async def get_plan(
+    plan_id: uuid.UUID,
+    ctx: RequestContext = Depends(current_org_member),
+) -> UtilityPlanResponse:
+    try:
+        return await utility_plan_service.get_plan(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            plan_id=plan_id,
+        )
+    except utility_plan_service.UtilityPlanNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL) from exc
+
+
+@router.patch("/{plan_id}", response_model=UtilityPlanResponse)
+async def update_plan(
+    plan_id: uuid.UUID,
+    payload: UtilityPlanUpdateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> UtilityPlanResponse:
+    # exclude_unset preserves the distinction between "field omitted" and
+    # "field explicitly set to null".
+    raw: dict[str, Any] = payload.model_dump(exclude_unset=True)
+    if not raw:
+        try:
+            return await utility_plan_service.get_plan(
+                user_id=ctx.user_id,
+                organization_id=ctx.organization_id,
+                plan_id=plan_id,
+            )
+        except utility_plan_service.UtilityPlanNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL) from exc
+
+    try:
+        return await utility_plan_service.update_plan(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            plan_id=plan_id,
+            fields=raw,
+        )
+    except utility_plan_service.UtilityPlanNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL) from exc
+    except utility_plan_service.InvalidUtilityPlanError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.delete("/{plan_id}", status_code=204)
+async def delete_plan(
+    plan_id: uuid.UUID,
+    ctx: RequestContext = Depends(require_write_access),
+) -> Response:
+    try:
+        await utility_plan_service.soft_delete_plan(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            plan_id=plan_id,
+        )
+    except utility_plan_service.UtilityPlanNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL) from exc
+    return Response(status_code=204)

--- a/apps/mybookkeeper/backend/app/cli/migrate_data.py
+++ b/apps/mybookkeeper/backend/app/cli/migrate_data.py
@@ -5,13 +5,18 @@ Usage:
     python -m app.cli.migrate_data cleanup-duplicates
     python -m app.cli.migrate_data recompute-tax --year 2025
     python -m app.cli.migrate_data dry-run cleanup-duplicates
+    python -m app.cli.migrate_data --dry-run seed-utility-plans
 """
 import argparse
 import sys
+import uuid
 
 from sqlalchemy import text
 
 from app.cli.db import SyncSession
+from app.cli.peerless_utility_plan_seed import PEERLESS_UTILITY_PLANS
+from app.cli.utility_plan_seed_row import UtilityPlanSeedRow
+from app.services.extraction.utility_account_service import normalize_account_number
 
 
 def cmd_cleanup_duplicates(args):
@@ -143,6 +148,139 @@ def cmd_reprocess_completed_without_transactions(args):
         print("The upload processor worker will re-extract and create transactions.")
 
 
+_FIND_PROPERTY = text("""
+    SELECT id, user_id, organization_id, name
+    FROM properties
+    WHERE name ILIKE :frag OR address ILIKE :frag
+    ORDER BY name
+""")
+
+# service_start_date is NULL for regulated plans, so a plain `=` would never
+# match and every re-run would insert a duplicate.
+_FIND_EXISTING_PLAN = text("""
+    SELECT id FROM utility_plans
+    WHERE property_id = :property_id
+      AND service_type = :service_type
+      AND provider_name = :provider_name
+      AND service_start_date IS NOT DISTINCT FROM :service_start_date
+      AND deleted_at IS NULL
+""")
+
+_INSERT_PLAN = text("""
+    INSERT INTO utility_plans (
+        id, user_id, organization_id, property_id,
+        service_type, provider_name, account_number, plan_name, rate_type,
+        energy_charge_cents_per_kwh, tdu_charge_cents_per_kwh,
+        avg_price_cents_per_kwh_at_1000, monthly_base_charge_cents,
+        term_months, service_start_date, term_end_date,
+        early_termination_fee_cents, has_bill_credit,
+        min_usage_fee_cents, min_usage_threshold_kwh, notes,
+        created_at, updated_at
+    ) VALUES (
+        :id, :user_id, :organization_id, :property_id,
+        :service_type, :provider_name, :account_number, :plan_name, :rate_type,
+        :energy_charge_cents_per_kwh, :tdu_charge_cents_per_kwh,
+        :avg_price_cents_per_kwh_at_1000, :monthly_base_charge_cents,
+        :term_months, :service_start_date, :term_end_date,
+        :early_termination_fee_cents, false,
+        :min_usage_fee_cents, :min_usage_threshold_kwh, :notes,
+        NOW(), NOW()
+    )
+""")
+
+
+def _plan_params(row: UtilityPlanSeedRow, prop) -> dict:
+    """Bind parameters for one seed row against its resolved property."""
+    account = row.account_number
+    return {
+        "id": str(uuid.uuid4()),
+        "user_id": str(prop.user_id),
+        "organization_id": str(prop.organization_id),
+        "property_id": str(prop.id),
+        "service_type": row.service_type,
+        "provider_name": row.provider_name,
+        # Normalized identically to utility_account_link so the two can be
+        # joined on the account number later.
+        "account_number": normalize_account_number(account) if account else None,
+        "plan_name": row.plan_name,
+        "rate_type": row.rate_type,
+        "energy_charge_cents_per_kwh": row.energy_charge_cents_per_kwh,
+        "tdu_charge_cents_per_kwh": row.tdu_charge_cents_per_kwh,
+        "avg_price_cents_per_kwh_at_1000": row.avg_price_cents_per_kwh_at_1000,
+        "monthly_base_charge_cents": row.monthly_base_charge_cents,
+        "term_months": row.term_months,
+        "service_start_date": row.service_start_date,
+        "term_end_date": row.term_end_date,
+        "early_termination_fee_cents": row.early_termination_fee_cents,
+        "min_usage_fee_cents": row.min_usage_fee_cents,
+        "min_usage_threshold_kwh": row.min_usage_threshold_kwh,
+        "notes": row.notes,
+    }
+
+
+def cmd_seed_utility_plans(args):
+    """Insert the Peerless St utility plans transcribed from provider email.
+
+    Idempotent: a row is skipped when a non-deleted plan already exists for the
+    same (property, service_type, provider, start date). Re-running after
+    adding a property picks up only what is missing.
+
+    A seed row whose property fragment matches zero or more than one property
+    is reported and skipped, never guessed — the wrong property would produce a
+    renewal alert for a contract that does not exist there.
+    """
+    inserted = skipped = unresolved = 0
+
+    with SyncSession() as session:
+        for row in PEERLESS_UTILITY_PLANS:
+            label = f"{row.property_match} / {row.service_type}"
+            matches = session.execute(
+                _FIND_PROPERTY, {"frag": f"%{row.property_match}%"},
+            ).fetchall()
+
+            if len(matches) != 1:
+                found = ", ".join(m.name for m in matches) or "nothing"
+                print(f"  SKIP {label} — matched {found}; expected exactly one property")
+                unresolved += 1
+                continue
+
+            prop = matches[0]
+            params = _plan_params(row, prop)
+
+            existing = session.execute(_FIND_EXISTING_PLAN, {
+                "property_id": params["property_id"],
+                "service_type": row.service_type,
+                "provider_name": row.provider_name,
+                "service_start_date": row.service_start_date,
+            }).first()
+            if existing:
+                print(f"  SKIP {label} — already present on {prop.name}")
+                skipped += 1
+                continue
+
+            # ASCII arrow on purpose: the Windows console this CLI is run from
+            # is cp1252, which has no U+2192 and raises UnicodeEncodeError.
+            if args.dry_run:
+                print(f"  WOULD INSERT {label} -> {prop.name} ({row.provider_name})")
+            else:
+                session.execute(_INSERT_PLAN, params)
+                print(f"  INSERT {label} -> {prop.name} ({row.provider_name})")
+            inserted += 1
+
+        if args.dry_run:
+            print(
+                f"\n[DRY RUN] Would insert {inserted}; "
+                f"{skipped} already present, {unresolved} unresolved."
+            )
+            return
+
+        session.commit()
+        print(
+            f"\nInserted {inserted} utility plans; "
+            f"{skipped} already present, {unresolved} unresolved."
+        )
+
+
 def main():
     parser = argparse.ArgumentParser(description="MyBookkeeper data migration CLI")
     parser.add_argument("--dry-run", action="store_true", help="Preview changes without applying")
@@ -159,11 +297,17 @@ def main():
         help="Reset completed docs with extractions but no transactions for re-processing",
     )
 
+    subparsers.add_parser(
+        "seed-utility-plans",
+        help="Insert the Peerless St utility plans transcribed from provider email",
+    )
+
     args = parser.parse_args()
     commands = {
         "cleanup-duplicates": cmd_cleanup_duplicates,
         "recompute-tax": cmd_recompute_tax,
         "reprocess-completed-without-transactions": cmd_reprocess_completed_without_transactions,
+        "seed-utility-plans": cmd_seed_utility_plans,
     }
     commands[args.command](args)
 

--- a/apps/mybookkeeper/backend/app/cli/peerless_utility_plan_seed.py
+++ b/apps/mybookkeeper/backend/app/cli/peerless_utility_plan_seed.py
@@ -1,0 +1,147 @@
+"""Seed rows for the Peerless St portfolio's utility plans.
+
+Every figure here was transcribed from the provider's own email, not inferred:
+
+* Constellation enrollment confirmations, 2025-01-23 — 6732 PEERLESS ST and
+  6734 PEERLESS ST (two separate messages, same plan and same rates).
+* Constellation "Residential Plan Change Notice", 2025-01-27 — 6738 PEERLESS
+  ST, account 204430810.
+* CenterPoint payment alerts — the only messages that print an account number
+  and its service address together: 6403771807-5 is 6734, 6403771834-9 is 6732.
+
+Two things are deliberately left NULL rather than guessed:
+
+1. **The electric account numbers for 6732 and 6734.** Two Constellation
+   accounts (204865879, 204865622) appear on invoices, but no message binds
+   either to a street address, and the enrollment confirmations pre-date
+   account creation. Which is which is recorded in ``notes`` for the operator
+   to resolve from a bill; inventing the mapping would silently attach the
+   wrong account to a property.
+2. **6738's average price and early-termination fee.** The plan-change notice
+   states the term, the component rates, and the start date, but not those two
+   figures. They are almost certainly identical to the other two properties —
+   "almost certainly" is not a source.
+
+``term_end_date`` is start + ``term_months`` in every case. The enrollment
+emails say the exact contract end date arrives in the welcome package, which is
+not in the mailbox; the derived date is accurate to the day the term was sold
+and is what the renewal alert needs. All three electric terms have already
+lapsed, which is the point of seeding them.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from decimal import Decimal
+
+from app.cli.utility_plan_seed_row import UtilityPlanSeedRow
+from app.core.utility_plan_constants import (
+    RATE_TYPE_FIXED,
+    RATE_TYPE_REGULATED,
+    SERVICE_TYPE_ELECTRICITY,
+    SERVICE_TYPE_NATURAL_GAS,
+)
+
+_CONSTELLATION = "Constellation"
+_CONSTELLATION_PLAN = "FIXED Electricity Plan + Air Conditioner Protection Plan"
+_CENTERPOINT = "CenterPoint Energy"
+
+_ENERGY_CHARGE = Decimal("11.6000")
+_TDU_CHARGE = Decimal("5.3509")
+_AVG_PRICE_AT_1000 = Decimal("13.9000")
+_MONTHLY_BASE_CENTS = 439
+_ETF_CENTS = 15_000
+
+# The EFL states a minimum-usage fee of 0.00000 below 999 kWh — i.e. the plan
+# has the trap's shape but the fee is zero. Recorded as stated so a later
+# comparison against a plan that *does* charge one is like-for-like.
+_MIN_USAGE_FEE_CENTS = 0
+_MIN_USAGE_THRESHOLD_KWH = 999
+
+_UNKNOWN_ELECTRIC_ACCOUNT_NOTE = (
+    "Electric account number unresolved: Constellation accounts 204865879 and "
+    "204865622 both bill to this portfolio, but no email binds either to a "
+    "street address. Set it from a bill. Term end derived as start + 12 months "
+    "(the welcome package holds the exact contract end date)."
+)
+
+PEERLESS_UTILITY_PLANS: tuple[UtilityPlanSeedRow, ...] = (
+    UtilityPlanSeedRow(
+        property_match="6732 Peerless",
+        service_type=SERVICE_TYPE_ELECTRICITY,
+        provider_name=_CONSTELLATION,
+        rate_type=RATE_TYPE_FIXED,
+        plan_name=_CONSTELLATION_PLAN,
+        energy_charge_cents_per_kwh=_ENERGY_CHARGE,
+        tdu_charge_cents_per_kwh=_TDU_CHARGE,
+        avg_price_cents_per_kwh_at_1000=_AVG_PRICE_AT_1000,
+        monthly_base_charge_cents=_MONTHLY_BASE_CENTS,
+        term_months=12,
+        service_start_date=_dt.date(2025, 1, 23),
+        term_end_date=_dt.date(2026, 1, 23),
+        early_termination_fee_cents=_ETF_CENTS,
+        min_usage_fee_cents=_MIN_USAGE_FEE_CENTS,
+        min_usage_threshold_kwh=_MIN_USAGE_THRESHOLD_KWH,
+        notes=_UNKNOWN_ELECTRIC_ACCOUNT_NOTE,
+    ),
+    UtilityPlanSeedRow(
+        property_match="6734 Peerless",
+        service_type=SERVICE_TYPE_ELECTRICITY,
+        provider_name=_CONSTELLATION,
+        rate_type=RATE_TYPE_FIXED,
+        plan_name=_CONSTELLATION_PLAN,
+        energy_charge_cents_per_kwh=_ENERGY_CHARGE,
+        tdu_charge_cents_per_kwh=_TDU_CHARGE,
+        avg_price_cents_per_kwh_at_1000=_AVG_PRICE_AT_1000,
+        monthly_base_charge_cents=_MONTHLY_BASE_CENTS,
+        term_months=12,
+        service_start_date=_dt.date(2025, 1, 23),
+        term_end_date=_dt.date(2026, 1, 23),
+        early_termination_fee_cents=_ETF_CENTS,
+        min_usage_fee_cents=_MIN_USAGE_FEE_CENTS,
+        min_usage_threshold_kwh=_MIN_USAGE_THRESHOLD_KWH,
+        notes=_UNKNOWN_ELECTRIC_ACCOUNT_NOTE,
+    ),
+    UtilityPlanSeedRow(
+        property_match="6738 Peerless",
+        service_type=SERVICE_TYPE_ELECTRICITY,
+        provider_name=_CONSTELLATION,
+        rate_type=RATE_TYPE_FIXED,
+        account_number="204430810",
+        plan_name=_CONSTELLATION_PLAN,
+        energy_charge_cents_per_kwh=_ENERGY_CHARGE,
+        tdu_charge_cents_per_kwh=_TDU_CHARGE,
+        monthly_base_charge_cents=_MONTHLY_BASE_CENTS,
+        term_months=12,
+        service_start_date=_dt.date(2025, 1, 27),
+        term_end_date=_dt.date(2026, 1, 27),
+        notes=(
+            "From the 2025-01-27 plan-change notice, which does not state the "
+            "average price at 1,000 kWh or the early-termination fee — both "
+            "left blank rather than copied from the sibling properties. Term "
+            "end derived as start + 12 months."
+        ),
+    ),
+    # Houston natural gas is a regulated monopoly: there is no competing
+    # supplier and no term to renew, so these carry no dates. They are recorded
+    # for the account number and provider, and RATE_TYPE_REGULATED is what
+    # keeps them out of the renewal alert.
+    UtilityPlanSeedRow(
+        property_match="6732 Peerless",
+        service_type=SERVICE_TYPE_NATURAL_GAS,
+        provider_name=_CENTERPOINT,
+        rate_type=RATE_TYPE_REGULATED,
+        account_number="6403771834-9",
+        notes="Account/address pairing confirmed from CenterPoint payment alerts.",
+    ),
+    UtilityPlanSeedRow(
+        property_match="6734 Peerless",
+        service_type=SERVICE_TYPE_NATURAL_GAS,
+        provider_name=_CENTERPOINT,
+        rate_type=RATE_TYPE_REGULATED,
+        account_number="6403771807-5",
+        notes="Account/address pairing confirmed from CenterPoint payment alerts.",
+    ),
+    # No CenterPoint gas account for 6738 appears anywhere in the mailbox.
+    # Absence of a bill is not evidence of absence of service, so nothing is
+    # seeded for it — the operator adds it through the UI if it exists.
+)

--- a/apps/mybookkeeper/backend/app/cli/utility_plan_seed_row.py
+++ b/apps/mybookkeeper/backend/app/cli/utility_plan_seed_row.py
@@ -1,0 +1,39 @@
+"""One row of utility-plan seed data, keyed to a property by address fragment.
+
+Separate from the seed data itself so the shape can be reused if another set of
+plans is ever seeded (a second portfolio, a restore onto a fresh database).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class UtilityPlanSeedRow:
+    """A plan to insert, plus the fragment used to find its property.
+
+    ``property_match`` is matched case-insensitively against both ``name`` and
+    ``address``. It must resolve to exactly one property — the seeder refuses
+    to guess, because attaching a rate plan to the wrong property produces a
+    renewal alert for a contract that does not exist there.
+    """
+
+    property_match: str
+    service_type: str
+    provider_name: str
+    rate_type: str
+    account_number: str | None = None
+    plan_name: str | None = None
+    energy_charge_cents_per_kwh: Decimal | None = None
+    tdu_charge_cents_per_kwh: Decimal | None = None
+    avg_price_cents_per_kwh_at_1000: Decimal | None = None
+    monthly_base_charge_cents: int | None = None
+    term_months: int | None = None
+    service_start_date: _dt.date | None = None
+    term_end_date: _dt.date | None = None
+    early_termination_fee_cents: int | None = None
+    min_usage_fee_cents: int | None = None
+    min_usage_threshold_kwh: int | None = None
+    notes: str | None = None

--- a/apps/mybookkeeper/backend/app/core/utility_plan_constants.py
+++ b/apps/mybookkeeper/backend/app/core/utility_plan_constants.py
@@ -1,0 +1,98 @@
+"""Utility-plan constants.
+
+A utility *plan* is the contract behind a utility account: the rate, the term,
+and — the part that costs money when nobody is watching — the date the term
+ends. When a fixed-rate term lapses without a renewal, deregulated providers
+move the account onto a month-to-month holdover product whose price is not
+fixed and can move every billing cycle. Nothing in the monthly "bill is ready"
+notification says this happened, so the overpay is silent and open-ended.
+
+``SERVICE_TYPES`` and ``RATE_TYPES`` are enforced in the DB by
+``CheckConstraint`` (String + CHECK, never the SQLAlchemy ``Enum`` type, per
+the monorepo schema conventions). Both are mirrored as TypeScript unions in
+``frontend/src/shared/types/utility/`` — a value added here MUST be added there
+in the same PR.
+"""
+
+# Utility service a plan covers. ``regulated`` markets (Houston natural gas,
+# most municipal water) still get a row: the renewal alert is meaningless for
+# them, but the rate and account details are still worth recording, and
+# ``RATE_TYPE_REGULATED`` is what suppresses the alert.
+SERVICE_TYPE_ELECTRICITY = "electricity"
+SERVICE_TYPE_NATURAL_GAS = "natural_gas"
+SERVICE_TYPE_WATER = "water"
+SERVICE_TYPE_INTERNET = "internet"
+
+SERVICE_TYPES: frozenset[str] = frozenset({
+    SERVICE_TYPE_ELECTRICITY,
+    SERVICE_TYPE_NATURAL_GAS,
+    SERVICE_TYPE_WATER,
+    SERVICE_TYPE_INTERNET,
+})
+
+# How the price is set.
+#   fixed     — locked ¢/kWh for the term; the only type with a real renewal cliff
+#   variable  — provider may reprice monthly (this is where a lapsed fixed plan lands)
+#   indexed   — tied to a published market index
+#   regulated — tariffed monopoly rate; there is no competing supplier to switch to
+RATE_TYPE_FIXED = "fixed"
+RATE_TYPE_VARIABLE = "variable"
+RATE_TYPE_INDEXED = "indexed"
+RATE_TYPE_REGULATED = "regulated"
+
+RATE_TYPES: frozenset[str] = frozenset({
+    RATE_TYPE_FIXED,
+    RATE_TYPE_VARIABLE,
+    RATE_TYPE_INDEXED,
+    RATE_TYPE_REGULATED,
+})
+
+# Rate types whose term genuinely ends on a date the operator must act before.
+# A ``regulated`` plan has no competitor to switch to, and a ``variable`` plan
+# has already lapsed — alerting on either is noise, so only these are eligible
+# for the expiring-soon surface.
+RENEWABLE_RATE_TYPES: frozenset[str] = frozenset({
+    RATE_TYPE_FIXED,
+    RATE_TYPE_INDEXED,
+})
+
+# Days of lead time on the expiring-soon surface. 45 days clears the 30-day
+# statutory notice window Texas REPs work to (16 TAC 25.475) and still leaves
+# room to shop, sign, and let the switch land on the next meter read.
+EXPIRING_SOON_DAYS = 45
+
+# Derived, never stored — computed from rate_type + term_end_date + today by
+# ``utility_plan_service.renewal_status`` so it can never drift from the dates
+# it describes. Mirrored as a TS union in
+# ``frontend/src/shared/types/utility/utility-plan-renewal-status.ts``.
+#   not_applicable — no term to lapse (regulated, or no end date recorded)
+#   active         — term ends beyond the alert window
+#   expiring_soon  — term ends within EXPIRING_SOON_DAYS; act now
+#   expired        — term end has passed; the account is almost certainly on a
+#                    holdover variable rate and bleeding money quietly
+RENEWAL_STATUS_NOT_APPLICABLE = "not_applicable"
+RENEWAL_STATUS_ACTIVE = "active"
+RENEWAL_STATUS_EXPIRING_SOON = "expiring_soon"
+RENEWAL_STATUS_EXPIRED = "expired"
+
+RENEWAL_STATUSES: frozenset[str] = frozenset({
+    RENEWAL_STATUS_NOT_APPLICABLE,
+    RENEWAL_STATUS_ACTIVE,
+    RENEWAL_STATUS_EXPIRING_SOON,
+    RENEWAL_STATUS_EXPIRED,
+})
+
+# Statuses that warrant surfacing to the operator without being asked.
+ACTIONABLE_RENEWAL_STATUSES: frozenset[str] = frozenset({
+    RENEWAL_STATUS_EXPIRING_SOON,
+    RENEWAL_STATUS_EXPIRED,
+})
+
+# Providers whose Texas service is a regulated monopoly, offered as UI hints so
+# the operator is not sent shopping for an alternative that does not exist.
+# Not enforced — an operator outside these markets can record any provider.
+REGULATED_TX_GAS_PROVIDERS: frozenset[str] = frozenset({
+    "centerpoint",
+    "atmos",
+    "texas gas service",
+})

--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -32,7 +32,7 @@ from app.db.session import AsyncSessionLocal
 from app.schemas.user.user import UserRead, UserCreate, UserUpdate
 from app.services.storage.bucket_initializer import ensure_bucket
 from app.workers.upload_processor_worker import main as worker_main
-from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_policies, lease_templates, listings, properties, public_inquiries, public_welcome_manuals, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, exports, imports, health_dashboard, totp, taxpayer_profiles, welcome_manuals
+from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_policies, lease_templates, listings, properties, public_inquiries, public_welcome_manuals, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, exports, imports, health_dashboard, totp, taxpayer_profiles, utility_plans, welcome_manuals
 
 logging.basicConfig(
     level=logging.INFO,
@@ -205,6 +205,7 @@ app.include_router(applicants.router)
 app.include_router(lease_templates.router)
 app.include_router(signed_leases.router)
 app.include_router(insurance_policies.router)
+app.include_router(utility_plans.router)
 app.include_router(screening.router)
 app.include_router(vendors.router)
 app.include_router(reply_templates.router)

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -10,6 +10,7 @@ from app.models.properties.activity_period import ActivityPeriod
 from app.models.properties.tenant import Tenant
 from app.models.properties.lease import Lease, LeaseStatus
 from app.models.properties.utility_account_link import UtilityAccountLink
+from app.models.properties.utility_plan import UtilityPlan
 from app.models.listings.listing import Listing
 from app.models.listings.listing_photo import ListingPhoto
 from app.models.listings.listing_external_id import ListingExternalId

--- a/apps/mybookkeeper/backend/app/models/properties/utility_plan.py
+++ b/apps/mybookkeeper/backend/app/models/properties/utility_plan.py
@@ -1,0 +1,209 @@
+"""ORM model for ``utility_plans`` — the contract behind a utility account.
+
+Sibling of ``utility_account_link``, which answers "which property does this
+provider account bill for?". This table answers the question that costs money:
+"what am I paying, under what terms, and when does the term end?"
+
+Rows are history, not state. A property accumulates one row per plan it has
+ever been on; the *current* plan for a (property, service_type) is the
+non-deleted row with the latest ``service_start_date``. There is deliberately
+no ``is_current`` column and no unique constraint forcing one row per
+(property, service_type) — the previous plan's rate is what a rate comparison
+is measured against, so discarding it would defeat the point. Deriving
+"current" instead of storing it keeps the two from drifting apart
+(``utility_plan_service.current_plan_ids``).
+
+Rate columns are ``Numeric``, not integer cents: a TDU charge of 5.3509 ¢/kWh
+carries four decimal places and integer cents cannot hold it. Flat money
+amounts (base charge, ETF, credits) stay ``BigInteger`` cents to match the rest
+of the schema.
+
+``account_number`` is stored in PLAINTEXT, matching ``utility_account_link``
+deliberately. That table must keep it plaintext — its lookup is an equality
+match and Fernet ciphertext is non-deterministic — so the same value is already
+recoverable from the same database. Encrypting only this copy would add
+ceremony without protecting anything, while making the two representations of
+one real-world identifier inconsistent. It is normalized (upper, spaces /
+dashes / dots stripped) identically to that table so the two can be joined.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    SmallInteger,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.utility_plan_constants import RATE_TYPES, SERVICE_TYPES
+from app.db.base import Base
+
+_SERVICE_TYPE_IN = ", ".join(f"'{v}'" for v in sorted(SERVICE_TYPES))
+_RATE_TYPE_IN = ", ".join(f"'{v}'" for v in sorted(RATE_TYPES))
+
+
+class UtilityPlan(Base):
+    __tablename__ = "utility_plans"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    # CASCADE: a deleted property's utility contracts are meaningless without it.
+    property_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("properties.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    service_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    provider_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Plaintext + normalized to match utility_account_link.account_number.
+    account_number: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    plan_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    rate_type: Mapped[str] = mapped_column(String(20), nullable=False)
+
+    # ---- Price components -------------------------------------------------
+    # Supplier's own charge. Null for regulated service where the operator only
+    # ever sees a single blended number.
+    energy_charge_cents_per_kwh: Mapped[Decimal | None] = mapped_column(
+        Numeric(9, 4), nullable=True,
+    )
+    # Wires charge from the delivery utility (TDU/TDSP). Passed through
+    # unchanged whichever supplier is chosen, so it is NOT part of what
+    # shopping can improve — recorded separately for exactly that reason.
+    tdu_charge_cents_per_kwh: Mapped[Decimal | None] = mapped_column(
+        Numeric(9, 4), nullable=True,
+    )
+    # The all-in average at 1,000 kWh that providers advertise. Stored as
+    # given rather than recomputed: it is the number on the EFL, and it is the
+    # only figure directly comparable to a competitor's headline rate.
+    avg_price_cents_per_kwh_at_1000: Mapped[Decimal | None] = mapped_column(
+        Numeric(9, 4), nullable=True,
+    )
+    monthly_base_charge_cents: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True,
+    )
+
+    # ---- Term -------------------------------------------------------------
+    term_months: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    service_start_date: Mapped[_dt.date | None] = mapped_column(Date, nullable=True)
+    # The renewal cliff. Null means open-ended (month-to-month or regulated).
+    term_end_date: Mapped[_dt.date | None] = mapped_column(Date, nullable=True)
+    early_termination_fee_cents: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True,
+    )
+
+    # ---- Usage-shaped pricing traps ---------------------------------------
+    # A bill-credit plan advertises a low ¢/kWh that only materializes at or
+    # above a usage threshold, so its real cost depends on the property's usage
+    # distribution rather than on the headline rate. Recording the shape is
+    # what lets a comparison be honest about months below the threshold.
+    has_bill_credit: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false"),
+    )
+    bill_credit_amount_cents: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True,
+    )
+    bill_credit_threshold_kwh: Mapped[int | None] = mapped_column(
+        Integer, nullable=True,
+    )
+    # The mirror image: a penalty applied below a usage floor.
+    min_usage_fee_cents: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    min_usage_threshold_kwh: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    deleted_at: Mapped[_dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    created_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        onupdate=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            f"service_type IN ({_SERVICE_TYPE_IN})",
+            name="chk_utility_plan_service_type",
+        ),
+        CheckConstraint(
+            f"rate_type IN ({_RATE_TYPE_IN})",
+            name="chk_utility_plan_rate_type",
+        ),
+        CheckConstraint(
+            "length(provider_name) > 0",
+            name="chk_utility_plan_provider_nonempty",
+        ),
+        # A term cannot end before it starts. Cheap to enforce, and a reversed
+        # pair would silently make the plan look permanently expired.
+        CheckConstraint(
+            "service_start_date IS NULL"
+            " OR term_end_date IS NULL"
+            " OR term_end_date >= service_start_date",
+            name="chk_utility_plan_term_order",
+        ),
+        # A bill credit is meaningless without both its amount and the
+        # threshold that unlocks it; storing one without the other would make
+        # any cost comparison quietly wrong.
+        CheckConstraint(
+            "has_bill_credit IS FALSE"
+            " OR (bill_credit_amount_cents IS NOT NULL"
+            " AND bill_credit_threshold_kwh IS NOT NULL)",
+            name="chk_utility_plan_bill_credit_complete",
+        ),
+        # Current-plan resolution: newest start per property + service.
+        Index(
+            "ix_utility_plans_property_service_start_active",
+            "property_id", "service_type", "service_start_date",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        # Expiring-soon sweep, per org and across orgs (worker).
+        Index(
+            "ix_utility_plans_org_term_end_active",
+            "organization_id", "term_end_date",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        Index(
+            "ix_utility_plans_term_end_active",
+            "term_end_date",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/repositories/__init__.py
+++ b/apps/mybookkeeper/backend/app/repositories/__init__.py
@@ -33,6 +33,7 @@ from app.repositories.properties import property_repo
 from app.repositories.properties import tenant_repo
 from app.repositories.properties import lease_repo
 from app.repositories.properties import utility_account_link_repo
+from app.repositories.properties import utility_plan_repo
 from app.repositories.listings import listing_repo
 from app.repositories.listings import listing_photo_repo
 from app.repositories.listings import listing_external_id_repo

--- a/apps/mybookkeeper/backend/app/repositories/properties/utility_plan_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/properties/utility_plan_repo.py
@@ -1,0 +1,300 @@
+"""Repository for ``utility_plans``.
+
+Queries stay portable across PostgreSQL (production) and SQLite (tests), so
+``DISTINCT ON`` and window functions are avoided. Selecting the *current* plan
+per (property, service_type) is ordering + a small in-memory reduction in the
+service layer rather than SQL — at the scale of one row per utility per
+property, the clarity is worth more than the round trip saved.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from typing import Any
+
+from sqlalchemy import Select, desc, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.properties.utility_plan import UtilityPlan
+
+
+def _scope(
+    stmt: Select,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    include_deleted: bool,
+) -> Select:
+    """Apply tenant isolation (and the soft-delete filter) to ``stmt``."""
+    stmt = stmt.where(
+        UtilityPlan.user_id == user_id,
+        UtilityPlan.organization_id == organization_id,
+    )
+    if not include_deleted:
+        stmt = stmt.where(UtilityPlan.deleted_at.is_(None))
+    return stmt
+
+
+def _apply_filters(
+    stmt: Select,
+    *,
+    property_id: uuid.UUID | None,
+    service_type: str | None,
+    expiring_before: _dt.date | None,
+) -> Select:
+    if property_id is not None:
+        stmt = stmt.where(UtilityPlan.property_id == property_id)
+    if service_type is not None:
+        stmt = stmt.where(UtilityPlan.service_type == service_type)
+    if expiring_before is not None:
+        stmt = stmt.where(
+            UtilityPlan.term_end_date.isnot(None),
+            UtilityPlan.term_end_date <= expiring_before,
+        )
+    return stmt
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    property_id: uuid.UUID,
+    service_type: str,
+    provider_name: str,
+    rate_type: str,
+    account_number: str | None = None,
+    plan_name: str | None = None,
+    energy_charge_cents_per_kwh: Any | None = None,
+    tdu_charge_cents_per_kwh: Any | None = None,
+    avg_price_cents_per_kwh_at_1000: Any | None = None,
+    monthly_base_charge_cents: int | None = None,
+    term_months: int | None = None,
+    service_start_date: _dt.date | None = None,
+    term_end_date: _dt.date | None = None,
+    early_termination_fee_cents: int | None = None,
+    has_bill_credit: bool = False,
+    bill_credit_amount_cents: int | None = None,
+    bill_credit_threshold_kwh: int | None = None,
+    min_usage_fee_cents: int | None = None,
+    min_usage_threshold_kwh: int | None = None,
+    notes: str | None = None,
+) -> UtilityPlan:
+    plan = UtilityPlan(
+        user_id=user_id,
+        organization_id=organization_id,
+        property_id=property_id,
+        service_type=service_type,
+        provider_name=provider_name,
+        rate_type=rate_type,
+        account_number=account_number,
+        plan_name=plan_name,
+        energy_charge_cents_per_kwh=energy_charge_cents_per_kwh,
+        tdu_charge_cents_per_kwh=tdu_charge_cents_per_kwh,
+        avg_price_cents_per_kwh_at_1000=avg_price_cents_per_kwh_at_1000,
+        monthly_base_charge_cents=monthly_base_charge_cents,
+        term_months=term_months,
+        service_start_date=service_start_date,
+        term_end_date=term_end_date,
+        early_termination_fee_cents=early_termination_fee_cents,
+        has_bill_credit=has_bill_credit,
+        bill_credit_amount_cents=bill_credit_amount_cents,
+        bill_credit_threshold_kwh=bill_credit_threshold_kwh,
+        min_usage_fee_cents=min_usage_fee_cents,
+        min_usage_threshold_kwh=min_usage_threshold_kwh,
+        notes=notes,
+    )
+    db.add(plan)
+    await db.flush()
+    return plan
+
+
+async def get(
+    db: AsyncSession,
+    *,
+    plan_id: uuid.UUID,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    include_deleted: bool = False,
+) -> UtilityPlan | None:
+    stmt = _scope(
+        select(UtilityPlan).where(UtilityPlan.id == plan_id),
+        user_id=user_id,
+        organization_id=organization_id,
+        include_deleted=include_deleted,
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_for_org(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    property_id: uuid.UUID | None = None,
+    service_type: str | None = None,
+    expiring_before: _dt.date | None = None,
+    include_deleted: bool = False,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[UtilityPlan]:
+    stmt = _apply_filters(
+        _scope(
+            select(UtilityPlan),
+            user_id=user_id,
+            organization_id=organization_id,
+            include_deleted=include_deleted,
+        ),
+        property_id=property_id,
+        service_type=service_type,
+        expiring_before=expiring_before,
+    )
+    # Newest term first so the current plan for each property leads its group;
+    # created_at breaks ties for rows entered without a start date.
+    stmt = (
+        stmt.order_by(
+            desc(UtilityPlan.service_start_date),
+            desc(UtilityPlan.created_at),
+        )
+        .limit(limit)
+        .offset(offset)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def count_for_org(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    property_id: uuid.UUID | None = None,
+    service_type: str | None = None,
+    expiring_before: _dt.date | None = None,
+    include_deleted: bool = False,
+) -> int:
+    stmt = _apply_filters(
+        _scope(
+            select(func.count()).select_from(UtilityPlan),
+            user_id=user_id,
+            organization_id=organization_id,
+            include_deleted=include_deleted,
+        ),
+        property_id=property_id,
+        service_type=service_type,
+        expiring_before=expiring_before,
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar_one())
+
+
+async def list_all_active_for_org(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+) -> list[UtilityPlan]:
+    """Every non-deleted plan for the org, newest term first.
+
+    Unpaginated on purpose: the caller reduces this to one current plan per
+    (property, service_type), which is only correct over the complete set. An
+    org tracks a handful of utilities per property, so the result stays small.
+    """
+    stmt = _scope(
+        select(UtilityPlan),
+        user_id=user_id,
+        organization_id=organization_id,
+        include_deleted=False,
+    ).order_by(
+        UtilityPlan.property_id,
+        UtilityPlan.service_type,
+        desc(UtilityPlan.service_start_date),
+        desc(UtilityPlan.created_at),
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def list_active_for_expiring_properties(
+    db: AsyncSession,
+    *,
+    cutoff: _dt.date,
+) -> list[UtilityPlan]:
+    """Every active plan belonging to a property with a term ending by ``cutoff``.
+
+    Deliberately NOT tenant-scoped — the scheduler sweeps across every user,
+    the same way ``signed_lease_repo`` does for lease auto-end.
+
+    The result is widened from "rows that expire" to "all rows of the affected
+    properties" because a plan only warrants an alert if it is the *current*
+    one, and currency can only be decided against a property's full set. The
+    subquery keeps that widening bounded to properties that have something
+    lapsing rather than scanning the whole table.
+    """
+    affected = (
+        select(UtilityPlan.property_id)
+        .where(
+            UtilityPlan.deleted_at.is_(None),
+            UtilityPlan.term_end_date.isnot(None),
+            UtilityPlan.term_end_date <= cutoff,
+        )
+        .scalar_subquery()
+    )
+    stmt = (
+        select(UtilityPlan)
+        .where(
+            UtilityPlan.deleted_at.is_(None),
+            UtilityPlan.property_id.in_(affected),
+        )
+        .order_by(
+            UtilityPlan.property_id,
+            UtilityPlan.service_type,
+            desc(UtilityPlan.service_start_date),
+            desc(UtilityPlan.created_at),
+        )
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def update_plan(
+    db: AsyncSession,
+    *,
+    plan_id: uuid.UUID,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> UtilityPlan | None:
+    plan = await get(
+        db,
+        plan_id=plan_id,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
+    if plan is None:
+        return None
+    for key, value in fields.items():
+        setattr(plan, key, value)
+    await db.flush()
+    return plan
+
+
+async def soft_delete(
+    db: AsyncSession,
+    *,
+    plan_id: uuid.UUID,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+) -> bool:
+    result = await db.execute(
+        update(UtilityPlan)
+        .where(
+            UtilityPlan.id == plan_id,
+            UtilityPlan.user_id == user_id,
+            UtilityPlan.organization_id == organization_id,
+            UtilityPlan.deleted_at.is_(None),
+        )
+        .values(deleted_at=_dt.datetime.now(_dt.timezone.utc))
+    )
+    return (result.rowcount or 0) > 0

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_create_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_create_request.py
@@ -1,0 +1,52 @@
+"""Schema for POST /utility-plans."""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.schemas.properties.utility_plan_validation import (
+    MAX_RATE_CENTS,
+    validate_plan_fields,
+)
+
+
+class UtilityPlanCreateRequest(BaseModel):
+    property_id: uuid.UUID
+    service_type: str
+    provider_name: str = Field(..., min_length=1, max_length=255)
+    rate_type: str
+    account_number: str | None = Field(None, max_length=100)
+    plan_name: str | None = Field(None, max_length=255)
+
+    energy_charge_cents_per_kwh: Decimal | None = Field(
+        None, ge=0, le=MAX_RATE_CENTS, decimal_places=4,
+    )
+    tdu_charge_cents_per_kwh: Decimal | None = Field(
+        None, ge=0, le=MAX_RATE_CENTS, decimal_places=4,
+    )
+    avg_price_cents_per_kwh_at_1000: Decimal | None = Field(
+        None, ge=0, le=MAX_RATE_CENTS, decimal_places=4,
+    )
+    monthly_base_charge_cents: int | None = Field(None, ge=0)
+
+    term_months: int | None = Field(None, ge=0, le=600)
+    service_start_date: _dt.date | None = None
+    term_end_date: _dt.date | None = None
+    early_termination_fee_cents: int | None = Field(None, ge=0)
+
+    has_bill_credit: bool = False
+    bill_credit_amount_cents: int | None = Field(None, ge=0)
+    bill_credit_threshold_kwh: int | None = Field(None, ge=0)
+    min_usage_fee_cents: int | None = Field(None, ge=0)
+    min_usage_threshold_kwh: int | None = Field(None, ge=0)
+
+    notes: str | None = Field(None, max_length=5000)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _check_fields(self) -> UtilityPlanCreateRequest:
+        return validate_plan_fields(self)

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_list_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_list_response.py
@@ -1,0 +1,10 @@
+"""Paginated list response for utility plans."""
+from __future__ import annotations
+
+from platform_shared.schemas.pagination import ListResponse
+
+from app.schemas.properties.utility_plan_summary import UtilityPlanSummary
+
+
+class UtilityPlanListResponse(ListResponse[UtilityPlanSummary]):
+    pass

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_renewal_alert_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_renewal_alert_response.py
@@ -1,0 +1,22 @@
+"""Dashboard payload for utility plans needing attention.
+
+Only *current* plans appear — a superseded plan whose term lapsed years ago is
+history, not an alert. ``expired`` is listed ahead of ``expiring_soon``
+because an expired term means money is already leaking.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.properties.utility_plan_summary import UtilityPlanSummary
+
+
+class UtilityPlanRenewalAlertResponse(BaseModel):
+    # Lead time used to build this payload, so the UI can say "in the next N
+    # days" without hardcoding a number the backend owns.
+    window_days: int
+    expired: list[UtilityPlanSummary]
+    expiring_soon: list[UtilityPlanSummary]
+    total_needing_attention: int
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_response.py
@@ -1,0 +1,50 @@
+"""Schema for a single utility plan (detail view)."""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class UtilityPlanResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    organization_id: uuid.UUID
+    property_id: uuid.UUID
+    property_name: str | None = None
+
+    service_type: str
+    provider_name: str
+    account_number: str | None = None
+    plan_name: str | None = None
+    rate_type: str
+
+    energy_charge_cents_per_kwh: Decimal | None = None
+    tdu_charge_cents_per_kwh: Decimal | None = None
+    avg_price_cents_per_kwh_at_1000: Decimal | None = None
+    monthly_base_charge_cents: int | None = None
+
+    term_months: int | None = None
+    service_start_date: _dt.date | None = None
+    term_end_date: _dt.date | None = None
+    early_termination_fee_cents: int | None = None
+
+    has_bill_credit: bool
+    bill_credit_amount_cents: int | None = None
+    bill_credit_threshold_kwh: int | None = None
+    min_usage_fee_cents: int | None = None
+    min_usage_threshold_kwh: int | None = None
+
+    notes: str | None = None
+
+    # Derived — see utility_plan_service.
+    days_until_term_end: int | None = None
+    renewal_status: str
+    is_current: bool
+
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_summary.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_summary.py
@@ -1,0 +1,33 @@
+"""Summary row for the utility-plan list view.
+
+``property_name``, ``renewal_status`` and ``days_until_term_end`` are joined /
+derived by the service — they are not columns. See
+``utility_plan_service.renewal_status``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class UtilityPlanSummary(BaseModel):
+    id: uuid.UUID
+    property_id: uuid.UUID
+    property_name: str | None = None
+    service_type: str
+    provider_name: str
+    plan_name: str | None = None
+    rate_type: str
+    avg_price_cents_per_kwh_at_1000: Decimal | None = None
+    term_end_date: _dt.date | None = None
+    # Negative once the term has lapsed, which is the case worth seeing.
+    days_until_term_end: int | None = None
+    renewal_status: str
+    is_current: bool
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_update_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_update_request.py
@@ -1,0 +1,59 @@
+"""Schema for PATCH /utility-plans/{id}.
+
+``property_id`` is intentionally absent: moving a plan to a different property
+would silently rewrite the other property's rate history. Delete and re-create
+instead.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.schemas.properties.utility_plan_validation import (
+    MAX_RATE_CENTS,
+    validate_plan_fields,
+)
+
+
+class UtilityPlanUpdateRequest(BaseModel):
+    service_type: str | None = None
+    provider_name: str | None = Field(None, min_length=1, max_length=255)
+    rate_type: str | None = None
+    account_number: str | None = Field(None, max_length=100)
+    plan_name: str | None = Field(None, max_length=255)
+
+    energy_charge_cents_per_kwh: Decimal | None = Field(
+        None, ge=0, le=MAX_RATE_CENTS, decimal_places=4,
+    )
+    tdu_charge_cents_per_kwh: Decimal | None = Field(
+        None, ge=0, le=MAX_RATE_CENTS, decimal_places=4,
+    )
+    avg_price_cents_per_kwh_at_1000: Decimal | None = Field(
+        None, ge=0, le=MAX_RATE_CENTS, decimal_places=4,
+    )
+    monthly_base_charge_cents: int | None = Field(None, ge=0)
+
+    term_months: int | None = Field(None, ge=0, le=600)
+    service_start_date: _dt.date | None = None
+    term_end_date: _dt.date | None = None
+    early_termination_fee_cents: int | None = Field(None, ge=0)
+
+    has_bill_credit: bool | None = None
+    bill_credit_amount_cents: int | None = Field(None, ge=0)
+    bill_credit_threshold_kwh: int | None = Field(None, ge=0)
+    min_usage_fee_cents: int | None = Field(None, ge=0)
+    min_usage_threshold_kwh: int | None = Field(None, ge=0)
+
+    notes: str | None = Field(None, max_length=5000)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _check_fields(self) -> UtilityPlanUpdateRequest:
+        # Only the fields present in this payload are validated here. A partial
+        # update that leaves the row inconsistent with a field it did NOT send
+        # is caught by the table's CHECK constraints; the service re-validates
+        # the merged row before flushing so that surfaces as a 422 too.
+        return validate_plan_fields(self)

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_validation.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_validation.py
@@ -1,0 +1,56 @@
+"""Cross-field validation shared by the utility-plan create and update payloads.
+
+Mirrors the ``utility_plans`` CHECK constraints at the edge so a bad payload
+fails as a readable 422 instead of surfacing as a 500 from an IntegrityError
+deeper in the stack. The DB constraints remain the real guarantee — this is the
+error-message layer, not the enforcement layer.
+
+Only fields actually set on the model are inspected, so the partial (PATCH)
+payload reuses this unchanged.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TypeVar
+
+from app.core.utility_plan_constants import RATE_TYPES, SERVICE_TYPES
+
+# Rates are ¢/kWh with four decimals (a TDU charge of 5.3509 is a real value).
+# The ceiling is deliberately loose — it exists to catch a unit mix-up (dollars
+# entered where cents belong), not to police the market.
+MAX_RATE_CENTS = Decimal("999.9999")
+
+ModelT = TypeVar("ModelT")
+
+
+def validate_plan_fields(model: ModelT) -> ModelT:
+    """Raise ``ValueError`` if ``model``'s utility-plan fields are inconsistent."""
+    service_type = getattr(model, "service_type", None)
+    if service_type is not None and service_type not in SERVICE_TYPES:
+        raise ValueError(
+            f"service_type must be one of: {', '.join(sorted(SERVICE_TYPES))}",
+        )
+
+    rate_type = getattr(model, "rate_type", None)
+    if rate_type is not None and rate_type not in RATE_TYPES:
+        raise ValueError(
+            f"rate_type must be one of: {', '.join(sorted(RATE_TYPES))}",
+        )
+
+    start = getattr(model, "service_start_date", None)
+    end = getattr(model, "term_end_date", None)
+    if start is not None and end is not None and end < start:
+        raise ValueError("term_end_date must be on or after service_start_date")
+
+    # A credit without its threshold (or vice versa) would make any cost
+    # comparison quietly wrong, so an incomplete pair is rejected outright.
+    if getattr(model, "has_bill_credit", False) and (
+        getattr(model, "bill_credit_amount_cents", None) is None
+        or getattr(model, "bill_credit_threshold_kwh", None) is None
+    ):
+        raise ValueError(
+            "bill_credit_amount_cents and bill_credit_threshold_kwh are "
+            "required when has_bill_credit is true",
+        )
+
+    return model

--- a/apps/mybookkeeper/backend/app/services/properties/utility_plan_service.py
+++ b/apps/mybookkeeper/backend/app/services/properties/utility_plan_service.py
@@ -1,0 +1,503 @@
+"""Service layer for utility plans.
+
+Owns three pieces of logic that are deliberately *not* columns:
+
+``renewal_status`` / ``days_until_term_end``
+    Derived from ``rate_type`` + ``term_end_date`` + today. Storing a status
+    would mean a row silently becoming wrong the morning its term lapsed, with
+    nothing to correct it — the exact failure this feature exists to prevent.
+
+``is_current``
+    A property accumulates one row per plan it has ever been on. The current
+    plan for a (property, service_type) is the one with the latest
+    ``service_start_date``, ties broken by ``created_at``. Rows with no start
+    date sort last: an undated row is a stub, and a dated row is better
+    evidence of what is actually in force.
+
+Renewal alerts fire only on *current* plans whose ``rate_type`` can actually be
+renewed. A superseded plan is history, and a ``regulated`` plan (Houston
+natural gas, most municipal water) has no competing supplier to switch to —
+alerting on either would train the operator to ignore the badge.
+
+All data access is through repositories; this module never imports SQLAlchemy.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from typing import Any
+
+from app.core.utility_plan_constants import (
+    ACTIONABLE_RENEWAL_STATUSES,
+    EXPIRING_SOON_DAYS,
+    RATE_TYPE_REGULATED,
+    RENEWABLE_RATE_TYPES,
+    RENEWAL_STATUS_ACTIVE,
+    RENEWAL_STATUS_EXPIRED,
+    RENEWAL_STATUS_EXPIRING_SOON,
+    RENEWAL_STATUS_NOT_APPLICABLE,
+)
+from app.db.session import unit_of_work
+from app.repositories.properties import property_repo, utility_plan_repo
+from app.schemas.properties.utility_plan_list_response import UtilityPlanListResponse
+from app.schemas.properties.utility_plan_renewal_alert_response import (
+    UtilityPlanRenewalAlertResponse,
+)
+from app.schemas.properties.utility_plan_response import UtilityPlanResponse
+from app.schemas.properties.utility_plan_summary import UtilityPlanSummary
+from app.schemas.properties.utility_plan_validation import validate_plan_fields
+from app.services.extraction.utility_account_service import normalize_account_number
+
+
+class UtilityPlanNotFoundError(LookupError):
+    pass
+
+
+class InvalidUtilityPlanError(ValueError):
+    """A create/update would leave the row internally inconsistent."""
+
+
+# ---------------------------------------------------------------------------
+# Derived fields — pure functions, no I/O
+# ---------------------------------------------------------------------------
+
+def days_until_term_end(
+    term_end_date: _dt.date | None,
+    *,
+    today: _dt.date | None = None,
+) -> int | None:
+    """Whole days from ``today`` to ``term_end_date``; negative once lapsed."""
+    if term_end_date is None:
+        return None
+    reference = today or _dt.date.today()
+    return (term_end_date - reference).days
+
+
+def renewal_status(
+    rate_type: str,
+    term_end_date: _dt.date | None,
+    *,
+    today: _dt.date | None = None,
+    window_days: int = EXPIRING_SOON_DAYS,
+) -> str:
+    """Classify a plan's renewal urgency.
+
+    ``not_applicable`` covers both "no end date recorded" and "regulated
+    monopoly" — in neither case is there a deadline the operator can act on.
+    A ``variable`` plan with an end date is still classified normally: that is
+    what a lapsed fixed plan looks like once it has been recorded honestly, and
+    the operator still wants to see it.
+    """
+    if rate_type == RATE_TYPE_REGULATED or term_end_date is None:
+        return RENEWAL_STATUS_NOT_APPLICABLE
+
+    remaining = days_until_term_end(term_end_date, today=today)
+    if remaining is None:
+        return RENEWAL_STATUS_NOT_APPLICABLE
+    if remaining < 0:
+        return RENEWAL_STATUS_EXPIRED
+    if remaining <= window_days:
+        return RENEWAL_STATUS_EXPIRING_SOON
+    return RENEWAL_STATUS_ACTIVE
+
+
+def _currency_sort_key(plan: Any) -> tuple:
+    """Sort key selecting the most recently started plan first.
+
+    Undated rows sort last (``date.min``) — a stub with no start date should
+    never outrank a row that records when service actually began.
+    """
+    return (
+        plan.service_start_date or _dt.date.min,
+        plan.created_at,
+    )
+
+
+def current_plan_ids(plans: list[Any]) -> set[uuid.UUID]:
+    """IDs of the current plan for each (property_id, service_type) group."""
+    best: dict[tuple[uuid.UUID, str], Any] = {}
+    for plan in plans:
+        key = (plan.property_id, plan.service_type)
+        incumbent = best.get(key)
+        if incumbent is None or _currency_sort_key(plan) > _currency_sort_key(incumbent):
+            best[key] = plan
+    return {plan.id for plan in best.values()}
+
+
+# ---------------------------------------------------------------------------
+# Mapping
+# ---------------------------------------------------------------------------
+
+def _to_summary(
+    plan: Any,
+    *,
+    property_names: dict[uuid.UUID, str],
+    current_ids: set[uuid.UUID],
+    today: _dt.date | None = None,
+) -> UtilityPlanSummary:
+    return UtilityPlanSummary(
+        id=plan.id,
+        property_id=plan.property_id,
+        property_name=property_names.get(plan.property_id),
+        service_type=plan.service_type,
+        provider_name=plan.provider_name,
+        plan_name=plan.plan_name,
+        rate_type=plan.rate_type,
+        avg_price_cents_per_kwh_at_1000=plan.avg_price_cents_per_kwh_at_1000,
+        term_end_date=plan.term_end_date,
+        days_until_term_end=days_until_term_end(plan.term_end_date, today=today),
+        renewal_status=renewal_status(plan.rate_type, plan.term_end_date, today=today),
+        is_current=plan.id in current_ids,
+        created_at=plan.created_at,
+        updated_at=plan.updated_at,
+    )
+
+
+def _to_detail(
+    plan: Any,
+    *,
+    property_name: str | None,
+    is_current: bool,
+    today: _dt.date | None = None,
+) -> UtilityPlanResponse:
+    return UtilityPlanResponse(
+        id=plan.id,
+        user_id=plan.user_id,
+        organization_id=plan.organization_id,
+        property_id=plan.property_id,
+        property_name=property_name,
+        service_type=plan.service_type,
+        provider_name=plan.provider_name,
+        account_number=plan.account_number,
+        plan_name=plan.plan_name,
+        rate_type=plan.rate_type,
+        energy_charge_cents_per_kwh=plan.energy_charge_cents_per_kwh,
+        tdu_charge_cents_per_kwh=plan.tdu_charge_cents_per_kwh,
+        avg_price_cents_per_kwh_at_1000=plan.avg_price_cents_per_kwh_at_1000,
+        monthly_base_charge_cents=plan.monthly_base_charge_cents,
+        term_months=plan.term_months,
+        service_start_date=plan.service_start_date,
+        term_end_date=plan.term_end_date,
+        early_termination_fee_cents=plan.early_termination_fee_cents,
+        has_bill_credit=plan.has_bill_credit,
+        bill_credit_amount_cents=plan.bill_credit_amount_cents,
+        bill_credit_threshold_kwh=plan.bill_credit_threshold_kwh,
+        min_usage_fee_cents=plan.min_usage_fee_cents,
+        min_usage_threshold_kwh=plan.min_usage_threshold_kwh,
+        notes=plan.notes,
+        days_until_term_end=days_until_term_end(plan.term_end_date, today=today),
+        renewal_status=renewal_status(plan.rate_type, plan.term_end_date, today=today),
+        is_current=is_current,
+        created_at=plan.created_at,
+        updated_at=plan.updated_at,
+    )
+
+
+class _MergedPlan:
+    """Post-update field view, used to re-validate a PATCH before it flushes.
+
+    A partial update can violate a cross-field rule using a value it did not
+    send (setting ``term_end_date`` earlier than a stored ``service_start_date``,
+    say). Validating the merged result here turns that into a 422 instead of an
+    IntegrityError surfacing as a 500.
+    """
+
+    def __init__(self, plan: Any, fields: dict[str, Any]) -> None:
+        for name in (
+            "service_type",
+            "rate_type",
+            "service_start_date",
+            "term_end_date",
+            "has_bill_credit",
+            "bill_credit_amount_cents",
+            "bill_credit_threshold_kwh",
+        ):
+            setattr(self, name, fields.get(name, getattr(plan, name)))
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+async def create_plan(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> UtilityPlanResponse:
+    payload = dict(fields)
+    account_number = payload.get("account_number")
+    if account_number:
+        # Normalized identically to utility_account_link so the plan and the
+        # learned bill→property link describe the same account key.
+        payload["account_number"] = normalize_account_number(account_number)
+
+    async with unit_of_work() as db:
+        plan = await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=organization_id,
+            **payload,
+        )
+        names = await property_repo.get_name_map(db, organization_id)
+        siblings = await utility_plan_repo.list_all_active_for_org(
+            db, user_id=user_id, organization_id=organization_id,
+        )
+        current_ids = current_plan_ids(siblings)
+        detail = _to_detail(
+            plan,
+            property_name=names.get(plan.property_id),
+            is_current=plan.id in current_ids,
+        )
+    return detail
+
+
+# ---------------------------------------------------------------------------
+# List + get
+# ---------------------------------------------------------------------------
+
+async def list_plans(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    property_id: uuid.UUID | None = None,
+    service_type: str | None = None,
+    expiring_before: _dt.date | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> UtilityPlanListResponse:
+    async with unit_of_work() as db:
+        rows = await utility_plan_repo.list_for_org(
+            db,
+            user_id=user_id,
+            organization_id=organization_id,
+            property_id=property_id,
+            service_type=service_type,
+            expiring_before=expiring_before,
+            limit=limit,
+            offset=offset,
+        )
+        total = await utility_plan_repo.count_for_org(
+            db,
+            user_id=user_id,
+            organization_id=organization_id,
+            property_id=property_id,
+            service_type=service_type,
+            expiring_before=expiring_before,
+        )
+        names = await property_repo.get_name_map(db, organization_id)
+        # Currency is a property of the whole set, so it is resolved against
+        # every active plan rather than just this page.
+        all_active = await utility_plan_repo.list_all_active_for_org(
+            db, user_id=user_id, organization_id=organization_id,
+        )
+        current_ids = current_plan_ids(all_active)
+
+    items = [
+        _to_summary(r, property_names=names, current_ids=current_ids)
+        for r in rows
+    ]
+    return UtilityPlanListResponse(
+        items=items, total=total, has_more=(offset + len(items)) < total,
+    )
+
+
+async def get_plan(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    plan_id: uuid.UUID,
+) -> UtilityPlanResponse:
+    async with unit_of_work() as db:
+        plan = await utility_plan_repo.get(
+            db,
+            plan_id=plan_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if plan is None:
+            raise UtilityPlanNotFoundError(str(plan_id))
+        names = await property_repo.get_name_map(db, organization_id)
+        all_active = await utility_plan_repo.list_all_active_for_org(
+            db, user_id=user_id, organization_id=organization_id,
+        )
+        current_ids = current_plan_ids(all_active)
+        return _to_detail(
+            plan,
+            property_name=names.get(plan.property_id),
+            is_current=plan.id in current_ids,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Renewal alerts
+# ---------------------------------------------------------------------------
+
+async def get_renewal_alerts(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    window_days: int = EXPIRING_SOON_DAYS,
+    today: _dt.date | None = None,
+) -> UtilityPlanRenewalAlertResponse:
+    """Current, renewable plans whose term has lapsed or is about to."""
+    async with unit_of_work() as db:
+        all_active = await utility_plan_repo.list_all_active_for_org(
+            db, user_id=user_id, organization_id=organization_id,
+        )
+        names = await property_repo.get_name_map(db, organization_id)
+
+    current_ids = current_plan_ids(all_active)
+
+    expired: list[UtilityPlanSummary] = []
+    expiring_soon: list[UtilityPlanSummary] = []
+    for plan in all_active:
+        if plan.id not in current_ids:
+            continue
+        if plan.rate_type not in RENEWABLE_RATE_TYPES:
+            continue
+        status = renewal_status(
+            plan.rate_type,
+            plan.term_end_date,
+            today=today,
+            window_days=window_days,
+        )
+        if status not in ACTIONABLE_RENEWAL_STATUSES:
+            continue
+        summary = _to_summary(
+            plan,
+            property_names=names,
+            current_ids=current_ids,
+            today=today,
+        )
+        if status == RENEWAL_STATUS_EXPIRED:
+            expired.append(summary)
+        else:
+            expiring_soon.append(summary)
+
+    # Longest-lapsed first, then soonest-to-lapse: both orderings put the most
+    # urgent row at the top of its group.
+    expired.sort(key=lambda s: s.days_until_term_end or 0)
+    expiring_soon.sort(key=lambda s: s.days_until_term_end or 0)
+
+    return UtilityPlanRenewalAlertResponse(
+        window_days=window_days,
+        expired=expired,
+        expiring_soon=expiring_soon,
+        total_needing_attention=len(expired) + len(expiring_soon),
+    )
+
+
+async def sweep_plans_needing_renewal(
+    *,
+    today: _dt.date | None = None,
+    window_days: int = EXPIRING_SOON_DAYS,
+) -> list[UtilityPlanSummary]:
+    """Cross-tenant version of :func:`get_renewal_alerts`, for the scheduler.
+
+    Every other function here is tenant-scoped; this one is not, because the
+    scheduler runs on behalf of no one. It is not reachable from any route —
+    only ``workers.scheduler_worker`` calls it.
+
+    Ordered most urgent (longest lapsed) first.
+    """
+    reference = today or _dt.date.today()
+    cutoff = reference + _dt.timedelta(days=window_days)
+
+    async with unit_of_work() as db:
+        candidates = await utility_plan_repo.list_active_for_expiring_properties(
+            db, cutoff=cutoff,
+        )
+        names = await property_repo.get_labels_by_ids(
+            db, [p.property_id for p in candidates],
+        )
+
+    current_ids = current_plan_ids(candidates)
+
+    flagged = [
+        _to_summary(
+            plan, property_names=names, current_ids=current_ids, today=reference,
+        )
+        for plan in candidates
+        if plan.id in current_ids
+        and plan.rate_type in RENEWABLE_RATE_TYPES
+        and renewal_status(
+            plan.rate_type,
+            plan.term_end_date,
+            today=reference,
+            window_days=window_days,
+        )
+        in ACTIONABLE_RENEWAL_STATUSES
+    ]
+    flagged.sort(key=lambda s: s.days_until_term_end or 0)
+    return flagged
+
+
+# ---------------------------------------------------------------------------
+# Update + delete
+# ---------------------------------------------------------------------------
+
+async def update_plan(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    plan_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> UtilityPlanResponse:
+    payload = dict(fields)
+    account_number = payload.get("account_number")
+    if account_number:
+        payload["account_number"] = normalize_account_number(account_number)
+
+    async with unit_of_work() as db:
+        existing = await utility_plan_repo.get(
+            db,
+            plan_id=plan_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if existing is None:
+            raise UtilityPlanNotFoundError(str(plan_id))
+
+        try:
+            validate_plan_fields(_MergedPlan(existing, payload))
+        except ValueError as exc:
+            raise InvalidUtilityPlanError(str(exc)) from exc
+
+        plan = await utility_plan_repo.update_plan(
+            db,
+            plan_id=plan_id,
+            user_id=user_id,
+            organization_id=organization_id,
+            fields=payload,
+        )
+        if plan is None:
+            raise UtilityPlanNotFoundError(str(plan_id))
+
+        names = await property_repo.get_name_map(db, organization_id)
+        all_active = await utility_plan_repo.list_all_active_for_org(
+            db, user_id=user_id, organization_id=organization_id,
+        )
+        current_ids = current_plan_ids(all_active)
+        return _to_detail(
+            plan,
+            property_name=names.get(plan.property_id),
+            is_current=plan.id in current_ids,
+        )
+
+
+async def soft_delete_plan(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    plan_id: uuid.UUID,
+) -> None:
+    async with unit_of_work() as db:
+        deleted = await utility_plan_repo.soft_delete(
+            db,
+            plan_id=plan_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+    if not deleted:
+        raise UtilityPlanNotFoundError(str(plan_id))

--- a/apps/mybookkeeper/backend/app/workers/scheduler_worker.py
+++ b/apps/mybookkeeper/backend/app/workers/scheduler_worker.py
@@ -20,6 +20,7 @@ from app.db.session import AsyncSessionLocal, unit_of_work
 from app.repositories import integration_repo
 from app.repositories.leases import signed_lease_repo
 from app.services.listings.channel_sync_service import poll_all as poll_all_channels
+from app.services.properties import utility_plan_service
 from app.workers.email_sync_worker import sync_gmail_for_user
 
 logger = logging.getLogger(__name__)
@@ -91,6 +92,37 @@ async def auto_end_replaced_leases() -> int:
     return transitioned
 
 
+async def flag_expiring_utility_plans() -> int:
+    """Log every current utility plan whose fixed term has lapsed or is about to.
+
+    Read-only — it changes no rows. The dashboard card is the operator-facing
+    surface; this exists so the same condition is visible server-side (journald
+    / Sentry) without anyone having to open the app, which is precisely the
+    failure mode a silently-lapsed rate plan exploits.
+
+    Returns the number of plans flagged. Never raises: a failure here must not
+    stop the Gmail or lease steps in the same cycle.
+    """
+    try:
+        flagged = await utility_plan_service.sweep_plans_needing_renewal()
+    except Exception:
+        logger.exception("flag_expiring_utility_plans cycle failed")
+        return 0
+
+    for plan in flagged:
+        logger.warning(
+            "Utility plan needs renewal: property=%s provider=%s service=%s "
+            "term_end=%s days_remaining=%s status=%s",
+            plan.property_name,
+            plan.provider_name,
+            plan.service_type,
+            plan.term_end_date,
+            plan.days_until_term_end,
+            plan.renewal_status,
+        )
+    return len(flagged)
+
+
 async def run_sync_cycle() -> None:
     """Run one full sync cycle for all integration types."""
     gmail_user_ids = await get_gmail_user_ids()
@@ -100,6 +132,7 @@ async def run_sync_cycle() -> None:
 
     await sync_all_channel_calendars()
     await auto_end_replaced_leases()
+    await flag_expiring_utility_plans()
 
 
 def run() -> None:

--- a/apps/mybookkeeper/backend/tests/test_utility_plan_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_plan_repo.py
@@ -1,0 +1,438 @@
+"""Repository tests for ``utility_plans``.
+
+Focus is on the two invariants every query in this module must hold — tenant
+scoping and soft-delete filtering — plus the filters and ordering the list
+endpoint depends on. ``list_all_active_for_org`` is unpaginated on purpose
+(current-plan resolution is only correct over the complete set), so it gets its
+own coverage rather than being assumed to behave like ``list_for_org``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.utility_plan_constants import (
+    RATE_TYPE_FIXED,
+    RATE_TYPE_REGULATED,
+    SERVICE_TYPE_ELECTRICITY,
+    SERVICE_TYPE_NATURAL_GAS,
+)
+from app.models.properties.property import Property
+from app.repositories.properties import utility_plan_repo
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_property(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    name: str = "6732 Peerless St",
+) -> Property:
+    prop = Property(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        name=name,
+        address=name,
+    )
+    db.add(prop)
+    await db.flush()
+    return prop
+
+
+async def _make_plan(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    property_id: uuid.UUID,
+    service_type: str = SERVICE_TYPE_ELECTRICITY,
+    provider_name: str = "Constellation",
+    rate_type: str = RATE_TYPE_FIXED,
+    **kwargs: object,
+):
+    return await utility_plan_repo.create(
+        db,
+        user_id=user_id,
+        organization_id=org_id,
+        property_id=property_id,
+        service_type=service_type,
+        provider_name=provider_name,
+        rate_type=rate_type,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+class TestCreateAndGet:
+    async def test_round_trips_all_rate_precision(self, db: AsyncSession) -> None:
+        """A TDU charge of 5.3509 ¢/kWh must survive the round trip intact."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        plan = await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            energy_charge_cents_per_kwh=Decimal("11.6000"),
+            tdu_charge_cents_per_kwh=Decimal("5.3509"),
+        )
+        # Refresh forces a read back out of the database rather than reading
+        # the value still sitting in the identity map.
+        await db.refresh(plan)
+
+        assert Decimal(str(plan.tdu_charge_cents_per_kwh)) == Decimal("5.3509")
+        assert Decimal(str(plan.energy_charge_cents_per_kwh)) == Decimal("11.6")
+
+    async def test_get_is_scoped_to_the_owning_org(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        plan = await _make_plan(
+            db, org_id=org_id, user_id=user_id, property_id=prop.id,
+        )
+
+        assert (
+            await utility_plan_repo.get(
+                db,
+                plan_id=plan.id,
+                user_id=user_id,
+                organization_id=uuid.uuid4(),
+            )
+            is None
+        )
+
+    async def test_get_is_scoped_to_the_owning_user(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        plan = await _make_plan(
+            db, org_id=org_id, user_id=user_id, property_id=prop.id,
+        )
+
+        assert (
+            await utility_plan_repo.get(
+                db,
+                plan_id=plan.id,
+                user_id=uuid.uuid4(),
+                organization_id=org_id,
+            )
+            is None
+        )
+
+
+class TestListAndCount:
+    async def test_filters_by_property(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        a = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        b = await _make_property(db, org_id, user_id, "6734 Peerless St")
+        await _make_plan(db, org_id=org_id, user_id=user_id, property_id=a.id)
+        await _make_plan(db, org_id=org_id, user_id=user_id, property_id=b.id)
+
+        rows = await utility_plan_repo.list_for_org(
+            db, user_id=user_id, organization_id=org_id, property_id=a.id,
+        )
+        assert [r.property_id for r in rows] == [a.id]
+        assert (
+            await utility_plan_repo.count_for_org(
+                db, user_id=user_id, organization_id=org_id, property_id=a.id,
+            )
+            == 1
+        )
+
+    async def test_filters_by_service_type(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        await _make_plan(db, org_id=org_id, user_id=user_id, property_id=prop.id)
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_NATURAL_GAS,
+            provider_name="CenterPoint",
+            rate_type=RATE_TYPE_REGULATED,
+        )
+
+        rows = await utility_plan_repo.list_for_org(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            service_type=SERVICE_TYPE_NATURAL_GAS,
+        )
+        assert [r.provider_name for r in rows] == ["CenterPoint"]
+
+    async def test_expiring_before_excludes_open_ended_plans(
+        self, db: AsyncSession,
+    ) -> None:
+        """A null term_end_date is "no deadline", not "deadline in the past"."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            provider_name="Open Ended",
+            term_end_date=None,
+        )
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            provider_name="Lapsing",
+            term_end_date=_dt.date(2026, 1, 27),
+        )
+
+        rows = await utility_plan_repo.list_for_org(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            expiring_before=_dt.date(2026, 9, 1),
+        )
+        assert [r.provider_name for r in rows] == ["Lapsing"]
+
+    async def test_orders_newest_service_start_first(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            provider_name="Older",
+            service_start_date=_dt.date(2024, 1, 1),
+        )
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            provider_name="Newer",
+            service_start_date=_dt.date(2025, 1, 23),
+        )
+
+        rows = await utility_plan_repo.list_for_org(
+            db, user_id=user_id, organization_id=org_id,
+        )
+        assert [r.provider_name for r in rows] == ["Newer", "Older"]
+
+    async def test_pagination_slices_without_changing_the_total(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        for day in range(1, 4):
+            await _make_plan(
+                db,
+                org_id=org_id,
+                user_id=user_id,
+                property_id=prop.id,
+                service_start_date=_dt.date(2025, 1, day),
+            )
+
+        page = await utility_plan_repo.list_for_org(
+            db, user_id=user_id, organization_id=org_id, limit=2, offset=1,
+        )
+        assert len(page) == 2
+        assert (
+            await utility_plan_repo.count_for_org(
+                db, user_id=user_id, organization_id=org_id,
+            )
+            == 3
+        )
+
+    async def test_another_orgs_rows_are_never_listed(
+        self, db: AsyncSession,
+    ) -> None:
+        mine_org, mine_user = uuid.uuid4(), uuid.uuid4()
+        other_org, other_user = uuid.uuid4(), uuid.uuid4()
+        other_prop = await _make_property(db, other_org, other_user, "Not Mine St")
+        await _make_plan(
+            db,
+            org_id=other_org,
+            user_id=other_user,
+            property_id=other_prop.id,
+        )
+
+        assert (
+            await utility_plan_repo.list_for_org(
+                db, user_id=mine_user, organization_id=mine_org,
+            )
+            == []
+        )
+        assert (
+            await utility_plan_repo.count_for_org(
+                db, user_id=mine_user, organization_id=mine_org,
+            )
+            == 0
+        )
+
+
+class TestListAllActive:
+    async def test_returns_every_row_regardless_of_page_size(
+        self, db: AsyncSession,
+    ) -> None:
+        """Unpaginated by contract — current-plan resolution needs the full set."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        for day in range(1, 8):
+            await _make_plan(
+                db,
+                org_id=org_id,
+                user_id=user_id,
+                property_id=prop.id,
+                service_start_date=_dt.date(2025, 1, day),
+            )
+
+        rows = await utility_plan_repo.list_all_active_for_org(
+            db, user_id=user_id, organization_id=org_id,
+        )
+        assert len(rows) == 7
+
+    async def test_excludes_soft_deleted_rows(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        kept = await _make_plan(
+            db, org_id=org_id, user_id=user_id, property_id=prop.id,
+            provider_name="Kept",
+        )
+        gone = await _make_plan(
+            db, org_id=org_id, user_id=user_id, property_id=prop.id,
+            provider_name="Gone",
+        )
+        await utility_plan_repo.soft_delete(
+            db, plan_id=gone.id, user_id=user_id, organization_id=org_id,
+        )
+
+        rows = await utility_plan_repo.list_all_active_for_org(
+            db, user_id=user_id, organization_id=org_id,
+        )
+        assert [r.id for r in rows] == [kept.id]
+
+
+class TestUpdate:
+    async def test_applies_only_the_supplied_fields(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        plan = await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            plan_name="Original",
+            term_months=12,
+        )
+
+        updated = await utility_plan_repo.update_plan(
+            db,
+            plan_id=plan.id,
+            user_id=user_id,
+            organization_id=org_id,
+            fields={"plan_name": "Renewed"},
+        )
+        assert updated is not None
+        assert updated.plan_name == "Renewed"
+        assert updated.term_months == 12
+
+    async def test_returns_none_for_another_orgs_row(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        plan = await _make_plan(
+            db, org_id=org_id, user_id=user_id, property_id=prop.id,
+        )
+
+        assert (
+            await utility_plan_repo.update_plan(
+                db,
+                plan_id=plan.id,
+                user_id=user_id,
+                organization_id=uuid.uuid4(),
+                fields={"plan_name": "Hijacked"},
+            )
+            is None
+        )
+
+
+class TestSoftDelete:
+    async def test_hides_the_row_from_subsequent_reads(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        plan = await _make_plan(
+            db, org_id=org_id, user_id=user_id, property_id=prop.id,
+        )
+
+        assert (
+            await utility_plan_repo.soft_delete(
+                db, plan_id=plan.id, user_id=user_id, organization_id=org_id,
+            )
+            is True
+        )
+        assert (
+            await utility_plan_repo.get(
+                db, plan_id=plan.id, user_id=user_id, organization_id=org_id,
+            )
+            is None
+        )
+
+    async def test_row_is_retained_and_readable_with_include_deleted(
+        self, db: AsyncSession,
+    ) -> None:
+        """Soft delete, not a hard one — the rate history survives."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        plan = await _make_plan(
+            db, org_id=org_id, user_id=user_id, property_id=prop.id,
+        )
+        await utility_plan_repo.soft_delete(
+            db, plan_id=plan.id, user_id=user_id, organization_id=org_id,
+        )
+
+        found = await utility_plan_repo.get(
+            db,
+            plan_id=plan.id,
+            user_id=user_id,
+            organization_id=org_id,
+            include_deleted=True,
+        )
+        assert found is not None
+        assert found.deleted_at is not None
+
+    async def test_second_delete_is_a_no_op(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        plan = await _make_plan(
+            db, org_id=org_id, user_id=user_id, property_id=prop.id,
+        )
+        await utility_plan_repo.soft_delete(
+            db, plan_id=plan.id, user_id=user_id, organization_id=org_id,
+        )
+
+        assert (
+            await utility_plan_repo.soft_delete(
+                db, plan_id=plan.id, user_id=user_id, organization_id=org_id,
+            )
+            is False
+        )
+
+    async def test_cannot_delete_another_orgs_row(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        plan = await _make_plan(
+            db, org_id=org_id, user_id=user_id, property_id=prop.id,
+        )
+
+        assert (
+            await utility_plan_repo.soft_delete(
+                db,
+                plan_id=plan.id,
+                user_id=user_id,
+                organization_id=uuid.uuid4(),
+            )
+            is False
+        )

--- a/apps/mybookkeeper/backend/tests/test_utility_plan_scheduler.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_plan_scheduler.py
@@ -1,0 +1,100 @@
+"""Tests for the expiring-utility-plan scheduler task.
+
+The task is read-only: it logs every current plan whose fixed term has lapsed
+or is about to, so the condition is visible server-side without anyone opening
+the dashboard. What matters here is that it emits at WARNING (so it reaches
+journald / Sentry) and that a failure inside it can never abort the cycle that
+also runs the Gmail and lease steps.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.utility_plan_constants import (
+    RATE_TYPE_FIXED,
+    SERVICE_TYPE_ELECTRICITY,
+)
+from app.models.properties.property import Property
+from app.repositories.properties import utility_plan_repo
+from app.workers.scheduler_worker import flag_expiring_utility_plans
+
+_UOW_TARGET = "app.services.properties.utility_plan_service.unit_of_work"
+
+
+def _fake_uow_for(session: AsyncSession):
+    @asynccontextmanager
+    async def _uow():
+        yield session
+    return _uow
+
+
+async def _seed_expired_plan(db: AsyncSession, name: str) -> None:
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = Property(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        name=name,
+        address=name,
+    )
+    db.add(prop)
+    await db.flush()
+    await utility_plan_repo.create(
+        db,
+        user_id=user_id,
+        organization_id=org_id,
+        property_id=prop.id,
+        service_type=SERVICE_TYPE_ELECTRICITY,
+        provider_name="Constellation",
+        rate_type=RATE_TYPE_FIXED,
+        service_start_date=_dt.date(2025, 1, 27),
+        term_end_date=_dt.date(2026, 1, 27),
+    )
+
+
+@pytest.mark.asyncio
+async def test_logs_a_warning_per_flagged_plan(
+    db: AsyncSession, caplog: pytest.LogCaptureFixture,
+) -> None:
+    await _seed_expired_plan(db, "6738 Peerless St")
+
+    with patch(_UOW_TARGET, _fake_uow_for(db)), caplog.at_level(
+        logging.WARNING, logger="app.workers.scheduler_worker",
+    ):
+        count = await flag_expiring_utility_plans()
+
+    assert count == 1
+    assert "6738 Peerless St" in caplog.text
+    assert "Constellation" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_quiet_when_nothing_needs_renewal(
+    db: AsyncSession, caplog: pytest.LogCaptureFixture,
+) -> None:
+    with patch(_UOW_TARGET, _fake_uow_for(db)), caplog.at_level(
+        logging.WARNING, logger="app.workers.scheduler_worker",
+    ):
+        count = await flag_expiring_utility_plans()
+
+    assert count == 0
+    assert caplog.text == ""
+
+
+@pytest.mark.asyncio
+async def test_a_failure_does_not_abort_the_cycle() -> None:
+    """A DB outage here must not take the Gmail and lease steps down with it."""
+    with patch(
+        "app.workers.scheduler_worker.utility_plan_service."
+        "sweep_plans_needing_renewal",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("database is on fire"),
+    ):
+        assert await flag_expiring_utility_plans() == 0

--- a/apps/mybookkeeper/backend/tests/test_utility_plan_seed.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_plan_seed.py
@@ -1,0 +1,173 @@
+"""Tests for the Peerless utility-plan seed data and its parameter mapping.
+
+The seed rows are hand-transcribed from provider email, so the risk they carry
+is a typo that the database would reject at INSERT time — after the operator
+has already run the command against production. These assertions move each
+CHECK constraint's failure to the test suite, and pin the two figures the seed
+deliberately leaves unknown so a future edit cannot quietly invent them.
+"""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.cli.migrate_data import _plan_params
+from app.cli.peerless_utility_plan_seed import PEERLESS_UTILITY_PLANS
+from app.cli.utility_plan_seed_row import UtilityPlanSeedRow
+from app.core.utility_plan_constants import (
+    RATE_TYPE_FIXED,
+    RATE_TYPE_REGULATED,
+    RATE_TYPES,
+    SERVICE_TYPE_ELECTRICITY,
+    SERVICE_TYPE_NATURAL_GAS,
+    SERVICE_TYPES,
+)
+
+
+def _row(match: str, service_type: str) -> UtilityPlanSeedRow:
+    for row in PEERLESS_UTILITY_PLANS:
+        if row.property_match == match and row.service_type == service_type:
+            return row
+    raise AssertionError(f"no seed row for {match} / {service_type}")
+
+
+class TestSeedRowsSatisfyTheSchema:
+    """Every constraint on ``utility_plans`` that the seed data could violate."""
+
+    @pytest.mark.parametrize("row", PEERLESS_UTILITY_PLANS, ids=lambda r: r.property_match)
+    def test_service_and_rate_types_are_known_values(self, row: UtilityPlanSeedRow) -> None:
+        assert row.service_type in SERVICE_TYPES
+        assert row.rate_type in RATE_TYPES
+
+    @pytest.mark.parametrize("row", PEERLESS_UTILITY_PLANS, ids=lambda r: r.property_match)
+    def test_provider_name_is_not_empty(self, row: UtilityPlanSeedRow) -> None:
+        assert row.provider_name.strip()
+
+    @pytest.mark.parametrize("row", PEERLESS_UTILITY_PLANS, ids=lambda r: r.property_match)
+    def test_a_term_never_ends_before_it_starts(self, row: UtilityPlanSeedRow) -> None:
+        if row.service_start_date is None or row.term_end_date is None:
+            return
+        assert row.term_end_date >= row.service_start_date
+
+    def test_no_two_rows_share_a_property_service_and_provider(self) -> None:
+        """Duplicates would collide on the seeder's own idempotency check."""
+        keys = [
+            (r.property_match, r.service_type, r.provider_name, r.service_start_date)
+            for r in PEERLESS_UTILITY_PLANS
+        ]
+        assert len(keys) == len(set(keys))
+
+
+class TestElectricPlans:
+    def test_all_three_properties_have_a_lapsed_fixed_term(self) -> None:
+        electric = [r for r in PEERLESS_UTILITY_PLANS if r.service_type == SERVICE_TYPE_ELECTRICITY]
+
+        assert {r.property_match for r in electric} == {
+            "6732 Peerless", "6734 Peerless", "6738 Peerless",
+        }
+        for row in electric:
+            assert row.rate_type == RATE_TYPE_FIXED
+            assert row.term_months == 12
+            # Term end is start + 12 months; both dates are in the past, which
+            # is what makes the renewal alert fire the moment the seed lands.
+            assert row.term_end_date is not None
+            assert row.term_end_date.year == row.service_start_date.year + 1
+            assert (row.term_end_date.month, row.term_end_date.day) == (
+                row.service_start_date.month, row.service_start_date.day,
+            )
+
+    def test_rates_match_the_enrollment_emails(self) -> None:
+        row = _row("6734 Peerless", SERVICE_TYPE_ELECTRICITY)
+
+        assert row.energy_charge_cents_per_kwh == Decimal("11.6000")
+        # Four decimal places — the reason the column is Numeric, not cents.
+        assert row.tdu_charge_cents_per_kwh == Decimal("5.3509")
+        assert row.avg_price_cents_per_kwh_at_1000 == Decimal("13.9000")
+        assert row.monthly_base_charge_cents == 439
+        assert row.early_termination_fee_cents == 15_000
+        # The EFL states the fee as 0.00000 below 999 kWh — the shape exists,
+        # the penalty does not. Zero is a recorded fact, not a missing value.
+        assert row.min_usage_fee_cents == 0
+        assert row.min_usage_threshold_kwh == 999
+
+    def test_6738_leaves_unstated_figures_blank(self) -> None:
+        """Its plan-change notice omits these; copying the siblings' would be invention."""
+        row = _row("6738 Peerless", SERVICE_TYPE_ELECTRICITY)
+
+        assert row.avg_price_cents_per_kwh_at_1000 is None
+        assert row.early_termination_fee_cents is None
+        assert row.account_number == "204430810"
+
+    def test_the_two_unbound_accounts_are_left_null_and_documented(self) -> None:
+        """No email binds 204865879 / 204865622 to an address — don't guess."""
+        for match in ("6732 Peerless", "6734 Peerless"):
+            row = _row(match, SERVICE_TYPE_ELECTRICITY)
+            assert row.account_number is None
+            assert "204865879" in row.notes
+            assert "204865622" in row.notes
+
+
+class TestGasPlans:
+    def test_regulated_gas_carries_an_account_but_no_term(self) -> None:
+        gas = [r for r in PEERLESS_UTILITY_PLANS if r.service_type == SERVICE_TYPE_NATURAL_GAS]
+
+        assert len(gas) == 2
+        for row in gas:
+            assert row.rate_type == RATE_TYPE_REGULATED
+            # No competing supplier and no term to renew — a term_end_date
+            # would make the alert fire on something unactionable.
+            assert row.term_end_date is None
+            assert row.term_months is None
+            assert row.account_number
+
+    def test_accounts_map_to_the_addresses_centerpoint_printed(self) -> None:
+        assert _row("6732 Peerless", SERVICE_TYPE_NATURAL_GAS).account_number == "6403771834-9"
+        assert _row("6734 Peerless", SERVICE_TYPE_NATURAL_GAS).account_number == "6403771807-5"
+
+    def test_no_gas_row_is_invented_for_6738(self) -> None:
+        """Nothing in the mailbox shows gas service there; absence isn't a value."""
+        matches = {
+            r.property_match
+            for r in PEERLESS_UTILITY_PLANS
+            if r.service_type == SERVICE_TYPE_NATURAL_GAS
+        }
+        assert "6738 Peerless" not in matches
+
+
+class TestPlanParams:
+    def _prop(self):
+        return SimpleNamespace(
+            id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+            name="6734 Peerless St",
+        )
+
+    def test_tenant_columns_come_from_the_matched_property(self) -> None:
+        prop = self._prop()
+
+        params = _plan_params(_row("6734 Peerless", SERVICE_TYPE_ELECTRICITY), prop)
+
+        assert params["property_id"] == str(prop.id)
+        assert params["user_id"] == str(prop.user_id)
+        assert params["organization_id"] == str(prop.organization_id)
+        assert uuid.UUID(params["id"])
+
+    def test_account_number_is_normalized_for_joining(self) -> None:
+        """Must match utility_account_link's stored form, dashes stripped."""
+        params = _plan_params(_row("6734 Peerless", SERVICE_TYPE_NATURAL_GAS), self._prop())
+
+        assert params["account_number"] == "64037718075"
+
+    def test_a_missing_account_number_stays_null(self) -> None:
+        params = _plan_params(_row("6732 Peerless", SERVICE_TYPE_ELECTRICITY), self._prop())
+
+        assert params["account_number"] is None
+
+    def test_rate_precision_is_passed_through_undamaged(self) -> None:
+        params = _plan_params(_row("6732 Peerless", SERVICE_TYPE_ELECTRICITY), self._prop())
+
+        assert params["tdu_charge_cents_per_kwh"] == Decimal("5.3509")

--- a/apps/mybookkeeper/backend/tests/test_utility_plan_service.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_plan_service.py
@@ -1,0 +1,627 @@
+"""Tests for the utility-plan renewal logic.
+
+The behaviour worth pinning is the derivation, not the CRUD: a plan's renewal
+status is computed from ``rate_type`` + ``term_end_date`` + today on every
+read, so it can never go stale the way a stored status would. These tests pass
+an explicit ``today`` so the boundaries are exact and the suite does not change
+meaning as the calendar moves.
+
+Also covers the two suppression rules that keep the alert badge credible — a
+superseded plan and a regulated (no-competitor) plan never raise an alert.
+
+The service opens its own session via ``unit_of_work()``; ``_make_fake_uow``
+patches it to yield the in-memory SQLite test session instead.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.utility_plan_constants import (
+    EXPIRING_SOON_DAYS,
+    RATE_TYPE_FIXED,
+    RATE_TYPE_INDEXED,
+    RATE_TYPE_REGULATED,
+    RATE_TYPE_VARIABLE,
+    RENEWAL_STATUS_ACTIVE,
+    RENEWAL_STATUS_EXPIRED,
+    RENEWAL_STATUS_EXPIRING_SOON,
+    RENEWAL_STATUS_NOT_APPLICABLE,
+    SERVICE_TYPE_ELECTRICITY,
+    SERVICE_TYPE_NATURAL_GAS,
+)
+from app.models.properties.property import Property
+from app.repositories.properties import utility_plan_repo
+from app.services.properties import utility_plan_service
+
+TODAY = _dt.date(2026, 8, 7)
+
+_UOW_TARGET = "app.services.properties.utility_plan_service.unit_of_work"
+
+
+def _make_fake_uow(session: AsyncSession):
+    """Return a ``unit_of_work`` replacement that yields the test session."""
+    @asynccontextmanager
+    async def _fake_uow():
+        yield session
+    return _fake_uow
+
+
+async def _make_property(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    name: str,
+) -> Property:
+    prop = Property(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        name=name,
+        address=name,
+    )
+    db.add(prop)
+    await db.flush()
+    return prop
+
+
+class TestRenewalStatus:
+    """Boundary behaviour of the derived status."""
+
+    def test_far_future_term_is_active(self) -> None:
+        assert (
+            utility_plan_service.renewal_status(
+                RATE_TYPE_FIXED, _dt.date(2027, 1, 1), today=TODAY,
+            )
+            == RENEWAL_STATUS_ACTIVE
+        )
+
+    def test_exactly_at_window_edge_is_expiring_soon(self) -> None:
+        edge = TODAY + _dt.timedelta(days=EXPIRING_SOON_DAYS)
+        assert (
+            utility_plan_service.renewal_status(RATE_TYPE_FIXED, edge, today=TODAY)
+            == RENEWAL_STATUS_EXPIRING_SOON
+        )
+
+    def test_one_day_past_window_is_still_active(self) -> None:
+        outside = TODAY + _dt.timedelta(days=EXPIRING_SOON_DAYS + 1)
+        assert (
+            utility_plan_service.renewal_status(RATE_TYPE_FIXED, outside, today=TODAY)
+            == RENEWAL_STATUS_ACTIVE
+        )
+
+    def test_term_ending_today_is_expiring_soon_not_expired(self) -> None:
+        # Service runs through the final day; it has not lapsed yet.
+        assert (
+            utility_plan_service.renewal_status(RATE_TYPE_FIXED, TODAY, today=TODAY)
+            == RENEWAL_STATUS_EXPIRING_SOON
+        )
+
+    def test_yesterday_is_expired(self) -> None:
+        assert (
+            utility_plan_service.renewal_status(
+                RATE_TYPE_FIXED, TODAY - _dt.timedelta(days=1), today=TODAY,
+            )
+            == RENEWAL_STATUS_EXPIRED
+        )
+
+    def test_regulated_service_never_has_a_renewal_deadline(self) -> None:
+        # Houston natural gas: no competing supplier exists, so an "expired"
+        # badge would be advice the operator cannot act on.
+        assert (
+            utility_plan_service.renewal_status(
+                RATE_TYPE_REGULATED, _dt.date(2020, 1, 1), today=TODAY,
+            )
+            == RENEWAL_STATUS_NOT_APPLICABLE
+        )
+
+    def test_missing_end_date_is_not_applicable(self) -> None:
+        assert (
+            utility_plan_service.renewal_status(RATE_TYPE_FIXED, None, today=TODAY)
+            == RENEWAL_STATUS_NOT_APPLICABLE
+        )
+
+    def test_indexed_plans_are_classified_like_fixed(self) -> None:
+        assert (
+            utility_plan_service.renewal_status(
+                RATE_TYPE_INDEXED, TODAY - _dt.timedelta(days=5), today=TODAY,
+            )
+            == RENEWAL_STATUS_EXPIRED
+        )
+
+    def test_window_is_overridable(self) -> None:
+        end = TODAY + _dt.timedelta(days=60)
+        assert (
+            utility_plan_service.renewal_status(
+                RATE_TYPE_FIXED, end, today=TODAY, window_days=90,
+            )
+            == RENEWAL_STATUS_EXPIRING_SOON
+        )
+
+
+class TestDaysUntilTermEnd:
+    def test_future_is_positive(self) -> None:
+        assert (
+            utility_plan_service.days_until_term_end(
+                TODAY + _dt.timedelta(days=10), today=TODAY,
+            )
+            == 10
+        )
+
+    def test_past_is_negative(self) -> None:
+        assert (
+            utility_plan_service.days_until_term_end(
+                TODAY - _dt.timedelta(days=193), today=TODAY,
+            )
+            == -193
+        )
+
+    def test_none_when_open_ended(self) -> None:
+        assert utility_plan_service.days_until_term_end(None, today=TODAY) is None
+
+
+@pytest.mark.asyncio
+class TestCurrentPlanResolution:
+    async def test_latest_start_date_wins_per_property_and_service(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6734 Peerless St")
+
+        old = await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Old REP",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2024, 1, 1),
+        )
+        new = await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="New REP",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2025, 1, 23),
+        )
+
+        assert utility_plan_service.current_plan_ids([old, new]) == {new.id}
+
+    async def test_different_service_types_are_independent(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St")
+
+        power = await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Constellation",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2025, 1, 23),
+        )
+        gas = await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_NATURAL_GAS,
+            provider_name="CenterPoint",
+            rate_type=RATE_TYPE_REGULATED,
+            service_start_date=_dt.date(2024, 6, 1),
+        )
+
+        # Electricity and gas each keep their own current row.
+        assert utility_plan_service.current_plan_ids([power, gas]) == {
+            power.id, gas.id,
+        }
+
+    async def test_dated_row_outranks_undated_stub(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6738 Peerless St")
+
+        stub = await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Unknown",
+            rate_type=RATE_TYPE_VARIABLE,
+            service_start_date=None,
+        )
+        dated = await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Constellation",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2025, 1, 27),
+        )
+
+        assert utility_plan_service.current_plan_ids([stub, dated]) == {dated.id}
+
+
+@pytest.mark.asyncio
+class TestRenewalAlerts:
+    async def test_expired_current_plan_is_reported(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6738 Peerless St")
+        await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Constellation",
+            plan_name="FIXED + Air Conditioner Protection",
+            rate_type=RATE_TYPE_FIXED,
+            energy_charge_cents_per_kwh=Decimal("11.6000"),
+            avg_price_cents_per_kwh_at_1000=Decimal("13.9000"),
+            term_months=12,
+            service_start_date=_dt.date(2025, 1, 27),
+            term_end_date=_dt.date(2026, 1, 27),
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await utility_plan_service.get_renewal_alerts(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.total_needing_attention == 1
+        assert result.window_days == EXPIRING_SOON_DAYS
+        assert len(result.expired) == 1
+        assert result.expired[0].property_name == "6738 Peerless St"
+        assert result.expired[0].days_until_term_end == -192
+        assert result.expired[0].is_current is True
+        assert result.expiring_soon == []
+
+    async def test_regulated_gas_plan_raises_no_alert(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_NATURAL_GAS,
+            provider_name="CenterPoint",
+            rate_type=RATE_TYPE_REGULATED,
+            # Even with a long-past end date, there is nothing to switch to.
+            term_end_date=_dt.date(2020, 1, 1),
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await utility_plan_service.get_renewal_alerts(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.total_needing_attention == 0
+
+    async def test_superseded_expired_plan_is_not_alerted(
+        self, db: AsyncSession,
+    ) -> None:
+        """History should not nag. Only the plan in force can need renewing."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6734 Peerless St")
+        await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Old REP",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2024, 1, 1),
+            term_end_date=_dt.date(2025, 1, 1),
+        )
+        await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Constellation",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2025, 1, 23),
+            term_end_date=_dt.date(2027, 1, 23),
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await utility_plan_service.get_renewal_alerts(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.total_needing_attention == 0
+
+    async def test_soft_deleted_plan_is_excluded(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6738 Peerless St")
+        plan = await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Constellation",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2025, 1, 27),
+            term_end_date=_dt.date(2026, 1, 27),
+        )
+        await utility_plan_repo.soft_delete(
+            db, plan_id=plan.id, user_id=user_id, organization_id=org_id,
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await utility_plan_service.get_renewal_alerts(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.total_needing_attention == 0
+
+    async def test_expiring_soon_sorted_soonest_first(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        far = await _make_property(db, org_id, user_id, "Far St")
+        near = await _make_property(db, org_id, user_id, "Near St")
+        for prop, end in (
+            (far, TODAY + _dt.timedelta(days=40)),
+            (near, TODAY + _dt.timedelta(days=5)),
+        ):
+            await utility_plan_repo.create(
+                db,
+                user_id=user_id,
+                organization_id=org_id,
+                property_id=prop.id,
+                service_type=SERVICE_TYPE_ELECTRICITY,
+                provider_name="Some REP",
+                rate_type=RATE_TYPE_FIXED,
+                service_start_date=_dt.date(2025, 1, 1),
+                term_end_date=end,
+            )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await utility_plan_service.get_renewal_alerts(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert [s.property_name for s in result.expiring_soon] == ["Near St", "Far St"]
+
+    async def test_expired_sorted_longest_lapsed_first(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        recent = await _make_property(db, org_id, user_id, "Recent St")
+        stale = await _make_property(db, org_id, user_id, "Stale St")
+        for prop, end in (
+            (recent, TODAY - _dt.timedelta(days=10)),
+            (stale, TODAY - _dt.timedelta(days=400)),
+        ):
+            await utility_plan_repo.create(
+                db,
+                user_id=user_id,
+                organization_id=org_id,
+                property_id=prop.id,
+                service_type=SERVICE_TYPE_ELECTRICITY,
+                provider_name="Some REP",
+                rate_type=RATE_TYPE_FIXED,
+                service_start_date=_dt.date(2023, 1, 1),
+                term_end_date=end,
+            )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await utility_plan_service.get_renewal_alerts(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert [s.property_name for s in result.expired] == ["Stale St", "Recent St"]
+
+    async def test_another_orgs_plans_are_invisible(self, db: AsyncSession) -> None:
+        mine_org, mine_user = uuid.uuid4(), uuid.uuid4()
+        other_org, other_user = uuid.uuid4(), uuid.uuid4()
+        other_prop = await _make_property(db, other_org, other_user, "Not Mine St")
+        await utility_plan_repo.create(
+            db,
+            user_id=other_user,
+            organization_id=other_org,
+            property_id=other_prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Constellation",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2025, 1, 27),
+            term_end_date=_dt.date(2026, 1, 27),
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await utility_plan_service.get_renewal_alerts(
+                user_id=mine_user, organization_id=mine_org, today=TODAY,
+            )
+
+        assert result.total_needing_attention == 0
+
+
+@pytest.mark.asyncio
+class TestSweepPlansNeedingRenewal:
+    """The scheduler's cross-tenant sweep."""
+
+    async def test_covers_every_tenant(self, db: AsyncSession) -> None:
+        org_a, user_a = uuid.uuid4(), uuid.uuid4()
+        org_b, user_b = uuid.uuid4(), uuid.uuid4()
+        prop_a = await _make_property(db, org_a, user_a, "Tenant A St")
+        prop_b = await _make_property(db, org_b, user_b, "Tenant B St")
+        for org_id, user_id, prop in (
+            (org_a, user_a, prop_a),
+            (org_b, user_b, prop_b),
+        ):
+            await utility_plan_repo.create(
+                db,
+                user_id=user_id,
+                organization_id=org_id,
+                property_id=prop.id,
+                service_type=SERVICE_TYPE_ELECTRICITY,
+                provider_name="Constellation",
+                rate_type=RATE_TYPE_FIXED,
+                service_start_date=_dt.date(2025, 1, 27),
+                term_end_date=_dt.date(2026, 1, 27),
+            )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            flagged = await utility_plan_service.sweep_plans_needing_renewal(
+                today=TODAY,
+            )
+
+        assert {s.property_name for s in flagged} == {"Tenant A St", "Tenant B St"}
+
+    async def test_applies_the_same_suppression_rules_as_the_dashboard(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6734 Peerless St")
+        # Superseded: expired, but no longer the plan in force.
+        await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Old REP",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2024, 1, 1),
+            term_end_date=_dt.date(2025, 1, 1),
+        )
+        # Current and expired — the one real flag.
+        await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Constellation",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2025, 1, 27),
+            term_end_date=_dt.date(2026, 1, 27),
+        )
+        # Regulated: expired on paper, nothing to switch to.
+        await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_NATURAL_GAS,
+            provider_name="CenterPoint",
+            rate_type=RATE_TYPE_REGULATED,
+            term_end_date=_dt.date(2020, 1, 1),
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            flagged = await utility_plan_service.sweep_plans_needing_renewal(
+                today=TODAY,
+            )
+
+        assert [s.provider_name for s in flagged] == ["Constellation"]
+
+    async def test_plans_outside_the_window_are_not_flagged(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "Safe St")
+        await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Constellation",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2026, 1, 1),
+            term_end_date=TODAY + _dt.timedelta(days=EXPIRING_SOON_DAYS + 1),
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            flagged = await utility_plan_service.sweep_plans_needing_renewal(
+                today=TODAY,
+            )
+
+        assert flagged == []
+
+
+@pytest.mark.asyncio
+class TestUpdatePlan:
+    async def test_patch_rejects_term_end_before_stored_start(
+        self, db: AsyncSession,
+    ) -> None:
+        """A partial update can break a rule using a field it did not send."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        plan = await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Constellation",
+            rate_type=RATE_TYPE_FIXED,
+            service_start_date=_dt.date(2025, 1, 27),
+            term_end_date=_dt.date(2026, 1, 27),
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            with pytest.raises(utility_plan_service.InvalidUtilityPlanError):
+                await utility_plan_service.update_plan(
+                    user_id=user_id,
+                    organization_id=org_id,
+                    plan_id=plan.id,
+                    fields={"term_end_date": _dt.date(2024, 6, 1)},
+                )
+
+    async def test_account_number_is_normalized_on_update(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6734 Peerless St")
+        plan = await utility_plan_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=org_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_NATURAL_GAS,
+            provider_name="CenterPoint",
+            rate_type=RATE_TYPE_REGULATED,
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            detail = await utility_plan_service.update_plan(
+                user_id=user_id,
+                organization_id=org_id,
+                plan_id=plan.id,
+                fields={"account_number": "6403771807-5"},
+            )
+
+        # Same normalization as utility_account_link, so the plan and the
+        # learned bill -> property link describe one account key.
+        assert detail.account_number == "64037718075"
+
+    async def test_unknown_plan_raises_not_found(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            with pytest.raises(utility_plan_service.UtilityPlanNotFoundError):
+                await utility_plan_service.update_plan(
+                    user_id=user_id,
+                    organization_id=org_id,
+                    plan_id=uuid.uuid4(),
+                    fields={"provider_name": "Anything"},
+                )

--- a/apps/mybookkeeper/backend/tests/test_utility_plans_api.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_plans_api.py
@@ -1,0 +1,396 @@
+"""HTTP route tests for /utility-plans.
+
+The service is mocked — its behaviour is covered in
+``test_utility_plan_service.py``. What these tests pin is the contract the
+routes own: payload validation, status codes, the permission dependency each
+route hangs off, and the route-ordering hazard where ``/renewal-alerts`` would
+be swallowed by ``/{plan_id}`` if the declaration order were ever changed.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.core.utility_plan_constants import (
+    EXPIRING_SOON_DAYS,
+    RATE_TYPE_FIXED,
+    RENEWAL_STATUS_EXPIRED,
+    SERVICE_TYPE_ELECTRICITY,
+)
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.properties.utility_plan_list_response import UtilityPlanListResponse
+from app.schemas.properties.utility_plan_renewal_alert_response import (
+    UtilityPlanRenewalAlertResponse,
+)
+from app.schemas.properties.utility_plan_response import UtilityPlanResponse
+from app.schemas.properties.utility_plan_summary import UtilityPlanSummary
+from app.services.properties.utility_plan_service import (
+    InvalidUtilityPlanError,
+    UtilityPlanNotFoundError,
+)
+
+ORG_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+PROPERTY_ID = uuid.uuid4()
+PLAN_ID = uuid.uuid4()
+
+_SERVICE = "app.api.utility_plans.utility_plan_service"
+
+
+def _ctx(role: OrgRole = OrgRole.OWNER) -> RequestContext:
+    return RequestContext(organization_id=ORG_ID, user_id=USER_ID, org_role=role)
+
+
+@pytest.fixture()
+def client():
+    """TestClient with both permission dependencies satisfied as an owner."""
+    app.dependency_overrides[current_org_member] = lambda: _ctx()
+    app.dependency_overrides[require_write_access] = lambda: _ctx()
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _detail(**overrides) -> UtilityPlanResponse:
+    now = _dt.datetime.now(_dt.timezone.utc)
+    fields = {
+        "id": PLAN_ID,
+        "user_id": USER_ID,
+        "organization_id": ORG_ID,
+        "property_id": PROPERTY_ID,
+        "property_name": "6732 Peerless St",
+        "service_type": SERVICE_TYPE_ELECTRICITY,
+        "provider_name": "Constellation",
+        "rate_type": RATE_TYPE_FIXED,
+        "has_bill_credit": False,
+        "renewal_status": RENEWAL_STATUS_EXPIRED,
+        "is_current": True,
+        "created_at": now,
+        "updated_at": now,
+    }
+    fields.update(overrides)
+    return UtilityPlanResponse(**fields)
+
+
+def _summary(**overrides) -> UtilityPlanSummary:
+    now = _dt.datetime.now(_dt.timezone.utc)
+    fields = {
+        "id": PLAN_ID,
+        "property_id": PROPERTY_ID,
+        "property_name": "6732 Peerless St",
+        "service_type": SERVICE_TYPE_ELECTRICITY,
+        "provider_name": "Constellation",
+        "rate_type": RATE_TYPE_FIXED,
+        "term_end_date": _dt.date(2026, 1, 27),
+        "days_until_term_end": -192,
+        "renewal_status": RENEWAL_STATUS_EXPIRED,
+        "is_current": True,
+        "created_at": now,
+        "updated_at": now,
+    }
+    fields.update(overrides)
+    return UtilityPlanSummary(**fields)
+
+
+class TestCreate:
+    def test_valid_payload_returns_201(self, client: TestClient) -> None:
+        with patch(
+            f"{_SERVICE}.create_plan", new_callable=AsyncMock, return_value=_detail(),
+        ) as mock_create:
+            response = client.post(
+                "/utility-plans",
+                json={
+                    "property_id": str(PROPERTY_ID),
+                    "service_type": "electricity",
+                    "provider_name": "Constellation",
+                    "rate_type": "fixed",
+                    "energy_charge_cents_per_kwh": "11.6000",
+                    "tdu_charge_cents_per_kwh": "5.3509",
+                    "service_start_date": "2025-01-27",
+                    "term_end_date": "2026-01-27",
+                },
+            )
+
+        assert response.status_code == 201
+        fields = mock_create.await_args.kwargs["fields"]
+        # Sub-cent precision must survive the JSON boundary — a TDU charge
+        # rounded to 5.35 would quietly misprice every comparison.
+        assert fields["tdu_charge_cents_per_kwh"] == Decimal("5.3509")
+
+    def test_unknown_service_type_returns_422(self, client: TestClient) -> None:
+        response = client.post(
+            "/utility-plans",
+            json={
+                "property_id": str(PROPERTY_ID),
+                "service_type": "teleportation",
+                "provider_name": "Constellation",
+                "rate_type": "fixed",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_term_end_before_start_returns_422(self, client: TestClient) -> None:
+        response = client.post(
+            "/utility-plans",
+            json={
+                "property_id": str(PROPERTY_ID),
+                "service_type": "electricity",
+                "provider_name": "Constellation",
+                "rate_type": "fixed",
+                "service_start_date": "2026-01-27",
+                "term_end_date": "2025-01-27",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_bill_credit_without_threshold_returns_422(
+        self, client: TestClient,
+    ) -> None:
+        response = client.post(
+            "/utility-plans",
+            json={
+                "property_id": str(PROPERTY_ID),
+                "service_type": "electricity",
+                "provider_name": "Constellation",
+                "rate_type": "fixed",
+                "has_bill_credit": True,
+                "bill_credit_amount_cents": 10000,
+            },
+        )
+        assert response.status_code == 422
+
+    def test_unknown_field_returns_422(self, client: TestClient) -> None:
+        response = client.post(
+            "/utility-plans",
+            json={
+                "property_id": str(PROPERTY_ID),
+                "service_type": "electricity",
+                "provider_name": "Constellation",
+                "rate_type": "fixed",
+                "kwh_used": 1200,
+            },
+        )
+        assert response.status_code == 422
+
+
+class TestList:
+    def test_forwards_filters_to_the_service(self, client: TestClient) -> None:
+        empty = UtilityPlanListResponse(items=[], total=0, has_more=False)
+        with patch(
+            f"{_SERVICE}.list_plans", new_callable=AsyncMock, return_value=empty,
+        ) as mock_list:
+            response = client.get(
+                "/utility-plans",
+                params={
+                    "property_id": str(PROPERTY_ID),
+                    "service_type": "natural_gas",
+                    "expiring_before": "2026-12-31",
+                    "limit": 10,
+                    "offset": 20,
+                },
+            )
+
+        assert response.status_code == 200
+        kwargs = mock_list.await_args.kwargs
+        assert kwargs["property_id"] == PROPERTY_ID
+        assert kwargs["service_type"] == "natural_gas"
+        assert kwargs["expiring_before"] == _dt.date(2026, 12, 31)
+        assert kwargs["limit"] == 10
+        assert kwargs["offset"] == 20
+
+    def test_limit_above_the_cap_returns_422(self, client: TestClient) -> None:
+        response = client.get("/utility-plans", params={"limit": 500})
+        assert response.status_code == 422
+
+
+class TestRenewalAlerts:
+    def test_literal_path_is_not_captured_by_the_uuid_route(
+        self, client: TestClient,
+    ) -> None:
+        """Regression guard: /renewal-alerts must not resolve as a plan id."""
+        payload = UtilityPlanRenewalAlertResponse(
+            window_days=EXPIRING_SOON_DAYS,
+            expired=[_summary()],
+            expiring_soon=[],
+            total_needing_attention=1,
+        )
+        with patch(
+            f"{_SERVICE}.get_renewal_alerts",
+            new_callable=AsyncMock,
+            return_value=payload,
+        ) as mock_alerts, patch(
+            f"{_SERVICE}.get_plan", new_callable=AsyncMock,
+        ) as mock_get:
+            response = client.get("/utility-plans/renewal-alerts")
+
+        assert response.status_code == 200
+        assert mock_alerts.await_count == 1
+        assert mock_get.await_count == 0
+        assert response.json()["total_needing_attention"] == 1
+
+    def test_window_days_is_forwarded(self, client: TestClient) -> None:
+        payload = UtilityPlanRenewalAlertResponse(
+            window_days=90, expired=[], expiring_soon=[], total_needing_attention=0,
+        )
+        with patch(
+            f"{_SERVICE}.get_renewal_alerts",
+            new_callable=AsyncMock,
+            return_value=payload,
+        ) as mock_alerts:
+            response = client.get(
+                "/utility-plans/renewal-alerts", params={"window_days": 90},
+            )
+
+        assert response.status_code == 200
+        assert mock_alerts.await_args.kwargs["window_days"] == 90
+
+    def test_window_days_out_of_range_returns_422(self, client: TestClient) -> None:
+        response = client.get(
+            "/utility-plans/renewal-alerts", params={"window_days": 0},
+        )
+        assert response.status_code == 422
+
+
+class TestGet:
+    def test_missing_plan_returns_404(self, client: TestClient) -> None:
+        with patch(
+            f"{_SERVICE}.get_plan",
+            new_callable=AsyncMock,
+            side_effect=UtilityPlanNotFoundError(str(PLAN_ID)),
+        ):
+            response = client.get(f"/utility-plans/{PLAN_ID}")
+        assert response.status_code == 404
+
+    def test_non_uuid_id_returns_422(self, client: TestClient) -> None:
+        response = client.get("/utility-plans/not-a-uuid")
+        assert response.status_code == 422
+
+
+class TestUpdate:
+    def test_only_sent_fields_reach_the_service(self, client: TestClient) -> None:
+        """exclude_unset keeps "omitted" distinct from "set to null"."""
+        with patch(
+            f"{_SERVICE}.update_plan", new_callable=AsyncMock, return_value=_detail(),
+        ) as mock_update:
+            response = client.patch(
+                f"/utility-plans/{PLAN_ID}", json={"plan_name": "Renewed 12"},
+            )
+
+        assert response.status_code == 200
+        assert mock_update.await_args.kwargs["fields"] == {"plan_name": "Renewed 12"}
+
+    def test_explicit_null_is_forwarded(self, client: TestClient) -> None:
+        with patch(
+            f"{_SERVICE}.update_plan", new_callable=AsyncMock, return_value=_detail(),
+        ) as mock_update:
+            client.patch(f"/utility-plans/{PLAN_ID}", json={"term_end_date": None})
+
+        assert mock_update.await_args.kwargs["fields"] == {"term_end_date": None}
+
+    def test_empty_body_reads_without_writing(self, client: TestClient) -> None:
+        with patch(
+            f"{_SERVICE}.get_plan", new_callable=AsyncMock, return_value=_detail(),
+        ) as mock_get, patch(
+            f"{_SERVICE}.update_plan", new_callable=AsyncMock,
+        ) as mock_update:
+            response = client.patch(f"/utility-plans/{PLAN_ID}", json={})
+
+        assert response.status_code == 200
+        assert mock_get.await_count == 1
+        assert mock_update.await_count == 0
+
+    def test_inconsistent_merge_returns_422_not_500(
+        self, client: TestClient,
+    ) -> None:
+        with patch(
+            f"{_SERVICE}.update_plan",
+            new_callable=AsyncMock,
+            side_effect=InvalidUtilityPlanError(
+                "term_end_date must be on or after service_start_date",
+            ),
+        ):
+            response = client.patch(
+                f"/utility-plans/{PLAN_ID}", json={"term_end_date": "2020-01-01"},
+            )
+
+        assert response.status_code == 422
+        assert "service_start_date" in response.json()["detail"]
+
+    def test_missing_plan_returns_404(self, client: TestClient) -> None:
+        with patch(
+            f"{_SERVICE}.update_plan",
+            new_callable=AsyncMock,
+            side_effect=UtilityPlanNotFoundError(str(PLAN_ID)),
+        ):
+            response = client.patch(
+                f"/utility-plans/{PLAN_ID}", json={"plan_name": "X"},
+            )
+        assert response.status_code == 404
+
+
+class TestDelete:
+    def test_returns_204(self, client: TestClient) -> None:
+        with patch(
+            f"{_SERVICE}.soft_delete_plan", new_callable=AsyncMock, return_value=None,
+        ) as mock_delete:
+            response = client.delete(f"/utility-plans/{PLAN_ID}")
+
+        assert response.status_code == 204
+        assert mock_delete.await_args.kwargs["plan_id"] == PLAN_ID
+
+    def test_missing_plan_returns_404(self, client: TestClient) -> None:
+        with patch(
+            f"{_SERVICE}.soft_delete_plan",
+            new_callable=AsyncMock,
+            side_effect=UtilityPlanNotFoundError(str(PLAN_ID)),
+        ):
+            response = client.delete(f"/utility-plans/{PLAN_ID}")
+        assert response.status_code == 404
+
+
+class TestPermissions:
+    def test_write_routes_reject_a_read_only_member(self) -> None:
+        """Only ``current_org_member`` is overridden, so the real
+        ``require_write_access`` runs against a viewer context and 403s."""
+        app.dependency_overrides[current_org_member] = lambda: _ctx(OrgRole.VIEWER)
+        try:
+            client = TestClient(app)
+            assert client.post(
+                "/utility-plans",
+                json={
+                    "property_id": str(PROPERTY_ID),
+                    "service_type": "electricity",
+                    "provider_name": "Constellation",
+                    "rate_type": "fixed",
+                },
+            ).status_code == 403
+            assert client.patch(
+                f"/utility-plans/{PLAN_ID}", json={"plan_name": "X"},
+            ).status_code == 403
+            assert client.delete(f"/utility-plans/{PLAN_ID}").status_code == 403
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_read_routes_allow_a_read_only_member(self) -> None:
+        app.dependency_overrides[current_org_member] = lambda: _ctx(OrgRole.VIEWER)
+        empty = UtilityPlanListResponse(items=[], total=0, has_more=False)
+        try:
+            with patch(
+                f"{_SERVICE}.list_plans", new_callable=AsyncMock, return_value=empty,
+            ):
+                assert TestClient(app).get("/utility-plans").status_code == 200
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_read_routes_require_authentication(self) -> None:
+        app.dependency_overrides.clear()
+        client = TestClient(app)
+        assert client.get("/utility-plans").status_code == 401
+        assert client.get("/utility-plans/renewal-alerts").status_code == 401

--- a/apps/mybookkeeper/frontend/e2e/utility-plans-layout.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-plans-layout.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * Layout E2E for the Utility Plans list.
+ *
+ * Verifies:
+ *   1. The loading skeleton has the same row count and the same
+ *      text-block-plus-badge shape as the loaded list, so nothing shifts when
+ *      the data arrives.
+ *   2. The list renders without horizontal overflow at mobile / tablet /
+ *      desktop widths.
+ *   3. The delete control meets the 44px touch-target minimum on mobile.
+ */
+
+const PLAN_COUNT = 3;
+/** Matches the placeholder row count in ``UtilityPlansListBody``'s skeleton. */
+const SKELETON_ROW_COUNT = 3;
+
+interface SeededPlan {
+  id: string;
+}
+
+async function seedPlan(
+  api: APIRequestContext,
+  propertyId: string,
+  providerName: string,
+): Promise<string> {
+  const res = await api.post("/utility-plans", {
+    data: {
+      property_id: propertyId,
+      service_type: "electricity",
+      provider_name: providerName,
+      rate_type: "fixed",
+      plan_name: "12 Month Fixed",
+      energy_charge_cents_per_kwh: "11.6000",
+      tdu_charge_cents_per_kwh: "5.3509",
+      avg_price_cents_per_kwh_at_1000: "13.9000",
+      term_months: 12,
+      term_end_date: "2026-01-27",
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedPlan failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as SeededPlan;
+  return body.id;
+}
+
+async function hasHorizontalOverflow(page: import("@playwright/test").Page): Promise<boolean> {
+  return page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+  );
+}
+
+test.describe("Utility Plans layout", () => {
+  test("skeleton row count and shape match the loaded list", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    let propertyId: string | null = null;
+    const planIds: string[] = [];
+
+    try {
+      const property = await createProperty(api, { name: `E2E Layout Property ${runId}` });
+      propertyId = property.id;
+      for (let i = 0; i < PLAN_COUNT; i++) {
+        planIds.push(await seedPlan(api, propertyId, `E2E Layout Power ${runId}-${i}`));
+      }
+
+      // Hold the list response long enough to observe the skeleton. The glob's
+      // trailing `*` stops at the next `/`, so `/renewal-alerts` is untouched.
+      await page.route("**/api/utility-plans*", async (route) => {
+        await new Promise((r) => setTimeout(r, 1500));
+        await route.continue();
+      });
+
+      const navPromise = page.goto("/utility-plans");
+
+      const skeleton = page.getByTestId("utility-plans-loading");
+      await expect(skeleton).toBeVisible({ timeout: 5000 });
+      const skeletonRows = skeleton.locator("> div");
+      await expect(skeletonRows).toHaveCount(SKELETON_ROW_COUNT);
+      // Each placeholder row reserves exactly one badge slot, like a real row.
+      await expect(skeleton.locator(".rounded-full")).toHaveCount(SKELETON_ROW_COUNT);
+
+      await navPromise;
+      const list = page.getByTestId("utility-plans-list");
+      await expect(list).toBeVisible({ timeout: 15000 });
+
+      // Every seeded plan is on the page, so the skeleton stood in for at
+      // least as many rows as arrived — it never under-reserved height.
+      for (const id of planIds) {
+        await expect(page.getByTestId(`utility-plan-item-${id}`)).toBeVisible();
+      }
+      const loadedRows = page.locator('[data-testid^="utility-plan-item-"]');
+      const loadedCount = await loadedRows.count();
+      expect(loadedCount).toBeGreaterThanOrEqual(PLAN_COUNT);
+
+      // One badge per row, loaded and loading alike — that 1:1 ratio is the
+      // shape the skeleton is promising, and it is what keeps the right-hand
+      // column from jumping when the data lands. Counted rather than compared
+      // to a fixed number because this account is shared with the sibling
+      // layout test running in parallel.
+      await expect(list.getByTestId(/^utility-plan-status-/)).toHaveCount(loadedCount);
+    } finally {
+      for (const id of planIds) await api.delete(`/utility-plans/${id}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+
+  test("the list fits every viewport width and keeps 44px touch targets", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    let propertyId: string | null = null;
+    let planId: string | null = null;
+
+    try {
+      const property = await createProperty(api, {
+        name: `E2E Wide Property Name That Could Overflow ${runId}`,
+      });
+      propertyId = property.id;
+      planId = await seedPlan(
+        api,
+        propertyId,
+        `E2E Provider With A Deliberately Long Name ${runId}`,
+      );
+
+      for (const size of [
+        { width: 375, height: 800 },
+        { width: 768, height: 900 },
+        { width: 1440, height: 900 },
+      ]) {
+        await page.setViewportSize(size);
+        await page.goto("/utility-plans");
+        await expect(page.getByTestId(`utility-plan-item-${planId}`)).toBeVisible({
+          timeout: 15000,
+        });
+        expect(
+          await hasHorizontalOverflow(page),
+          `horizontal overflow at ${size.width}px`,
+        ).toBe(false);
+      }
+
+      await page.setViewportSize({ width: 375, height: 800 });
+      await page.goto("/utility-plans");
+      const deleteButton = page.getByTestId(`utility-plan-delete-${planId}`);
+      await expect(deleteButton).toBeVisible({ timeout: 15000 });
+      const box = await deleteButton.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.width).toBeGreaterThanOrEqual(44);
+      expect(box!.height).toBeGreaterThanOrEqual(44);
+    } finally {
+      if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/e2e/utility-plans.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-plans.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect, type APIRequestContext, type Page } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * Utility Plans full-flow behavioural E2E.
+ *
+ * Drives the real user journey: create a plan through the dialog → it appears
+ * in the list with a derived renewal status → the dashboard alert card picks
+ * it up → the "needs renewing" filter selects on that status → delete.
+ *
+ * Verifies UI state AND backend state via the public API, and cleans up every
+ * seeded row in `finally` per the project's "never leave test data" rule.
+ *
+ * The plan is seeded with a term that has already lapsed, because the whole
+ * point of the feature is catching a fixed rate that quietly rolled onto a
+ * variable holdover — an "active" plan would exercise none of that.
+ */
+
+interface UtilityPlanRow {
+  id: string;
+  provider_name: string;
+  renewal_status: string;
+  is_current: boolean;
+  days_until_term_end: number | null;
+  tdu_charge_cents_per_kwh: string | null;
+}
+
+interface RenewalAlerts {
+  window_days: number;
+  expired: UtilityPlanRow[];
+  expiring_soon: UtilityPlanRow[];
+  total_needing_attention: number;
+}
+
+/** ``offsetDays`` from today as ``YYYY-MM-DD``. Negative is in the past. */
+function isoDateOffset(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+async function fetchPlan(api: APIRequestContext, id: string): Promise<UtilityPlanRow> {
+  const res = await api.get(`/utility-plans/${id}`);
+  if (!res.ok()) throw new Error(`fetchPlan failed: ${res.status()} ${await res.text()}`);
+  return res.json();
+}
+
+async function fetchAlerts(api: APIRequestContext): Promise<RenewalAlerts> {
+  const res = await api.get("/utility-plans/renewal-alerts");
+  if (!res.ok()) throw new Error(`fetchAlerts failed: ${res.status()} ${await res.text()}`);
+  return res.json();
+}
+
+async function waitForListPage(page: Page): Promise<void> {
+  await expect(page.getByRole("heading", { name: "Utility Plans" })).toBeVisible({
+    timeout: 10000,
+  });
+  await page.waitForLoadState("networkidle");
+}
+
+test.describe("Utility Plans", () => {
+  test("create a lapsed plan, see it flagged on the dashboard, filter it, delete it", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const propertyName = `E2E Utility Property ${runId}`;
+    const providerName = `E2E Power Co ${runId}`;
+    let propertyId: string | null = null;
+    let planId: string | null = null;
+
+    try {
+      const property = await createProperty(api, {
+        name: propertyName,
+        address: `${runId} Peerless St, Houston, TX 77021`,
+      });
+      propertyId = property.id;
+
+      // 1) CREATE through the dialog.
+      await page.goto("/utility-plans");
+      await waitForListPage(page);
+
+      await page.getByTestId("add-utility-plan-button").click();
+      await expect(page.getByTestId("add-utility-plan-dialog")).toBeVisible();
+
+      await page.getByTestId("utility-plan-property-select").selectOption({ label: propertyName });
+      await page.getByTestId("utility-plan-service-select").selectOption("electricity");
+      await page.getByTestId("utility-plan-rate-type-select").selectOption("fixed");
+      await page.getByTestId("utility-plan-provider-input").fill(providerName);
+      await page.getByTestId("utility-plan-name-input").fill("12 Month Fixed");
+      await page.getByTestId("utility-plan-energy-input").fill("11.6");
+      await page.getByTestId("utility-plan-tdu-input").fill("5.3509");
+      await page.getByTestId("utility-plan-avg-price-input").fill("13.9");
+      await page.getByTestId("utility-plan-base-charge-input").fill("4.39");
+      await page.getByTestId("utility-plan-term-months-input").fill("12");
+      await page.getByTestId("utility-plan-start-date-input").fill(isoDateOffset(-400));
+      // Term lapsed 35 days ago.
+      await page.getByTestId("utility-plan-end-date-input").fill(isoDateOffset(-35));
+      await page.getByTestId("utility-plan-etf-input").fill("150");
+      await page.getByTestId("utility-plan-save-button").click();
+
+      await expect(page.getByTestId("add-utility-plan-dialog")).toBeHidden({ timeout: 10000 });
+      await page.waitForLoadState("networkidle");
+
+      // 2) It shows in the list with the derived status the backend computed.
+      const row = page.locator('[data-testid^="utility-plan-item-"]', {
+        hasText: providerName,
+      });
+      await expect(row).toBeVisible({ timeout: 10000 });
+      await expect(row).toContainText(propertyName);
+      await expect(row).toContainText("Lapsed 35 days ago");
+      await expect(row.getByTestId("utility-plan-status-expired")).toBeVisible();
+
+      const testId = await row.getAttribute("data-testid");
+      planId = testId?.replace("utility-plan-item-", "") ?? null;
+      expect(planId).toBeTruthy();
+      if (!planId) throw new Error("Could not parse plan id from the row");
+
+      // 3) Backend state agrees, including the sub-cent rate surviving the
+      //    round trip — a TDU charge rounded to 5.35 would misprice the plan.
+      const saved = await fetchPlan(api, planId);
+      expect(saved.provider_name).toBe(providerName);
+      expect(saved.renewal_status).toBe("expired");
+      expect(saved.is_current).toBe(true);
+      expect(saved.days_until_term_end).toBe(-35);
+      expect(Number(saved.tdu_charge_cents_per_kwh)).toBeCloseTo(5.3509, 4);
+
+      const alerts = await fetchAlerts(api);
+      expect(alerts.expired.some((p) => p.id === planId)).toBe(true);
+
+      // 4) The "needs renewing" filter keeps it.
+      await page.getByTestId("utility-plans-expiring-toggle").check();
+      await expect(row).toBeVisible();
+
+      // 5) The dashboard card surfaces it without the operator going looking.
+      await page.goto("/");
+      await page.waitForLoadState("networkidle");
+      const card = page.getByTestId("utility-plan-alert-card");
+      await expect(card).toBeVisible({ timeout: 15000 });
+      await expect(card).toContainText("Utility plans needing renewal");
+      await expect(
+        page.getByTestId(`utility-plan-alert-${planId}`),
+      ).toContainText(propertyName);
+
+      // 6) DELETE through the UI; the row goes and the API agrees.
+      await page.goto("/utility-plans");
+      await waitForListPage(page);
+      await page.getByTestId(`utility-plan-delete-${planId}`).click();
+      await expect(page.getByTestId(`utility-plan-item-${planId}`)).toBeHidden({
+        timeout: 10000,
+      });
+
+      const afterDelete = await api.get(`/utility-plans/${planId}`);
+      expect(afterDelete.status()).toBe(404);
+      planId = null;
+    } finally {
+      if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+
+  test("a regulated plan is recorded without a renewal alert", async ({
+    authedPage: page,
+    api,
+  }) => {
+    // Houston natural gas is a monopoly — there is no competing supplier, so
+    // flagging it for renewal would be pure noise. This is the case the
+    // rate-type hint in the dialog exists to explain.
+    const runId = Date.now();
+    const propertyName = `E2E Gas Property ${runId}`;
+    const providerName = `E2E Gas Co ${runId}`;
+    let propertyId: string | null = null;
+    let planId: string | null = null;
+
+    try {
+      const property = await createProperty(api, { name: propertyName });
+      propertyId = property.id;
+
+      await page.goto("/utility-plans");
+      await waitForListPage(page);
+
+      await page.getByTestId("add-utility-plan-button").click();
+      await page.getByTestId("utility-plan-property-select").selectOption({ label: propertyName });
+      await page.getByTestId("utility-plan-service-select").selectOption("natural_gas");
+      await page.getByTestId("utility-plan-rate-type-select").selectOption("regulated");
+      await expect(page.getByTestId("utility-plan-rate-hint")).toContainText(
+        "no renewal alert",
+      );
+      await page.getByTestId("utility-plan-provider-input").fill(providerName);
+      await page.getByTestId("utility-plan-account-input").fill("6403771807-5");
+      await page.getByTestId("utility-plan-save-button").click();
+
+      await expect(page.getByTestId("add-utility-plan-dialog")).toBeHidden({ timeout: 10000 });
+      await page.waitForLoadState("networkidle");
+
+      const row = page.locator('[data-testid^="utility-plan-item-"]', {
+        hasText: providerName,
+      });
+      await expect(row).toBeVisible({ timeout: 10000 });
+      await expect(row.getByTestId("utility-plan-status-not_applicable")).toBeVisible();
+
+      const testId = await row.getAttribute("data-testid");
+      planId = testId?.replace("utility-plan-item-", "") ?? null;
+      if (!planId) throw new Error("Could not parse plan id from the row");
+
+      // Absent from the alerts payload entirely.
+      const alerts = await fetchAlerts(api);
+      const flagged = [...alerts.expired, ...alerts.expiring_soon];
+      expect(flagged.some((p) => p.id === planId)).toBe(false);
+
+      // And the "needs renewing" filter excludes it.
+      await page.getByTestId("utility-plans-expiring-toggle").check();
+      await expect(page.getByTestId(`utility-plan-item-${planId}`)).toBeHidden();
+    } finally {
+      if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/src/App.tsx
+++ b/apps/mybookkeeper/frontend/src/App.tsx
@@ -38,6 +38,7 @@ import VendorDetail from "@/app/pages/VendorDetail";
 import ReplyTemplates from "@/app/pages/ReplyTemplates";
 import InsurancePolicies from "@/app/pages/InsurancePolicies";
 import InsurancePolicyDetail from "@/app/pages/InsurancePolicyDetail";
+import UtilityPlans from "@/app/pages/UtilityPlans";
 import TaxReport from "@/app/pages/TaxReport";
 import Integrations from "@/app/pages/Integrations";
 import Members from "@/app/pages/Members";
@@ -138,6 +139,7 @@ export default function App() {
               <Route path="vendors/:vendorId" element={<VendorDetail />} />
               <Route path="insurance-policies" element={<InsurancePolicies />} />
               <Route path="insurance-policies/:policyId" element={<InsurancePolicyDetail />} />
+              <Route path="utility-plans" element={<UtilityPlans />} />
               <Route path="reply-templates" element={<ReplyTemplates />} />
               <Route path="reconciliation" element={<Reconciliation />} />
               <Route path="tax" element={<TaxReport />} />

--- a/apps/mybookkeeper/frontend/src/__tests__/UtilityPlanRenewalAlertCard.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/UtilityPlanRenewalAlertCard.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Unit tests for the dashboard utility-plan renewal card.
+ *
+ * The behaviour worth protecting is when the card is *absent*: it must
+ * disappear for operators who track no plans (an always-empty dashboard card
+ * is noise) while still saying "nothing is due" for operators who do — silence
+ * and "all clear" are different messages.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { store } from "@/shared/store";
+import UtilityPlanRenewalAlertCard from "@/app/features/utility/UtilityPlanRenewalAlertCard";
+import type { UtilityPlanRenewalAlert } from "@/shared/types/utility/utility-plan-renewal-alert";
+import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockRefetch = vi.fn();
+let mockAlerts: UtilityPlanRenewalAlert | undefined;
+let mockAlertsLoading = false;
+let mockAlertsError = false;
+let mockPlanTotal = 0;
+let mockPlansLoading = false;
+
+vi.mock("@/shared/store/utilityPlansApi", () => ({
+  useGetUtilityPlanRenewalAlertsQuery: vi.fn(() => ({
+    data: mockAlerts,
+    isLoading: mockAlertsLoading,
+    isError: mockAlertsError,
+    isFetching: false,
+    refetch: mockRefetch,
+  })),
+  useGetUtilityPlansQuery: vi.fn(() => ({
+    data: { items: [], total: mockPlanTotal, has_more: false },
+    isLoading: mockPlansLoading,
+  })),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+function makePlan(overrides: Partial<UtilityPlanSummary> = {}): UtilityPlanSummary {
+  return {
+    id: "plan-a",
+    property_id: "prop-1",
+    property_name: "6738 Peerless St",
+    service_type: "electricity",
+    provider_name: "Constellation",
+    plan_name: "FIXED Electricity Plan",
+    rate_type: "fixed",
+    avg_price_cents_per_kwh_at_1000: "13.9000",
+    term_end_date: "2026-01-27",
+    days_until_term_end: -192,
+    renewal_status: "expired",
+    is_current: true,
+    created_at: "2025-01-27T00:00:00Z",
+    updated_at: "2025-01-27T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderCard() {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <UtilityPlanRenewalAlertCard />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAlerts = undefined;
+  mockAlertsLoading = false;
+  mockAlertsError = false;
+  mockPlanTotal = 0;
+  mockPlansLoading = false;
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("UtilityPlanRenewalAlertCard — when it renders at all", () => {
+  it("renders nothing when the operator tracks no utility plans", () => {
+    mockPlanTotal = 0;
+    mockAlerts = { window_days: 45, expired: [], expiring_soon: [], total_needing_attention: 0 };
+
+    const { container } = renderCard();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("states the all-clear once at least one plan is tracked", () => {
+    mockPlanTotal = 5;
+    mockAlerts = { window_days: 45, expired: [], expiring_soon: [], total_needing_attention: 0 };
+
+    renderCard();
+
+    expect(screen.getByTestId("utility-plan-alert-card-clear")).toHaveTextContent(
+      "No utility plans need renewing in the next 45 days.",
+    );
+  });
+
+  it("shows a skeleton matching the loaded card while loading", () => {
+    mockAlertsLoading = true;
+
+    renderCard();
+
+    const skeleton = screen.getByTestId("utility-plan-alert-card-loading");
+    expect(skeleton).toHaveAttribute("aria-busy", "true");
+    // Two placeholder rows, each ending in a badge slot — the loaded shape.
+    expect(skeleton.querySelectorAll(".rounded-full")).toHaveLength(2);
+  });
+
+  it("offers a retry when the alerts query fails", async () => {
+    mockAlertsError = true;
+    mockPlanTotal = 3;
+    const user = userEvent.setup();
+
+    renderCard();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("UtilityPlanRenewalAlertCard — alerts", () => {
+  beforeEach(() => {
+    mockPlanTotal = 5;
+  });
+
+  it("leads with lapsed plans and explains why they matter", () => {
+    mockAlerts = {
+      window_days: 45,
+      expired: [makePlan({ id: "plan-expired" })],
+      expiring_soon: [
+        makePlan({ id: "plan-soon", renewal_status: "expiring_soon", days_until_term_end: 12 }),
+      ],
+      total_needing_attention: 2,
+    };
+
+    renderCard();
+
+    expect(screen.getByTestId("utility-plan-alert-card")).toHaveTextContent(
+      "Utility plans needing renewal (2)",
+    );
+    expect(screen.getByText("Already lapsed — likely on a holdover rate")).toBeInTheDocument();
+    expect(screen.getByTestId("utility-plan-alert-plan-expired")).toHaveTextContent(
+      "Lapsed 192 days ago",
+    );
+    expect(screen.getByTestId("utility-plan-alert-plan-soon")).toHaveTextContent(
+      "Ends in 12 days",
+    );
+  });
+
+  it("omits the lapsed section entirely when nothing has lapsed", () => {
+    mockAlerts = {
+      window_days: 45,
+      expired: [],
+      expiring_soon: [
+        makePlan({ id: "plan-soon", renewal_status: "expiring_soon", days_until_term_end: 12 }),
+      ],
+      total_needing_attention: 1,
+    };
+
+    renderCard();
+
+    expect(
+      screen.queryByText("Already lapsed — likely on a holdover rate"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Expiring within 45 days")).toBeInTheDocument();
+  });
+
+  it("uses the backend's window rather than a hardcoded number", () => {
+    mockAlerts = {
+      window_days: 60,
+      expired: [],
+      expiring_soon: [makePlan({ renewal_status: "expiring_soon", days_until_term_end: 50 })],
+      total_needing_attention: 1,
+    };
+
+    renderCard();
+
+    expect(screen.getByText("Expiring within 60 days")).toBeInTheDocument();
+  });
+
+  it("links through to the full list", () => {
+    mockAlerts = {
+      window_days: 45,
+      expired: [makePlan()],
+      expiring_soon: [],
+      total_needing_attention: 1,
+    };
+
+    renderCard();
+
+    expect(screen.getByRole("link", { name: "View all" })).toHaveAttribute(
+      "href",
+      "/utility-plans",
+    );
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/UtilityPlans.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/UtilityPlans.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for the UtilityPlans list page.
+ *
+ * Verifies:
+ * - Loading skeleton mirrors the loaded row structure
+ * - Error state with retry
+ * - Empty states (all plans / needs-renewing filter active)
+ * - Rows render provider, rate, term countdown and status badge
+ * - The "needs renewing" filter keys off derived status, not the raw date
+ * - Superseded plans stay listed but are marked as history
+ * - Delete surfaces success and failure
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { store } from "@/shared/store";
+import UtilityPlans from "@/app/pages/UtilityPlans";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockRefetch = vi.fn();
+const mockDeleteUnwrap = vi.fn();
+let mockIsLoading = false;
+let mockIsError = false;
+let mockIsFetching = false;
+let mockPlans: UtilityPlanSummary[] = [];
+
+vi.mock("@/shared/store/utilityPlansApi", () => ({
+  useGetUtilityPlansQuery: vi.fn(() => ({
+    data: { items: mockPlans, total: mockPlans.length, has_more: false },
+    isLoading: mockIsLoading,
+    isError: mockIsError,
+    isFetching: mockIsFetching,
+    refetch: mockRefetch,
+  })),
+  useDeleteUtilityPlanMutation: vi.fn(() => [
+    vi.fn(() => ({ unwrap: mockDeleteUnwrap })),
+    { isLoading: false },
+  ]),
+  useCreateUtilityPlanMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useGetUtilityPlanRenewalAlertsQuery: vi.fn(() => ({ data: undefined })),
+}));
+
+vi.mock("@/shared/store/propertiesApi", () => ({
+  useGetPropertiesQuery: vi.fn(() => ({ data: [{ id: "prop-1", name: "6738 Peerless St" }] })),
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+function makePlan(overrides: Partial<UtilityPlanSummary> = {}): UtilityPlanSummary {
+  return {
+    id: "plan-a",
+    property_id: "prop-1",
+    property_name: "6738 Peerless St",
+    service_type: "electricity",
+    provider_name: "Constellation",
+    plan_name: "FIXED Electricity Plan",
+    rate_type: "fixed",
+    avg_price_cents_per_kwh_at_1000: "13.9000",
+    term_end_date: "2026-01-27",
+    days_until_term_end: -192,
+    renewal_status: "expired",
+    is_current: true,
+    created_at: "2025-01-27T00:00:00Z",
+    updated_at: "2025-01-27T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const GAS_PLAN = makePlan({
+  id: "plan-gas",
+  property_name: "6734 Peerless St",
+  service_type: "natural_gas",
+  provider_name: "CenterPoint Energy",
+  plan_name: null,
+  rate_type: "regulated",
+  avg_price_cents_per_kwh_at_1000: null,
+  term_end_date: null,
+  days_until_term_end: null,
+  renewal_status: "not_applicable",
+});
+
+function renderPage() {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <UtilityPlans />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsLoading = false;
+  mockIsError = false;
+  mockIsFetching = false;
+  mockPlans = [];
+  mockDeleteUnwrap.mockResolvedValue(undefined);
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("UtilityPlans — load states", () => {
+  it("shows a skeleton whose rows match the loaded row shape", () => {
+    mockIsLoading = true;
+
+    renderPage();
+
+    const skeleton = screen.getByTestId("utility-plans-loading");
+    expect(skeleton).toHaveAttribute("aria-busy", "true");
+    // Three placeholder rows, each with a badge slot on the right — same shape
+    // as a loaded row, so nothing shifts when the data arrives.
+    expect(skeleton.querySelectorAll(".rounded-full")).toHaveLength(3);
+  });
+
+  it("offers a retry when the query fails", async () => {
+    mockIsError = true;
+    const user = userEvent.setup();
+
+    renderPage();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("prompts the operator to add a plan when there are none", () => {
+    renderPage();
+
+    expect(screen.getByTestId("utility-plans-empty")).toHaveTextContent(
+      "No utility plans yet",
+    );
+  });
+});
+
+describe("UtilityPlans — rows", () => {
+  it("renders provider, rate and how long ago the term lapsed", () => {
+    mockPlans = [makePlan()];
+
+    renderPage();
+
+    const row = screen.getByTestId("utility-plan-item-plan-a");
+    expect(row).toHaveTextContent("6738 Peerless St");
+    expect(row).toHaveTextContent("Electricity");
+    expect(row).toHaveTextContent("Constellation");
+    expect(row).toHaveTextContent("13.9¢/kWh at 1,000 kWh");
+    expect(row).toHaveTextContent("Lapsed 192 days ago");
+    expect(screen.getByTestId("utility-plan-status-expired")).toBeInTheDocument();
+  });
+
+  it("marks a superseded plan as history instead of hiding it", () => {
+    // The previous rate is the baseline a new offer is measured against, so it
+    // must stay visible — but it must not read as the live contract.
+    mockPlans = [makePlan({ id: "plan-old", is_current: false })];
+
+    renderPage();
+
+    expect(screen.getByTestId("utility-plan-item-plan-old")).toHaveTextContent(
+      "Superseded — kept for rate history",
+    );
+  });
+
+  it("renders a regulated plan with no term as not-applicable", () => {
+    mockPlans = [GAS_PLAN];
+
+    renderPage();
+
+    expect(screen.getByTestId("utility-plan-status-not_applicable")).toBeInTheDocument();
+    expect(screen.getByTestId("utility-plan-item-plan-gas")).not.toHaveTextContent(
+      "Term ends",
+    );
+  });
+});
+
+describe("UtilityPlans — needs-renewing filter", () => {
+  it("keeps only current plans whose derived status is actionable", async () => {
+    const user = userEvent.setup();
+    mockPlans = [
+      makePlan({ id: "plan-expired" }),
+      makePlan({ id: "plan-soon", renewal_status: "expiring_soon", days_until_term_end: 12 }),
+      makePlan({ id: "plan-active", renewal_status: "active", days_until_term_end: 300 }),
+      // Regulated gas has a provider monopoly — nothing to renew, so it must
+      // not be swept in even though it is current.
+      GAS_PLAN,
+      // Already superseded: its lapse is history, not an action.
+      makePlan({ id: "plan-old", is_current: false }),
+    ];
+
+    renderPage();
+    await user.click(screen.getByTestId("utility-plans-expiring-toggle"));
+
+    expect(screen.getByTestId("utility-plan-item-plan-expired")).toBeInTheDocument();
+    expect(screen.getByTestId("utility-plan-item-plan-soon")).toBeInTheDocument();
+    expect(screen.queryByTestId("utility-plan-item-plan-active")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("utility-plan-item-plan-gas")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("utility-plan-item-plan-old")).not.toBeInTheDocument();
+  });
+
+  it("says nothing needs renewing when the filter empties the list", async () => {
+    const user = userEvent.setup();
+    mockPlans = [makePlan({ renewal_status: "active", days_until_term_end: 300 })];
+
+    renderPage();
+    await user.click(screen.getByTestId("utility-plans-expiring-toggle"));
+
+    expect(screen.getByTestId("utility-plans-empty")).toHaveTextContent(
+      "No plans are expiring soon",
+    );
+  });
+});
+
+describe("UtilityPlans — delete", () => {
+  it("confirms removal on success", async () => {
+    const user = userEvent.setup();
+    mockPlans = [makePlan()];
+
+    renderPage();
+    await user.click(screen.getByTestId("utility-plan-delete-plan-a"));
+
+    await waitFor(() => expect(showSuccess).toHaveBeenCalledWith("Utility plan removed."));
+  });
+
+  it("surfaces a failure instead of silently leaving the row", async () => {
+    const user = userEvent.setup();
+    mockPlans = [makePlan()];
+    mockDeleteUnwrap.mockRejectedValue(new Error("boom"));
+
+    renderPage();
+    await user.click(screen.getByTestId("utility-plan-delete-plan-a"));
+
+    await waitFor(() =>
+      expect(showError).toHaveBeenCalledWith("Couldn't remove the plan. Please try again."),
+    );
+  });
+});
+
+describe("UtilityPlans — add dialog", () => {
+  it("opens on the Add plan button", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+    await user.click(screen.getByTestId("add-utility-plan-button"));
+
+    expect(screen.getByTestId("add-utility-plan-dialog")).toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/utility-plan-format.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/utility-plan-format.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the utility-plan display helpers.
+ *
+ * These parse the rate strings the backend sends (``Numeric`` serializes as a
+ * JSON string, not a number). Getting that wrong is silent: a mis-parse shows
+ * a plausible-looking price that is simply not the contracted rate.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  formatCents,
+  formatCentsPerKwh,
+  formatPlanDate,
+  formatRenewalCountdown,
+} from "@/shared/lib/utility-plan-format";
+
+describe("formatCentsPerKwh", () => {
+  it("keeps sub-cent precision", () => {
+    // A TDU charge rounded to 5.35 would misprice every comparison.
+    expect(formatCentsPerKwh("5.3509")).toBe("5.3509¢/kWh");
+  });
+
+  it("drops the trailing zeros the backend pads to four places", () => {
+    expect(formatCentsPerKwh("13.9000")).toBe("13.9¢/kWh");
+  });
+
+  it("renders a whole-number rate without a decimal point", () => {
+    expect(formatCentsPerKwh("12.0000")).toBe("12¢/kWh");
+  });
+
+  it("falls back to a dash for missing or unparseable values", () => {
+    expect(formatCentsPerKwh(null)).toBe("—");
+    expect(formatCentsPerKwh("")).toBe("—");
+    expect(formatCentsPerKwh("not-a-number")).toBe("—");
+  });
+});
+
+describe("formatCents", () => {
+  it("renders integer cents as dollars", () => {
+    expect(formatCents(439)).toBe("$4.39");
+    expect(formatCents(15000)).toBe("$150.00");
+  });
+
+  it("renders a genuine zero rather than a dash", () => {
+    // The Constellation EFL states a minimum-usage fee of 0.00000 — zero is a
+    // recorded fact, not a missing value, and must not read as "unknown".
+    expect(formatCents(0)).toBe("$0.00");
+  });
+
+  it("falls back to a dash when unset", () => {
+    expect(formatCents(null)).toBe("—");
+  });
+});
+
+describe("formatRenewalCountdown", () => {
+  it("reports a lapsed term in the past tense", () => {
+    expect(formatRenewalCountdown(-196)).toBe("Lapsed 196 days ago");
+    expect(formatRenewalCountdown(-1)).toBe("Lapsed 1 day ago");
+  });
+
+  it("calls out the day the term ends", () => {
+    expect(formatRenewalCountdown(0)).toBe("Ends today");
+  });
+
+  it("counts down to a future end date", () => {
+    expect(formatRenewalCountdown(1)).toBe("Ends in 1 day");
+    expect(formatRenewalCountdown(45)).toBe("Ends in 45 days");
+  });
+
+  it("says so when no term end is recorded", () => {
+    expect(formatRenewalCountdown(null)).toBe("No term end recorded");
+  });
+});
+
+describe("formatPlanDate", () => {
+  it("formats an ISO date in the viewer's local timezone", () => {
+    // Parsed as local midnight, not UTC — otherwise a US viewer sees Jan 22
+    // for a term that ended Jan 23.
+    expect(formatPlanDate("2026-01-23")).toBe("Jan 23, 2026");
+  });
+
+  it("falls back to a dash for missing or invalid input", () => {
+    expect(formatPlanDate(null)).toBe("—");
+    expect(formatPlanDate("garbage")).toBe("—");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/DashboardSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/DashboardSkeleton.tsx
@@ -20,6 +20,26 @@ export default function DashboardSkeleton() {
         ))}
       </section>
 
+      {/* Utility plan renewal card — matches UtilityPlanRenewalAlertCard:
+          header row with a title + "View all" link, then two alert rows */}
+      <Card className="overflow-hidden p-0">
+        <div className="flex items-center justify-between px-6 py-4 border-b">
+          <Skeleton className="h-5 w-56" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+        <div className="px-6 py-2 divide-y">
+          {[0, 1].map((i) => (
+            <div key={i} className="flex items-start justify-between gap-3 py-2">
+              <div className="flex-1">
+                <Skeleton className="h-4 w-1/2" />
+                <Skeleton className="h-3 w-2/3 mt-1" />
+              </div>
+              <Skeleton className="h-5 w-20 rounded-full" />
+            </div>
+          ))}
+        </div>
+      </Card>
+
       {/* Monthly Average card — matches MonthlyAverageCard */}
       <Card>
         <div className="flex items-baseline justify-between mb-4">

--- a/apps/mybookkeeper/frontend/src/app/features/utility/AddUtilityPlanDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/AddUtilityPlanDialog.tsx
@@ -1,0 +1,397 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import { Button, LoadingButton } from "@platform/ui";
+import FormField from "@/shared/components/ui/FormField";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { useGetPropertiesQuery } from "@/shared/store/propertiesApi";
+import { useCreateUtilityPlanMutation } from "@/shared/store/utilityPlansApi";
+import {
+  UTILITY_PLAN_RATE_TYPES,
+  UTILITY_PLAN_RATE_TYPE_HINTS,
+  UTILITY_PLAN_RATE_TYPE_LABELS,
+} from "@/shared/types/utility/utility-plan-rate-type";
+import {
+  UTILITY_SERVICE_TYPES,
+  UTILITY_SERVICE_TYPE_LABELS,
+} from "@/shared/types/utility/utility-service-type";
+import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-rate-type";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+export interface AddUtilityPlanDialogProps {
+  onClose: () => void;
+}
+
+const INPUT_CLASS = "w-full px-3 py-2 text-sm border rounded-md";
+
+/** ``""`` → null so an untouched field is absent rather than zero. */
+function optionalText(value: string): string | null {
+  return value.trim() === "" ? null : value.trim();
+}
+
+/**
+ * Dollars → integer cents. Kept separate from the rate fields, which are sent
+ * as strings: a rate carries four decimal places and must not round-trip
+ * through a float.
+ */
+function dollarsToCents(value: string): number | null {
+  if (value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.round(parsed * 100) : null;
+}
+
+function toInt(value: string): number | null {
+  if (value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.round(parsed) : null;
+}
+
+/**
+ * Modal dialog for recording a utility plan against a property.
+ */
+export default function AddUtilityPlanDialog({ onClose }: AddUtilityPlanDialogProps) {
+  const { data: properties = [] } = useGetPropertiesQuery();
+  const [createPlan, { isLoading }] = useCreateUtilityPlanMutation();
+
+  const [propertyId, setPropertyId] = useState("");
+  const [serviceType, setServiceType] = useState<UtilityServiceType>("electricity");
+  const [rateType, setRateType] = useState<UtilityPlanRateType>("fixed");
+  const [providerName, setProviderName] = useState("");
+  const [planName, setPlanName] = useState("");
+  const [accountNumber, setAccountNumber] = useState("");
+
+  const [energyCharge, setEnergyCharge] = useState("");
+  const [tduCharge, setTduCharge] = useState("");
+  const [avgPrice, setAvgPrice] = useState("");
+  const [monthlyBase, setMonthlyBase] = useState("");
+
+  const [termMonths, setTermMonths] = useState("");
+  const [serviceStartDate, setServiceStartDate] = useState("");
+  const [termEndDate, setTermEndDate] = useState("");
+  const [etf, setEtf] = useState("");
+
+  const [hasBillCredit, setHasBillCredit] = useState(false);
+  const [billCreditAmount, setBillCreditAmount] = useState("");
+  const [billCreditThreshold, setBillCreditThreshold] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!propertyId) {
+      showError("Pick a property.");
+      return;
+    }
+    if (!providerName.trim()) {
+      showError("Provider is required.");
+      return;
+    }
+    if (hasBillCredit && (billCreditAmount.trim() === "" || billCreditThreshold.trim() === "")) {
+      // The backend rejects a half-recorded credit too; catching it here saves
+      // a round trip and points at the field rather than the form.
+      showError("A bill credit needs both an amount and a usage threshold.");
+      return;
+    }
+
+    try {
+      await createPlan({
+        property_id: propertyId,
+        service_type: serviceType,
+        rate_type: rateType,
+        provider_name: providerName.trim(),
+        plan_name: optionalText(planName),
+        account_number: optionalText(accountNumber),
+        // Rates stay strings end-to-end so 5.3509 survives intact.
+        energy_charge_cents_per_kwh: optionalText(energyCharge),
+        tdu_charge_cents_per_kwh: optionalText(tduCharge),
+        avg_price_cents_per_kwh_at_1000: optionalText(avgPrice),
+        monthly_base_charge_cents: dollarsToCents(monthlyBase),
+        term_months: toInt(termMonths),
+        service_start_date: serviceStartDate || null,
+        term_end_date: termEndDate || null,
+        early_termination_fee_cents: dollarsToCents(etf),
+        has_bill_credit: hasBillCredit,
+        bill_credit_amount_cents: hasBillCredit ? dollarsToCents(billCreditAmount) : null,
+        bill_credit_threshold_kwh: hasBillCredit ? toInt(billCreditThreshold) : null,
+      }).unwrap();
+      showSuccess("Utility plan added.");
+      onClose();
+    } catch {
+      showError("Couldn't save the plan. Please try again.");
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      data-testid="add-utility-plan-dialog"
+    >
+      <div className="bg-background rounded-lg shadow-lg w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b">
+          <h2 className="text-base font-semibold">Add utility plan</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground min-h-[44px] min-w-[44px] flex items-center justify-center"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="p-5 space-y-4">
+          <FormField label="Property" required>
+            <select
+              value={propertyId}
+              onChange={(e) => setPropertyId(e.target.value)}
+              className={INPUT_CLASS}
+              required
+              data-testid="utility-plan-property-select"
+            >
+              <option value="">Select a property…</option>
+              {properties.map((property) => (
+                <option key={property.id} value={property.id}>
+                  {property.name}
+                </option>
+              ))}
+            </select>
+          </FormField>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FormField label="Service" required>
+              <select
+                value={serviceType}
+                onChange={(e) => setServiceType(e.target.value as UtilityServiceType)}
+                className={INPUT_CLASS}
+                data-testid="utility-plan-service-select"
+              >
+                {UTILITY_SERVICE_TYPES.map((value) => (
+                  <option key={value} value={value}>
+                    {UTILITY_SERVICE_TYPE_LABELS[value]}
+                  </option>
+                ))}
+              </select>
+            </FormField>
+
+            <FormField label="Rate type" required>
+              <select
+                value={rateType}
+                onChange={(e) => setRateType(e.target.value as UtilityPlanRateType)}
+                className={INPUT_CLASS}
+                data-testid="utility-plan-rate-type-select"
+              >
+                {UTILITY_PLAN_RATE_TYPES.map((value) => (
+                  <option key={value} value={value}>
+                    {UTILITY_PLAN_RATE_TYPE_LABELS[value]}
+                  </option>
+                ))}
+              </select>
+            </FormField>
+          </div>
+
+          <p className="text-xs text-muted-foreground -mt-2" data-testid="utility-plan-rate-hint">
+            {UTILITY_PLAN_RATE_TYPE_HINTS[rateType]}
+          </p>
+
+          <FormField label="Provider" required>
+            <input
+              type="text"
+              value={providerName}
+              onChange={(e) => setProviderName(e.target.value)}
+              placeholder="e.g. Constellation"
+              className={INPUT_CLASS}
+              maxLength={255}
+              required
+              data-testid="utility-plan-provider-input"
+            />
+          </FormField>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FormField label="Plan name">
+              <input
+                type="text"
+                value={planName}
+                onChange={(e) => setPlanName(e.target.value)}
+                placeholder="e.g. 12 Month Fixed"
+                className={INPUT_CLASS}
+                maxLength={255}
+                data-testid="utility-plan-name-input"
+              />
+            </FormField>
+
+            <FormField label="Account number">
+              <input
+                type="text"
+                value={accountNumber}
+                onChange={(e) => setAccountNumber(e.target.value)}
+                placeholder="e.g. 6403771807-5"
+                className={INPUT_CLASS}
+                maxLength={100}
+                data-testid="utility-plan-account-input"
+              />
+            </FormField>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FormField label="Energy charge (¢/kWh)">
+              <input
+                type="number"
+                value={energyCharge}
+                onChange={(e) => setEnergyCharge(e.target.value)}
+                placeholder="11.6"
+                min="0"
+                step="0.0001"
+                className={INPUT_CLASS}
+                data-testid="utility-plan-energy-input"
+              />
+            </FormField>
+
+            <FormField label="Delivery / TDU charge (¢/kWh)">
+              <input
+                type="number"
+                value={tduCharge}
+                onChange={(e) => setTduCharge(e.target.value)}
+                placeholder="5.3509"
+                min="0"
+                step="0.0001"
+                className={INPUT_CLASS}
+                data-testid="utility-plan-tdu-input"
+              />
+            </FormField>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FormField label="Average price at 1,000 kWh (¢/kWh)">
+              <input
+                type="number"
+                value={avgPrice}
+                onChange={(e) => setAvgPrice(e.target.value)}
+                placeholder="13.9"
+                min="0"
+                step="0.0001"
+                className={INPUT_CLASS}
+                data-testid="utility-plan-avg-price-input"
+              />
+            </FormField>
+
+            <FormField label="Monthly base charge (USD)">
+              <input
+                type="number"
+                value={monthlyBase}
+                onChange={(e) => setMonthlyBase(e.target.value)}
+                placeholder="4.39"
+                min="0"
+                step="0.01"
+                className={INPUT_CLASS}
+                data-testid="utility-plan-base-charge-input"
+              />
+            </FormField>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <FormField label="Term (months)">
+              <input
+                type="number"
+                value={termMonths}
+                onChange={(e) => setTermMonths(e.target.value)}
+                placeholder="12"
+                min="0"
+                max="600"
+                step="1"
+                className={INPUT_CLASS}
+                data-testid="utility-plan-term-months-input"
+              />
+            </FormField>
+
+            <FormField label="Service start">
+              <input
+                type="date"
+                value={serviceStartDate}
+                onChange={(e) => setServiceStartDate(e.target.value)}
+                className={INPUT_CLASS}
+                data-testid="utility-plan-start-date-input"
+              />
+            </FormField>
+
+            <FormField label="Term ends">
+              <input
+                type="date"
+                value={termEndDate}
+                onChange={(e) => setTermEndDate(e.target.value)}
+                className={INPUT_CLASS}
+                data-testid="utility-plan-end-date-input"
+              />
+            </FormField>
+          </div>
+
+          <FormField label="Early termination fee (USD)">
+            <input
+              type="number"
+              value={etf}
+              onChange={(e) => setEtf(e.target.value)}
+              placeholder="150"
+              min="0"
+              step="0.01"
+              className={INPUT_CLASS}
+              data-testid="utility-plan-etf-input"
+            />
+          </FormField>
+
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={hasBillCredit}
+              onChange={(e) => setHasBillCredit(e.target.checked)}
+              className="rounded"
+              data-testid="utility-plan-bill-credit-toggle"
+            />
+            This plan has a usage-based bill credit
+          </label>
+
+          {hasBillCredit ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <FormField label="Credit amount (USD)" required>
+                <input
+                  type="number"
+                  value={billCreditAmount}
+                  onChange={(e) => setBillCreditAmount(e.target.value)}
+                  placeholder="35"
+                  min="0"
+                  step="0.01"
+                  className={INPUT_CLASS}
+                  data-testid="utility-plan-credit-amount-input"
+                />
+              </FormField>
+
+              <FormField label="Applies at or above (kWh)" required>
+                <input
+                  type="number"
+                  value={billCreditThreshold}
+                  onChange={(e) => setBillCreditThreshold(e.target.value)}
+                  placeholder="1000"
+                  min="0"
+                  step="1"
+                  className={INPUT_CLASS}
+                  data-testid="utility-plan-credit-threshold-input"
+                />
+              </FormField>
+            </div>
+          ) : null}
+
+          <div className="flex gap-3 pt-2 justify-end">
+            <Button type="button" variant="secondary" size="md" onClick={onClose}>
+              Cancel
+            </Button>
+            <LoadingButton
+              type="submit"
+              variant="primary"
+              size="md"
+              isLoading={isLoading}
+              loadingText="Saving..."
+              data-testid="utility-plan-save-button"
+            >
+              Save plan
+            </LoadingButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanAlertCardSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanAlertCardSkeleton.tsx
@@ -1,0 +1,29 @@
+/**
+ * Loading placeholder for the dashboard renewal card.
+ *
+ * Mirrors the loaded card exactly — same Card chrome, a heading line, and two
+ * rows each with a two-line left block and a badge on the right — so the
+ * dashboard does not shift when the alerts land.
+ */
+export default function UtilityPlanAlertCardSkeleton() {
+  return (
+    <div
+      className="bg-card border rounded-lg p-6 animate-pulse"
+      aria-busy="true"
+      data-testid="utility-plan-alert-card-loading"
+    >
+      <div className="h-5 bg-muted rounded w-48 mb-4" />
+      <ul className="divide-y">
+        {[1, 2].map((i) => (
+          <li key={i} className="flex items-start justify-between gap-3 py-2">
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="h-4 bg-muted rounded w-1/2" />
+              <div className="h-3 bg-muted rounded w-2/3" />
+            </div>
+            <div className="h-5 w-20 bg-muted rounded-full shrink-0" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanAlertRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanAlertRow.tsx
@@ -1,0 +1,32 @@
+import { formatPlanDate, formatRenewalCountdown } from "@/shared/lib/utility-plan-format";
+import { UTILITY_SERVICE_TYPE_LABELS } from "@/shared/types/utility/utility-service-type";
+import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
+import UtilityPlanRenewalBadge from "./UtilityPlanRenewalBadge";
+
+export interface UtilityPlanAlertRowProps {
+  plan: UtilityPlanSummary;
+}
+
+export default function UtilityPlanAlertRow({ plan }: UtilityPlanAlertRowProps) {
+  return (
+    <li
+      className="flex items-start justify-between gap-3 py-2"
+      data-testid={`utility-plan-alert-${plan.id}`}
+    >
+      <div className="min-w-0">
+        <p className="text-sm font-medium truncate">
+          {plan.property_name ?? "Unknown property"}
+          <span className="text-muted-foreground font-normal">
+            {" · "}
+            {UTILITY_SERVICE_TYPE_LABELS[plan.service_type]}
+          </span>
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5 truncate">
+          {plan.provider_name} · {formatRenewalCountdown(plan.days_until_term_end)} (
+          {formatPlanDate(plan.term_end_date)})
+        </p>
+      </div>
+      <UtilityPlanRenewalBadge status={plan.renewal_status} />
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRenewalAlertCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRenewalAlertCard.tsx
@@ -1,0 +1,111 @@
+import { Link } from "react-router-dom";
+import AlertBox from "@/shared/components/ui/AlertBox";
+import Card from "@/shared/components/ui/Card";
+import {
+  useGetUtilityPlanRenewalAlertsQuery,
+  useGetUtilityPlansQuery,
+} from "@/shared/store/utilityPlansApi";
+import UtilityPlanAlertRow from "./UtilityPlanAlertRow";
+import UtilityPlanAlertCardSkeleton from "./UtilityPlanAlertCardSkeleton";
+import { useUtilityPlanAlertCardMode } from "./useUtilityPlanAlertCardMode";
+
+/**
+ * Dashboard card for utility plans whose fixed term has lapsed or is about to.
+ *
+ * Fetches its own data so the dashboard only has to place it. Expired plans
+ * lead: an expired term means the account has almost certainly rolled onto a
+ * holdover variable rate and is already costing money, whereas an
+ * expiring-soon one is still just a deadline.
+ */
+export default function UtilityPlanRenewalAlertCard() {
+  const { data, isLoading, isError, refetch, isFetching } =
+    useGetUtilityPlanRenewalAlertsQuery();
+  // One page is enough to answer "do they track any plans at all?", which is
+  // all this drives — the card hides itself for operators who track none.
+  const { data: plansPage, isLoading: isPlansLoading } = useGetUtilityPlansQuery({ limit: 1 });
+
+  const mode = useUtilityPlanAlertCardMode({
+    isLoading: isLoading || isPlansLoading,
+    isError,
+    totalNeedingAttention: data?.total_needing_attention,
+    hasAnyPlans: (plansPage?.total ?? 0) > 0,
+  });
+
+  if (mode === "loading") return <UtilityPlanAlertCardSkeleton />;
+  if (mode === "hidden") return null;
+
+  if (mode === "error") {
+    return (
+      <AlertBox variant="error" className="flex items-center justify-between gap-3">
+        <span>Couldn't check utility plan renewals.</span>
+        <button
+          type="button"
+          onClick={() => void refetch()}
+          className="text-sm font-medium hover:underline"
+        >
+          {isFetching ? "Retrying..." : "Retry"}
+        </button>
+      </AlertBox>
+    );
+  }
+
+  if (mode === "clear") {
+    return (
+      <Card title="Utility plans" className="text-sm text-muted-foreground">
+        <p data-testid="utility-plan-alert-card-clear">
+          No utility plans need renewing in the next {data?.window_days ?? 45} days.
+        </p>
+      </Card>
+    );
+  }
+
+  const expired = data?.expired ?? [];
+  const expiringSoon = data?.expiring_soon ?? [];
+
+  return (
+    <Card className="p-0 overflow-hidden">
+      <div
+        className="flex items-center justify-between gap-3 px-6 py-4 border-b"
+        data-testid="utility-plan-alert-card"
+      >
+        <h2 className="text-base font-medium">
+          Utility plans needing renewal ({data?.total_needing_attention ?? 0})
+        </h2>
+        <Link
+          to="/utility-plans"
+          className="text-sm font-medium text-primary hover:underline shrink-0"
+        >
+          View all
+        </Link>
+      </div>
+
+      <div className="px-6 py-2">
+        {expired.length > 0 ? (
+          <section>
+            <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground pt-2">
+              Already lapsed — likely on a holdover rate
+            </h3>
+            <ul className="divide-y">
+              {expired.map((plan) => (
+                <UtilityPlanAlertRow key={plan.id} plan={plan} />
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
+        {expiringSoon.length > 0 ? (
+          <section>
+            <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground pt-2">
+              Expiring within {data?.window_days ?? 45} days
+            </h3>
+            <ul className="divide-y">
+              {expiringSoon.map((plan) => (
+                <UtilityPlanAlertRow key={plan.id} plan={plan} />
+              ))}
+            </ul>
+          </section>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRenewalBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRenewalBadge.tsx
@@ -1,0 +1,25 @@
+import {
+  UTILITY_PLAN_RENEWAL_STATUS_CLASSES,
+  UTILITY_PLAN_RENEWAL_STATUS_LABELS,
+} from "@/shared/types/utility/utility-plan-renewal-status";
+import type { UtilityPlanRenewalStatus } from "@/shared/types/utility/utility-plan-renewal-status";
+
+export interface UtilityPlanRenewalBadgeProps {
+  status: UtilityPlanRenewalStatus;
+}
+
+/**
+ * Renewal-status pill. The status is computed by the backend from the term end
+ * date and today — never recomputed here, so the badge cannot disagree with
+ * the alert that put the plan on the dashboard.
+ */
+export default function UtilityPlanRenewalBadge({ status }: UtilityPlanRenewalBadgeProps) {
+  return (
+    <span
+      className={`shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${UTILITY_PLAN_RENEWAL_STATUS_CLASSES[status]}`}
+      data-testid={`utility-plan-status-${status}`}
+    >
+      {UTILITY_PLAN_RENEWAL_STATUS_LABELS[status]}
+    </span>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRow.tsx
@@ -1,0 +1,74 @@
+import { Trash2 } from "lucide-react";
+import {
+  formatCentsPerKwh,
+  formatPlanDate,
+  formatRenewalCountdown,
+} from "@/shared/lib/utility-plan-format";
+import { UTILITY_PLAN_RATE_TYPE_LABELS } from "@/shared/types/utility/utility-plan-rate-type";
+import { UTILITY_SERVICE_TYPE_LABELS } from "@/shared/types/utility/utility-service-type";
+import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
+import UtilityPlanRenewalBadge from "./UtilityPlanRenewalBadge";
+
+export interface UtilityPlanRowProps {
+  plan: UtilityPlanSummary;
+  isDeleting: boolean;
+  onDelete: (plan: UtilityPlanSummary) => void;
+}
+
+export default function UtilityPlanRow({ plan, isDeleting, onDelete }: UtilityPlanRowProps) {
+  return (
+    <li
+      className="border rounded-lg px-4 py-3 text-sm"
+      data-testid={`utility-plan-item-${plan.id}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="font-medium truncate">
+            {plan.property_name ?? "Unknown property"}
+            <span className="text-muted-foreground font-normal">
+              {" · "}
+              {UTILITY_SERVICE_TYPE_LABELS[plan.service_type]}
+            </span>
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5 truncate">
+            {plan.provider_name}
+            {plan.plan_name ? ` — ${plan.plan_name}` : ""}
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {UTILITY_PLAN_RATE_TYPE_LABELS[plan.rate_type]}
+            {plan.avg_price_cents_per_kwh_at_1000
+              ? ` · ${formatCentsPerKwh(plan.avg_price_cents_per_kwh_at_1000)} at 1,000 kWh`
+              : ""}
+          </p>
+          {plan.term_end_date ? (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Term ends {formatPlanDate(plan.term_end_date)} ·{" "}
+              {formatRenewalCountdown(plan.days_until_term_end)}
+            </p>
+          ) : null}
+          {/* A superseded plan is kept as the baseline a new rate is measured
+              against, so it stays visible — but it must not read as live. */}
+          {plan.is_current ? null : (
+            <p className="text-xs text-muted-foreground mt-0.5 italic">
+              Superseded — kept for rate history
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <UtilityPlanRenewalBadge status={plan.renewal_status} />
+          <button
+            type="button"
+            onClick={() => onDelete(plan)}
+            disabled={isDeleting}
+            aria-label={`Delete ${plan.provider_name} plan`}
+            className="text-muted-foreground hover:text-red-600 disabled:opacity-50 min-h-[44px] min-w-[44px] flex items-center justify-center"
+            data-testid={`utility-plan-delete-${plan.id}`}
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlansListBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlansListBody.tsx
@@ -1,0 +1,66 @@
+import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
+import type { UtilityPlansListMode } from "@/shared/types/utility/utility-plans-list-mode";
+import UtilityPlanRow from "./UtilityPlanRow";
+
+export interface UtilityPlansListBodyProps {
+  mode: UtilityPlansListMode;
+  plans: UtilityPlanSummary[];
+  showExpiringOnly: boolean;
+  deletingPlanId: string | null;
+  onDelete: (plan: UtilityPlanSummary) => void;
+}
+
+export default function UtilityPlansListBody({
+  mode,
+  plans,
+  showExpiringOnly,
+  deletingPlanId,
+  onDelete,
+}: UtilityPlansListBodyProps) {
+  switch (mode) {
+    case "loading":
+      return (
+        // Mirrors the loaded row: two-line left block plus a badge on the
+        // right, so nothing shifts when the data lands.
+        <div
+          className="space-y-2 animate-pulse"
+          aria-busy="true"
+          data-testid="utility-plans-loading"
+        >
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="border rounded-lg px-4 py-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1 space-y-2">
+                  <div className="h-4 bg-muted rounded w-1/2" />
+                  <div className="h-3 bg-muted rounded w-1/3" />
+                  <div className="h-3 bg-muted rounded w-2/5" />
+                </div>
+                <div className="h-5 w-20 bg-muted rounded-full shrink-0" />
+              </div>
+            </div>
+          ))}
+        </div>
+      );
+    case "empty":
+      return (
+        <p className="text-sm text-muted-foreground" data-testid="utility-plans-empty">
+          {showExpiringOnly
+            ? "No plans are expiring soon — nothing needs renewing right now."
+            : "No utility plans yet — add one to get warned before a fixed rate lapses."}
+        </p>
+      );
+    case "list":
+      return (
+        <ul className="space-y-2" data-testid="utility-plans-list">
+          {plans.map((plan) => (
+            <UtilityPlanRow
+              key={plan.id}
+              plan={plan}
+              isDeleting={deletingPlanId === plan.id}
+              onDelete={onDelete}
+            />
+          ))}
+        </ul>
+      );
+  }
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlanAlertCardMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlanAlertCardMode.ts
@@ -1,0 +1,31 @@
+import type { UtilityPlanAlertCardMode } from "@/shared/types/utility/utility-plan-alert-card-mode";
+
+interface UseUtilityPlanAlertCardModeArgs {
+  isLoading: boolean;
+  isError: boolean;
+  /** Undefined until the alerts query resolves. */
+  totalNeedingAttention: number | undefined;
+  /** Whether the operator tracks any plans at all. */
+  hasAnyPlans: boolean;
+}
+
+/**
+ * Resolves what the dashboard renewal card should render.
+ *
+ * The ``hidden`` case is the important one: an operator who tracks no utility
+ * plans should not see a permanently empty card on their dashboard. Once they
+ * track at least one, the card stays visible even when nothing is due, so
+ * "nothing is wrong" is stated rather than merely implied by absence.
+ */
+export function useUtilityPlanAlertCardMode({
+  isLoading,
+  isError,
+  totalNeedingAttention,
+  hasAnyPlans,
+}: UseUtilityPlanAlertCardModeArgs): UtilityPlanAlertCardMode {
+  if (isLoading) return "loading";
+  if (isError) return "error";
+  if (!hasAnyPlans) return "hidden";
+  if ((totalNeedingAttention ?? 0) === 0) return "clear";
+  return "alerts";
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlansListMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlansListMode.ts
@@ -1,0 +1,19 @@
+import type { UtilityPlansListMode } from "@/shared/types/utility/utility-plans-list-mode";
+
+interface UseUtilityPlansListModeArgs {
+  isLoading: boolean;
+  planCount: number;
+}
+
+/**
+ * Resolves the utility-plans list render mode. Single source of truth so the
+ * body is a flat switch instead of a ternary chain.
+ */
+export function useUtilityPlansListMode({
+  isLoading,
+  planCount,
+}: UseUtilityPlansListModeArgs): UtilityPlansListMode {
+  if (isLoading) return "loading";
+  if (planCount === 0) return "empty";
+  return "list";
+}

--- a/apps/mybookkeeper/frontend/src/app/lib/nav.ts
+++ b/apps/mybookkeeper/frontend/src/app/lib/nav.ts
@@ -18,6 +18,7 @@ export const NAV_GROUPS: readonly NavGroup[] = [
       { to: "/listings", label: "Listings" },
       { to: "/welcome-manuals", label: "Welcome Manuals" },
       { to: "/insurance-policies", label: "Insurance" },
+      { to: "/utility-plans", label: "Utility Plans" },
       { to: "/calendar", label: "Calendar" },
     ],
   },

--- a/apps/mybookkeeper/frontend/src/app/pages/Dashboard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Dashboard.tsx
@@ -27,6 +27,7 @@ import Card from "@/shared/components/ui/Card";
 import SectionHeader from "@/shared/components/ui/SectionHeader";
 import PropertyPnLGrid from "@/app/features/attribution/PropertyPnLGrid";
 import PnLDateRangeSelector from "@/app/features/attribution/PnLDateRangeSelector";
+import UtilityPlanRenewalAlertCard from "@/app/features/utility/UtilityPlanRenewalAlertCard";
 
 function getThisMonthRange(): { since: string; until: string } {
   const now = new Date();
@@ -185,6 +186,11 @@ export default function Dashboard() {
           }
         />
       </section>
+
+      {/* Sits high on the page and outside the isEmpty branch: a lapsed rate
+          plan costs money whether or not any transactions have been imported
+          yet, so it must not be hidden behind the no-data empty state. */}
+      <UtilityPlanRenewalAlertCard />
 
       {!isEmpty && (filteredSummary?.by_month?.length ?? 0) > 0 && (
         <MonthlyAverageCard byMonth={filteredSummary?.by_month ?? []} />

--- a/apps/mybookkeeper/frontend/src/app/pages/UtilityPlans.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/UtilityPlans.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { Button } from "@platform/ui";
+import AlertBox from "@/shared/components/ui/AlertBox";
+import SectionHeader from "@/shared/components/ui/SectionHeader";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import {
+  useDeleteUtilityPlanMutation,
+  useGetUtilityPlansQuery,
+} from "@/shared/store/utilityPlansApi";
+import AddUtilityPlanDialog from "@/app/features/utility/AddUtilityPlanDialog";
+import UtilityPlansListBody from "@/app/features/utility/UtilityPlansListBody";
+import { useUtilityPlansListMode } from "@/app/features/utility/useUtilityPlansListMode";
+import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
+
+/**
+ * All-plans view: every utility contract across every property.
+ *
+ * The list intentionally includes superseded plans — the previous rate is what
+ * a new offer gets compared against — so each row says whether it is current.
+ */
+export default function UtilityPlans() {
+  const [showExpiringOnly, setShowExpiringOnly] = useState(false);
+  const [showAddDialog, setShowAddDialog] = useState(false);
+  const [deletingPlanId, setDeletingPlanId] = useState<string | null>(null);
+
+  const { data, isLoading, isError, isFetching, refetch } = useGetUtilityPlansQuery({});
+  const [deletePlan] = useDeleteUtilityPlanMutation();
+
+  const allPlans = data?.items ?? [];
+  // Filtered client-side rather than through ``expiring_before``: the server
+  // filter keys off the raw date, but what the operator means by "needs
+  // attention" is the derived status, which already accounts for rate type —
+  // a regulated plan has no renewal to act on.
+  const plans = showExpiringOnly
+    ? allPlans.filter(
+        (plan) =>
+          plan.is_current &&
+          (plan.renewal_status === "expired" || plan.renewal_status === "expiring_soon"),
+      )
+    : allPlans;
+
+  const mode = useUtilityPlansListMode({ isLoading, planCount: plans.length });
+
+  async function handleDelete(plan: UtilityPlanSummary) {
+    setDeletingPlanId(plan.id);
+    try {
+      await deletePlan(plan.id).unwrap();
+      showSuccess("Utility plan removed.");
+    } catch {
+      showError("Couldn't remove the plan. Please try again.");
+    } finally {
+      setDeletingPlanId(null);
+    }
+  }
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <SectionHeader
+        title="Utility Plans"
+        subtitle="Track what each property pays for power and gas, and get warned before a fixed rate lapses."
+        actions={
+          <Button
+            type="button"
+            variant="primary"
+            size="md"
+            onClick={() => setShowAddDialog(true)}
+            data-testid="add-utility-plan-button"
+          >
+            Add plan
+          </Button>
+        }
+      />
+
+      {isError ? (
+        <AlertBox variant="error" className="flex items-center justify-between gap-3">
+          <span>Couldn't load utility plans.</span>
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="text-sm font-medium hover:underline"
+          >
+            {isFetching ? "Retrying..." : "Retry"}
+          </button>
+        </AlertBox>
+      ) : null}
+
+      <div className="flex items-center gap-3">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={showExpiringOnly}
+            onChange={(e) => setShowExpiringOnly(e.target.checked)}
+            className="rounded"
+            data-testid="utility-plans-expiring-toggle"
+          />
+          Show only plans that need renewing
+        </label>
+      </div>
+
+      <UtilityPlansListBody
+        mode={mode}
+        plans={plans}
+        showExpiringOnly={showExpiringOnly}
+        deletingPlanId={deletingPlanId}
+        onDelete={(plan) => void handleDelete(plan)}
+      />
+
+      {showAddDialog ? (
+        <AddUtilityPlanDialog onClose={() => setShowAddDialog(false)} />
+      ) : null}
+    </main>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-format.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-format.ts
@@ -1,0 +1,58 @@
+import { formatCurrency } from "@/shared/utils/currency";
+
+/**
+ * Display helpers for utility-plan figures.
+ *
+ * Rate fields arrive as JSON *strings* (``"13.9000"``) because the backend
+ * column is ``Numeric`` — Pydantic serializes Decimal as a string to avoid the
+ * float round-trip that would turn 5.3509 into 5.350900000000001. These
+ * helpers are the only place that string is parsed.
+ */
+
+/** ``"13.9000"`` → ``"13.9¢/kWh"``. Trailing zeros are noise on a price tag. */
+export function formatCentsPerKwh(value: string | null): string {
+  if (value === null || value.trim() === "") return "—";
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return "—";
+  // Up to 4 dp preserves a TDU charge like 5.3509; minimumFractionDigits 0
+  // drops the padding on a clean 13.9.
+  const formatted = parsed.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 4,
+  });
+  return `${formatted}¢/kWh`;
+}
+
+/** Integer cents → ``"$4.39"``. */
+export function formatCents(value: number | null): string {
+  if (value === null) return "—";
+  return formatCurrency(value / 100);
+}
+
+/**
+ * Human phrasing for the renewal countdown.
+ *
+ * ``days`` is negative once the term has lapsed — the case that matters, since
+ * the account is by then on an unfixed holdover rate.
+ */
+export function formatRenewalCountdown(days: number | null): string {
+  if (days === null) return "No term end recorded";
+  if (days < 0) {
+    const lapsed = Math.abs(days);
+    return `Lapsed ${lapsed} day${lapsed === 1 ? "" : "s"} ago`;
+  }
+  if (days === 0) return "Ends today";
+  return `Ends in ${days} day${days === 1 ? "" : "s"}`;
+}
+
+/** ``"2026-01-23"`` → ``"Jan 23, 2026"``, parsed as a local date, not UTC. */
+export function formatPlanDate(value: string | null): string {
+  if (!value) return "—";
+  const parsed = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return "—";
+  return parsed.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
@@ -4,6 +4,6 @@ import { axiosBaseQuery } from "./baseQuery";
 export const baseApi = createApi({
   reducerPath: "api",
   baseQuery: axiosBaseQuery,
-  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "BookingStatement", "Reconciliation", "TaxReturn", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor", "Screening", "Channel", "ChannelListing", "Calendar", "BlackoutAttachments", "LeaseTemplate", "SignedLease", "ReviewQueue", "InsurancePolicy", "AttributionQueue", "WelcomeManual", "WelcomeManualSend"],
+  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "BookingStatement", "Reconciliation", "TaxReturn", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor", "Screening", "Channel", "ChannelListing", "Calendar", "BlackoutAttachments", "LeaseTemplate", "SignedLease", "ReviewQueue", "InsurancePolicy", "AttributionQueue", "WelcomeManual", "WelcomeManualSend", "UtilityPlan"],
   endpoints: () => ({}),
 });

--- a/apps/mybookkeeper/frontend/src/shared/store/utilityPlansApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/utilityPlansApi.ts
@@ -1,0 +1,118 @@
+import { baseApi } from "./baseApi";
+import type { UtilityPlanCreateRequest } from "@/shared/types/utility/utility-plan-create-request";
+import type { UtilityPlanDetail } from "@/shared/types/utility/utility-plan-detail";
+import type { UtilityPlanListResponse } from "@/shared/types/utility/utility-plan-list-response";
+import type { UtilityPlanRenewalAlert } from "@/shared/types/utility/utility-plan-renewal-alert";
+import type { UtilityPlanUpdateRequest } from "@/shared/types/utility/utility-plan-update-request";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+export interface UtilityPlanListArgs {
+  property_id?: string;
+  service_type?: UtilityServiceType;
+  expiring_before?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * RTK Query slice for the Utility Plans domain.
+ *
+ * Tag strategy mirrors insurancePoliciesApi: per-id ``UtilityPlan:{id}`` plus
+ * a shared ``UtilityPlan:LIST``. Every mutation also invalidates
+ * ``UtilityPlan:ALERTS`` — the dashboard card is derived from the same rows,
+ * so editing a term end date must refresh it or the operator keeps seeing an
+ * alert they already dealt with.
+ */
+const utilityPlansApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getUtilityPlans: builder.query<
+      UtilityPlanListResponse,
+      UtilityPlanListArgs | void
+    >({
+      query: (args) => ({
+        url: "/utility-plans",
+        params: {
+          ...(args?.property_id ? { property_id: args.property_id } : {}),
+          ...(args?.service_type ? { service_type: args.service_type } : {}),
+          ...(args?.expiring_before ? { expiring_before: args.expiring_before } : {}),
+          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
+          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+        },
+      }),
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.items.map((p) => ({
+                type: "UtilityPlan" as const,
+                id: p.id,
+              })),
+              { type: "UtilityPlan" as const, id: "LIST" },
+            ]
+          : [{ type: "UtilityPlan" as const, id: "LIST" }],
+    }),
+
+    getUtilityPlanRenewalAlerts: builder.query<
+      UtilityPlanRenewalAlert,
+      { window_days?: number } | void
+    >({
+      query: (args) => ({
+        url: "/utility-plans/renewal-alerts",
+        params: {
+          ...(args?.window_days !== undefined
+            ? { window_days: args.window_days }
+            : {}),
+        },
+      }),
+      providesTags: [{ type: "UtilityPlan", id: "ALERTS" }],
+    }),
+
+    getUtilityPlanById: builder.query<UtilityPlanDetail, string>({
+      query: (id) => ({ url: `/utility-plans/${id}` }),
+      providesTags: (_r, _e, id) => [{ type: "UtilityPlan", id }],
+    }),
+
+    createUtilityPlan: builder.mutation<
+      UtilityPlanDetail,
+      UtilityPlanCreateRequest
+    >({
+      query: (data) => ({ url: "/utility-plans", method: "POST", data }),
+      invalidatesTags: [
+        { type: "UtilityPlan", id: "LIST" },
+        { type: "UtilityPlan", id: "ALERTS" },
+      ],
+    }),
+
+    updateUtilityPlan: builder.mutation<
+      UtilityPlanDetail,
+      { planId: string; data: UtilityPlanUpdateRequest }
+    >({
+      query: ({ planId, data }) => ({
+        url: `/utility-plans/${planId}`,
+        method: "PATCH",
+        data,
+      }),
+      invalidatesTags: (_r, _e, { planId }) => [
+        { type: "UtilityPlan", id: planId },
+        { type: "UtilityPlan", id: "LIST" },
+        { type: "UtilityPlan", id: "ALERTS" },
+      ],
+    }),
+
+    deleteUtilityPlan: builder.mutation<void, string>({
+      query: (id) => ({ url: `/utility-plans/${id}`, method: "DELETE" }),
+      invalidatesTags: [
+        { type: "UtilityPlan", id: "LIST" },
+        { type: "UtilityPlan", id: "ALERTS" },
+      ],
+    }),
+  }),
+});
+
+export const {
+  useGetUtilityPlansQuery,
+  useGetUtilityPlanRenewalAlertsQuery,
+  useGetUtilityPlanByIdQuery,
+  useCreateUtilityPlanMutation,
+  useUpdateUtilityPlanMutation,
+  useDeleteUtilityPlanMutation,
+} = utilityPlansApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-alert-card-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-alert-card-mode.ts
@@ -1,0 +1,8 @@
+/**
+ * What the dashboard renewal-alert card should render.
+ *
+ * ``clear`` is distinct from ``hidden``: the card renders a reassuring line
+ * when plans exist and none need attention, and disappears entirely when the
+ * operator tracks no plans at all — an empty card on a dashboard is noise.
+ */
+export type UtilityPlanAlertCardMode = "loading" | "error" | "hidden" | "clear" | "alerts";

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-create-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-create-request.ts
@@ -1,0 +1,39 @@
+import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-rate-type";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+/**
+ * Body for ``POST /utility-plans``.
+ *
+ * Mirrors ``schemas/properties/utility_plan_create_request.py``, which sets
+ * ``extra="forbid"`` — an unknown key is a 422, not a silently dropped field.
+ *
+ * Rate fields are sent as strings so sub-cent precision survives the JSON
+ * boundary: a TDU charge of 5.3509 ¢/kWh rounded to 5.35 by a float round-trip
+ * would misprice every comparison built on it.
+ */
+export interface UtilityPlanCreateRequest {
+  property_id: string;
+  service_type: UtilityServiceType;
+  provider_name: string;
+  rate_type: UtilityPlanRateType;
+  account_number?: string | null;
+  plan_name?: string | null;
+
+  energy_charge_cents_per_kwh?: string | null;
+  tdu_charge_cents_per_kwh?: string | null;
+  avg_price_cents_per_kwh_at_1000?: string | null;
+  monthly_base_charge_cents?: number | null;
+
+  term_months?: number | null;
+  service_start_date?: string | null;
+  term_end_date?: string | null;
+  early_termination_fee_cents?: number | null;
+
+  has_bill_credit?: boolean;
+  bill_credit_amount_cents?: number | null;
+  bill_credit_threshold_kwh?: number | null;
+  min_usage_fee_cents?: number | null;
+  min_usage_threshold_kwh?: number | null;
+
+  notes?: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-detail.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-detail.ts
@@ -1,0 +1,48 @@
+import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-rate-type";
+import type { UtilityPlanRenewalStatus } from "@/shared/types/utility/utility-plan-renewal-status";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+/**
+ * A single utility plan in full.
+ *
+ * Mirrors ``schemas/properties/utility_plan_response.py``. Rate fields are
+ * JSON strings (see ``UtilityPlanSummary``); flat money is integer cents.
+ */
+export interface UtilityPlanDetail {
+  id: string;
+  user_id: string;
+  organization_id: string;
+  property_id: string;
+  property_name: string | null;
+
+  service_type: UtilityServiceType;
+  provider_name: string;
+  account_number: string | null;
+  plan_name: string | null;
+  rate_type: UtilityPlanRateType;
+
+  energy_charge_cents_per_kwh: string | null;
+  tdu_charge_cents_per_kwh: string | null;
+  avg_price_cents_per_kwh_at_1000: string | null;
+  monthly_base_charge_cents: number | null;
+
+  term_months: number | null;
+  service_start_date: string | null;
+  term_end_date: string | null;
+  early_termination_fee_cents: number | null;
+
+  has_bill_credit: boolean;
+  bill_credit_amount_cents: number | null;
+  bill_credit_threshold_kwh: number | null;
+  min_usage_fee_cents: number | null;
+  min_usage_threshold_kwh: number | null;
+
+  notes: string | null;
+
+  days_until_term_end: number | null;
+  renewal_status: UtilityPlanRenewalStatus;
+  is_current: boolean;
+
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-list-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-list-response.ts
@@ -1,0 +1,12 @@
+import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
+
+/**
+ * Paginated list response for utility plans.
+ *
+ * Mirrors ``schemas/properties/utility_plan_list_response.py``.
+ */
+export interface UtilityPlanListResponse {
+  items: UtilityPlanSummary[];
+  total: number;
+  has_more: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-rate-type.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-rate-type.ts
@@ -1,0 +1,38 @@
+/**
+ * How a plan's price is set.
+ *
+ * Mirrors ``RATE_TYPES`` in ``backend/app/core/utility_plan_constants.py``,
+ * which is enforced by a CHECK constraint. A value added there MUST be added
+ * here in the same PR.
+ */
+export type UtilityPlanRateType =
+  | "fixed"
+  | "variable"
+  | "indexed"
+  | "regulated";
+
+export const UTILITY_PLAN_RATE_TYPES: readonly UtilityPlanRateType[] = [
+  "fixed",
+  "variable",
+  "indexed",
+  "regulated",
+];
+
+export const UTILITY_PLAN_RATE_TYPE_LABELS: Record<UtilityPlanRateType, string> = {
+  fixed: "Fixed",
+  variable: "Variable",
+  indexed: "Indexed",
+  regulated: "Regulated",
+};
+
+/**
+ * Why each rate type behaves the way it does at renewal time. Shown next to
+ * the selector so the operator understands why picking ``regulated`` silences
+ * the renewal alert.
+ */
+export const UTILITY_PLAN_RATE_TYPE_HINTS: Record<UtilityPlanRateType, string> = {
+  fixed: "Locked rate for the term. Alerts before the term ends.",
+  variable: "Provider can reprice monthly — this is where a lapsed fixed plan lands.",
+  indexed: "Tied to a published market index. Alerts before the term ends.",
+  regulated: "Tariffed monopoly rate. No competing supplier, so no renewal alert.",
+};

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-renewal-alert.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-renewal-alert.ts
@@ -1,0 +1,15 @@
+import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
+
+/**
+ * Dashboard payload for plans needing attention.
+ *
+ * Mirrors ``schemas/properties/utility_plan_renewal_alert_response.py``.
+ * ``window_days`` is supplied by the backend so the UI can say "in the next N
+ * days" without hardcoding a number it does not own.
+ */
+export interface UtilityPlanRenewalAlert {
+  window_days: number;
+  expired: UtilityPlanSummary[];
+  expiring_soon: UtilityPlanSummary[];
+  total_needing_attention: number;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-renewal-status.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-renewal-status.ts
@@ -1,0 +1,41 @@
+/**
+ * Derived renewal state of a plan — never stored, computed by the backend from
+ * rate type + term end date + today.
+ *
+ * Mirrors ``RENEWAL_STATUSES`` in
+ * ``backend/app/core/utility_plan_constants.py``. A value added there MUST be
+ * added here in the same PR.
+ */
+export type UtilityPlanRenewalStatus =
+  | "not_applicable"
+  | "active"
+  | "expiring_soon"
+  | "expired";
+
+export const UTILITY_PLAN_RENEWAL_STATUS_LABELS: Record<
+  UtilityPlanRenewalStatus,
+  string
+> = {
+  not_applicable: "No term",
+  active: "Active",
+  expiring_soon: "Expiring soon",
+  expired: "Expired",
+};
+
+/**
+ * Badge styling per status. ``expired`` is the loudest because the money is
+ * already leaking — the account has almost certainly rolled onto a holdover
+ * variable rate.
+ */
+export const UTILITY_PLAN_RENEWAL_STATUS_CLASSES: Record<
+  UtilityPlanRenewalStatus,
+  string
+> = {
+  not_applicable:
+    "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+  active:
+    "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
+  expiring_soon:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+  expired: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
+};

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-summary.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-summary.ts
@@ -1,0 +1,29 @@
+import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-rate-type";
+import type { UtilityPlanRenewalStatus } from "@/shared/types/utility/utility-plan-renewal-status";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+/**
+ * Summary row for the utility-plan list.
+ *
+ * Mirrors ``schemas/properties/utility_plan_summary.py``.
+ *
+ * Rate columns are ``Numeric`` on the backend and serialize as JSON *strings*
+ * (``"13.9000"``), not numbers — parse before doing arithmetic.
+ */
+export interface UtilityPlanSummary {
+  id: string;
+  property_id: string;
+  property_name: string | null;
+  service_type: UtilityServiceType;
+  provider_name: string;
+  plan_name: string | null;
+  rate_type: UtilityPlanRateType;
+  avg_price_cents_per_kwh_at_1000: string | null;
+  term_end_date: string | null;
+  /** Negative once the term has lapsed, which is the case worth seeing. */
+  days_until_term_end: number | null;
+  renewal_status: UtilityPlanRenewalStatus;
+  is_current: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-update-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-update-request.ts
@@ -1,0 +1,14 @@
+import type { UtilityPlanCreateRequest } from "@/shared/types/utility/utility-plan-create-request";
+
+/**
+ * Body for ``PATCH /utility-plans/{id}``.
+ *
+ * Mirrors ``schemas/properties/utility_plan_update_request.py``. Every field
+ * is optional; only the keys present are applied.
+ *
+ * ``property_id`` is deliberately excluded — moving a plan to another property
+ * would silently rewrite that property's rate history. Delete and re-create.
+ */
+export type UtilityPlanUpdateRequest = Partial<
+  Omit<UtilityPlanCreateRequest, "property_id">
+>;

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plans-list-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plans-list-mode.ts
@@ -1,0 +1,5 @@
+/**
+ * Discriminated union for what the UtilityPlans list body should render.
+ * Keeps the body a flat switch instead of a ternary chain.
+ */
+export type UtilityPlansListMode = "loading" | "empty" | "list";

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-service-type.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-service-type.ts
@@ -1,0 +1,26 @@
+/**
+ * Utility service a plan covers.
+ *
+ * Mirrors ``SERVICE_TYPES`` in ``backend/app/core/utility_plan_constants.py``,
+ * which is enforced by a CHECK constraint. A value added there MUST be added
+ * here in the same PR.
+ */
+export type UtilityServiceType =
+  | "electricity"
+  | "natural_gas"
+  | "water"
+  | "internet";
+
+export const UTILITY_SERVICE_TYPES: readonly UtilityServiceType[] = [
+  "electricity",
+  "natural_gas",
+  "water",
+  "internet",
+];
+
+export const UTILITY_SERVICE_TYPE_LABELS: Record<UtilityServiceType, string> = {
+  electricity: "Electricity",
+  natural_gas: "Natural gas",
+  water: "Water",
+  internet: "Internet",
+};

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -613,6 +613,50 @@
         "insurance-policies.spec.ts"
       ]
     },
+    "utility_plans": {
+      "source_paths": [
+        "backend/app/models/properties/utility_plan.py",
+        "backend/app/repositories/properties/utility_plan_repo.py",
+        "backend/app/schemas/properties/utility_plan_create_request.py",
+        "backend/app/schemas/properties/utility_plan_update_request.py",
+        "backend/app/schemas/properties/utility_plan_summary.py",
+        "backend/app/schemas/properties/utility_plan_response.py",
+        "backend/app/schemas/properties/utility_plan_list_response.py",
+        "backend/app/schemas/properties/utility_plan_renewal_alert_response.py",
+        "backend/app/schemas/properties/utility_plan_validation.py",
+        "backend/app/services/properties/utility_plan_service.py",
+        "backend/app/api/utility_plans.py",
+        "backend/app/core/utility_plan_constants.py",
+        "backend/app/cli/utility_plan_seed_row.py",
+        "backend/app/cli/peerless_utility_plan_seed.py",
+        "backend/app/cli/migrate_data.py",
+        "backend/app/workers/scheduler_worker.py",
+        "backend/alembic/versions/utilplan260807_add_utility_plans.py",
+        "frontend/src/app/pages/UtilityPlans.tsx",
+        "frontend/src/app/features/utility/",
+        "frontend/src/shared/types/utility/",
+        "frontend/src/shared/store/utilityPlansApi.ts",
+        "frontend/src/shared/lib/utility-plan-format.ts"
+      ],
+      "backend_tests": [
+        "test_utility_plan_service.py",
+        "test_utility_plan_repo.py",
+        "test_utility_plans_api.py",
+        "test_utility_plan_scheduler.py",
+        "test_utility_plan_seed.py"
+      ],
+      "frontend_tests": [
+        "UtilityPlans.test.tsx",
+        "UtilityPlanRenewalAlertCard.test.tsx",
+        "utility-plan-format.test.ts",
+        "Dashboard.test.tsx"
+      ],
+      "e2e_specs": [
+        "utility-plans.spec.ts",
+        "utility-plans-layout.spec.ts",
+        "dashboard.spec.ts"
+      ]
+    },
     "welcome_manuals": {
       "source_paths": [
         "backend/app/models/welcome_manuals/",
@@ -875,7 +919,7 @@
         "backend/app/api/reconciliation.py",
         "backend/app/api/summary.py",
         "frontend/src/pages/Transactions.tsx",
-        "frontend/src/pages/Dashboard.tsx",
+        "frontend/src/app/pages/Dashboard.tsx",
         "frontend/src/features/transactions/",
         "frontend/src/features/dashboard/",
         "frontend/src/shared/types/dashboard/",


### PR DESCRIPTION
## What

Tracks each property's electricity and gas plan, and warns before a fixed rate lapses.

In Texas a fixed-term electricity plan doesn't end — it rolls onto a month-to-month **holdover rate**, silently, at whatever the retailer chooses. All three Peerless plans have been on that holdover since January 2026 and nothing in the app said so. This PR makes that visible and keeps it visible for the next renewal.

Scope is **plans + renewal alerts** (no usage capture, no market-rate comparison).

## Backend

- **`utility_plans` table** (migration `utilplan260807`) — one row per contract, per property, modelled on `insurance_policies`. Rows are history, not state: a superseded plan stays as the baseline a new offer gets measured against.
- **`renewal_status`, `days_until_term_end`, `is_current` are derived, never stored.** A stored status silently goes wrong the morning a term lapses.
- **Regulated service is excluded from alerts.** Houston natural gas is a monopoly — there is no competing supplier to switch to, so a renewal alert would be pure noise. The dialog says so in a rate-type hint.
- `GET /utility-plans/renewal-alerts` splits already-expired from expiring-soon (45-day window). `scheduler_worker` logs the same set each cycle at WARNING; the sweep is read-only and never raises.
- Rates are `Numeric(9,4)` — a TDU charge rounded to `5.35` instead of `5.3509` misprices every comparison.
- Enums are `String` + `CheckConstraint`, not SQLAlchemy `Enum`, per the schema conventions.

## Frontend

- `/utility-plans` list page + nav entry under **Property**. The needs-renewing filter keys off the derived status rather than the raw date, so regulated and superseded rows stay out of it.
- **Dashboard card** above the fold and outside the empty-state branch — a lapsed rate costs money whether or not any transactions have been imported yet. It hides entirely when no plans are tracked (an always-empty card is noise) but states an explicit all-clear once at least one is.
- Rate fields are typed `string | null`: Pydantic serializes `Decimal` to a JSON **string**, verified against the running app rather than assumed.

## Seed from the operator's billing email

`python -m app.cli.migrate_data seed-utility-plans` loads the three Constellation plans and the two CenterPoint gas accounts, so the alert fires against real data immediately. Idempotent (`IS NOT DISTINCT FROM` on the nullable start date, so regulated rows don't duplicate on re-run) and `--dry-run` capable.

It **refuses to guess**:

- A property fragment matching zero or several rows is reported and skipped, not resolved arbitrarily.
- Values absent from the source emails are left `NULL`, not copied from a sibling plan — 6738's average price and ETF (its plan-change notice omits both), and which Constellation account number belongs to 6732 vs 6734 (both candidates are recorded in `notes`).

## Verification

| Layer | Result |
|---|---|
| Backend pytest | 97 passed (service 28, repo 17, API 22, scheduler 3, seed 27) |
| Frontend vitest | 46 passed (incl. Dashboard regression) |
| E2E behaviour | 2 passed — create → derived status → dashboard card → filter → delete, plus the regulated no-alert case |
| E2E layout | 2 passed — skeleton/loaded parity, no horizontal overflow at 375/768/1440, 44px touch targets |
| `tsc --noEmit` | clean |
| ESLint | 0 errors (11 pre-existing warnings, none in new files) |
| `check-file-size.py` | all files within thresholds |

Also exercised against the real local database: migration applied, seed inserted 3 plans (2 correctly skipped as ambiguous — see below), `get_renewal_alerts` and the scheduler sweep both flag the two lapsed Constellation plans at −196 and −192 days.

Seven `dashboard.spec.ts` / `navigation.spec.ts` E2E tests fail locally. Confirmed pre-existing by stashing this PR's two dashboard files and re-running — identical 7 failures at baseline. They are local-data and strict-locator issues (a `Documents` / `Tax Documents` link collision), untouched by this PR.

## Operator follow-ups

Neither blocks the merge; both need information only you have.

1. **Which Constellation account is 6732 and which is 6734** — `204865879` / `204865622`. Nothing in the mailbox binds either number to an address; both rows carry `account_number = NULL` with both candidates in `notes`. A single bill resolves it.
2. **The local dev database has a duplicate property**, `6734 Peerless St (DEV)` alongside `6734 Peerless St, Houston, TX 77021`. The seed correctly refused to guess between them, so 6734's two plans were skipped locally. Delete the DEV row and re-run the seed, or add them through the UI.

Separately: the *current* holdover rate on each account sits behind a Constellation / CenterPoint login, which only you can perform. Once you have those numbers, enter them as new plans — the superseded rows are already kept as the comparison baseline.