### PR TITLE
fix(mbk): confirm before removing a utility plan

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/utility-plans.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-plans.spec.ts
@@ -142,10 +142,17 @@ test.describe("Utility Plans", () => {
         page.getByTestId(`utility-plan-alert-${planId}`),
       ).toContainText(propertyName);
 
-      // 6) DELETE through the UI; the row goes and the API agrees.
+      // 6) DELETE through the UI; the row goes and the API agrees. The trash
+      //    icon only opens the confirmation — the plan survives until the
+      //    operator confirms, so the row must still be there in between.
       await page.goto("/utility-plans");
       await waitForListPage(page);
       await page.getByTestId(`utility-plan-delete-${planId}`).click();
+      await expect(page.getByText("Remove this utility plan?")).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByTestId(`utility-plan-item-${planId}`)).toBeVisible();
+      await page.getByRole("button", { name: "Remove plan" }).click();
       await expect(page.getByTestId(`utility-plan-item-${planId}`)).toBeHidden({
         timeout: 10000,
       });

--- a/apps/mybookkeeper/frontend/src/__tests__/UtilityPlans.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/UtilityPlans.test.tsx
@@ -219,12 +219,38 @@ describe("UtilityPlans — needs-renewing filter", () => {
 });
 
 describe("UtilityPlans — delete", () => {
+  it("asks before removing rather than deleting on the first click", async () => {
+    const user = userEvent.setup();
+    mockPlans = [makePlan()];
+
+    renderPage();
+    await user.click(screen.getByTestId("utility-plan-delete-plan-a"));
+
+    expect(screen.getByText("Remove this utility plan?")).toBeInTheDocument();
+    expect(mockDeleteUnwrap).not.toHaveBeenCalled();
+  });
+
+  it("leaves the plan alone when the confirmation is dismissed", async () => {
+    const user = userEvent.setup();
+    mockPlans = [makePlan()];
+
+    renderPage();
+    await user.click(screen.getByTestId("utility-plan-delete-plan-a"));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockDeleteUnwrap).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.queryByText("Remove this utility plan?")).not.toBeInTheDocument(),
+    );
+  });
+
   it("confirms removal on success", async () => {
     const user = userEvent.setup();
     mockPlans = [makePlan()];
 
     renderPage();
     await user.click(screen.getByTestId("utility-plan-delete-plan-a"));
+    await user.click(screen.getByRole("button", { name: "Remove plan" }));
 
     await waitFor(() => expect(showSuccess).toHaveBeenCalledWith("Utility plan removed."));
   });
@@ -236,10 +262,26 @@ describe("UtilityPlans — delete", () => {
 
     renderPage();
     await user.click(screen.getByTestId("utility-plan-delete-plan-a"));
+    await user.click(screen.getByRole("button", { name: "Remove plan" }));
 
     await waitFor(() =>
       expect(showError).toHaveBeenCalledWith("Couldn't remove the plan. Please try again."),
     );
+  });
+
+  // A failed delete must keep the dialog open — closing it would strand the
+  // operator with a row they asked to remove and no way to see the retry.
+  it("keeps the confirmation open when the delete fails", async () => {
+    const user = userEvent.setup();
+    mockPlans = [makePlan()];
+    mockDeleteUnwrap.mockRejectedValue(new Error("boom"));
+
+    renderPage();
+    await user.click(screen.getByTestId("utility-plan-delete-plan-a"));
+    await user.click(screen.getByRole("button", { name: "Remove plan" }));
+
+    await waitFor(() => expect(showError).toHaveBeenCalled());
+    expect(screen.getByText("Remove this utility plan?")).toBeInTheDocument();
   });
 });
 

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRow.tsx
@@ -57,11 +57,17 @@ export default function UtilityPlanRow({ plan, isDeleting, onDelete }: UtilityPl
 
         <div className="flex items-center gap-2 shrink-0">
           <UtilityPlanRenewalBadge status={plan.renewal_status} />
+          {/* Provider alone is ambiguous: the same regulated utility serves
+              every property, so several rows would all read "Delete
+              CenterPoint Energy plan" to a screen reader. Property and
+              service disambiguate them. */}
           <button
             type="button"
             onClick={() => onDelete(plan)}
             disabled={isDeleting}
-            aria-label={`Delete ${plan.provider_name} plan`}
+            aria-label={`Delete ${plan.provider_name} ${UTILITY_SERVICE_TYPE_LABELS[
+              plan.service_type
+            ].toLowerCase()} plan for ${plan.property_name ?? "unknown property"}`}
             className="text-muted-foreground hover:text-red-600 disabled:opacity-50 min-h-[44px] min-w-[44px] flex items-center justify-center"
             data-testid={`utility-plan-delete-${plan.id}`}
           >

--- a/apps/mybookkeeper/frontend/src/app/pages/UtilityPlans.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/UtilityPlans.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button } from "@platform/ui";
+import { Button, ConfirmDialog } from "@platform/ui";
 import AlertBox from "@/shared/components/ui/AlertBox";
 import SectionHeader from "@/shared/components/ui/SectionHeader";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
@@ -22,6 +22,7 @@ export default function UtilityPlans() {
   const [showExpiringOnly, setShowExpiringOnly] = useState(false);
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [deletingPlanId, setDeletingPlanId] = useState<string | null>(null);
+  const [planPendingDelete, setPlanPendingDelete] = useState<UtilityPlanSummary | null>(null);
 
   const { data, isLoading, isError, isFetching, refetch } = useGetUtilityPlansQuery({});
   const [deletePlan] = useDeleteUtilityPlanMutation();
@@ -41,11 +42,14 @@ export default function UtilityPlans() {
 
   const mode = useUtilityPlansListMode({ isLoading, planCount: plans.length });
 
-  async function handleDelete(plan: UtilityPlanSummary) {
+  async function handleConfirmDelete() {
+    const plan = planPendingDelete;
+    if (!plan) return;
     setDeletingPlanId(plan.id);
     try {
       await deletePlan(plan.id).unwrap();
       showSuccess("Utility plan removed.");
+      setPlanPendingDelete(null);
     } catch {
       showError("Couldn't remove the plan. Please try again.");
     } finally {
@@ -102,12 +106,27 @@ export default function UtilityPlans() {
         plans={plans}
         showExpiringOnly={showExpiringOnly}
         deletingPlanId={deletingPlanId}
-        onDelete={(plan) => void handleDelete(plan)}
+        onDelete={(plan) => setPlanPendingDelete(plan)}
       />
 
       {showAddDialog ? (
         <AddUtilityPlanDialog onClose={() => setShowAddDialog(false)} />
       ) : null}
+
+      <ConfirmDialog
+        open={planPendingDelete !== null}
+        title="Remove this utility plan?"
+        description={
+          planPendingDelete
+            ? `${planPendingDelete.provider_name} for ${planPendingDelete.property_name ?? "this property"}. The rate history it holds is what a new offer gets compared against, so removing it leaves nothing to measure the next plan against.`
+            : ""
+        }
+        confirmLabel="Remove plan"
+        variant="danger"
+        isLoading={deletingPlanId !== null}
+        onConfirm={() => void handleConfirmDelete()}
+        onCancel={() => setPlanPendingDelete(null)}
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Problem

The trash icon on a Utility Plans row deleted the plan on the first click — no confirmation, no undo. Every other destructive action in MyBookkeeper already routes through the shared `ConfirmDialog` (Documents, Properties, Transactions, Insurance, Leases, Listings, Members). Utility Plans was the only outlier.

The cost of a stray click is not just re-typing a provider name: a superseded plan row is deliberately kept as the rate baseline a new offer gets measured against. Deleting it removes the thing the feature exists to compare against.

Found during a hands-on UI pass against real seeded data (5 plans across 3 properties).

## Changes

- **`UtilityPlans.tsx`** — delete routes through `ConfirmDialog`, naming the specific provider and property. The dialog stays open when the delete fails, so a failed removal doesn't strand the operator with a row they asked to delete and no visible retry.
- **`UtilityPlanRow.tsx`** — the delete button's `aria-label` was provider-only. The same regulated utility serves all three properties, so a screen reader heard three identical "Delete CenterPoint Energy plan" buttons. Now includes service type and property.
- **`UtilityPlans.test.tsx`** — the two delete tests become five: first click does not delete, Cancel does not delete, success path, failure path, and dialog-stays-open-on-failure.
- **`utility-plans.spec.ts`** — the E2E delete step now asserts the row is *still present* after the trash click and only disappears after confirming.

## Verification

- `tsc -b` clean
- ESLint: 0 errors (11 warnings, all pre-existing in untouched `Transactions.tsx` / `ColumnFilter.tsx`)
- 22/22 unit tests pass across `UtilityPlans.test.tsx` + `UtilityPlanRenewalAlertCard.test.tsx`
- Browser-verified against the real local DB: clicking the trash icon on the 6734 Peerless St CenterPoint gas plan opened "Remove this utility plan?" with the property named and a red "Remove plan" button; all 5 rows stayed visible; Cancel left all 5 plans present (confirmed via API, not just the UI).

## Out of scope — what this pass surfaced and deliberately did not fix

1. **There is no edit UI.** `useUpdateUtilityPlanMutation` and `useGetUtilityPlanByIdQuery` have zero consumers — the endpoints exist, nothing calls them. A typo in a rate can only be corrected by deleting and re-adding. That's a PR-sized feature (dialog + form + tests), not a fix to bolt onto this one. Either build the edit flow or delete the dead hooks.
2. **Sort order buries the actionable rows.** The three Expired electricity plans sit below the regulated "No term" gas plans, because the backend orders by `desc(service_start_date), desc(created_at)`. That ordering has a documented in-code rationale, so changing it is a decision rather than a bug fix — reporting rather than unilaterally changing.

The blank average price on 6738's electricity plan is **not** a gap — `peerless_utility_plan_seed.py` documents that the 2025-01-27 plan-change notice never stated one, and it was left NULL rather than copied from the sibling properties. The row renders correctly without it. Noting it here only so the next reader doesn't re-open it as a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sr27bfGYRjFvsRc9JuBwKk
