### PR TITLE
feat(mybookkeeper): edit a utility plan without erasing what the form can't see

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/utility-plans-layout.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-plans-layout.spec.ts
@@ -147,12 +147,69 @@ test.describe("Utility Plans layout", () => {
 
       await page.setViewportSize({ width: 375, height: 800 });
       await page.goto("/utility-plans");
-      const deleteButton = page.getByTestId(`utility-plan-delete-${planId}`);
-      await expect(deleteButton).toBeVisible({ timeout: 15000 });
-      const box = await deleteButton.boundingBox();
-      expect(box).not.toBeNull();
-      expect(box!.width).toBeGreaterThanOrEqual(44);
-      expect(box!.height).toBeGreaterThanOrEqual(44);
+      await expect(page.getByTestId(`utility-plan-item-${planId}`)).toBeVisible({
+        timeout: 15000,
+      });
+      for (const testId of [
+        `utility-plan-edit-${planId}`,
+        `utility-plan-delete-${planId}`,
+      ]) {
+        const control = page.getByTestId(testId);
+        await expect(control).toBeVisible();
+        const box = await control.boundingBox();
+        expect(box, `${testId} has no box`).not.toBeNull();
+        expect(box!.width, `${testId} width`).toBeGreaterThanOrEqual(44);
+        expect(box!.height, `${testId} height`).toBeGreaterThanOrEqual(44);
+      }
+    } finally {
+      if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+
+  test("the edit dialog holds its shape while the plan loads", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    let propertyId: string | null = null;
+    let planId: string | null = null;
+
+    try {
+      const property = await createProperty(api, { name: `E2E Edit Layout ${runId}` });
+      propertyId = property.id;
+      planId = await seedPlan(api, propertyId, `E2E Edit Layout Power ${runId}`);
+
+      await page.setViewportSize({ width: 375, height: 800 });
+      await page.goto("/utility-plans");
+      await expect(page.getByTestId(`utility-plan-item-${planId}`)).toBeVisible({
+        timeout: 15000,
+      });
+
+      // Hold the single-plan fetch so the dialog's skeleton is observable. The
+      // list glob above it has already resolved.
+      await page.route(`**/api/utility-plans/${planId}`, async (route) => {
+        await new Promise((r) => setTimeout(r, 1500));
+        await route.continue();
+      });
+
+      await page.getByTestId(`utility-plan-edit-${planId}`).click();
+
+      const skeleton = page.getByTestId("utility-plan-form-loading");
+      await expect(skeleton).toBeVisible({ timeout: 5000 });
+      const skeletonHeight = (await skeleton.boundingBox())!.height;
+      expect(await hasHorizontalOverflow(page), "overflow while loading").toBe(false);
+
+      // The real form replaces it without the dialog jumping. The threshold is
+      // generous — the promise is "no visible jolt", not pixel equality.
+      const form = page.getByTestId("utility-plan-provider-input");
+      await expect(form).toBeVisible({ timeout: 15000 });
+      const loadedHeight = (await page
+        .getByTestId("edit-utility-plan-dialog")
+        .locator("form")
+        .boundingBox())!.height;
+      expect(Math.abs(loadedHeight - skeletonHeight)).toBeLessThan(160);
+      expect(await hasHorizontalOverflow(page), "overflow when loaded").toBe(false);
     } finally {
       if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
       if (propertyId) await deleteProperty(api, propertyId);

--- a/apps/mybookkeeper/frontend/e2e/utility-plans.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-plans.spec.ts
@@ -19,10 +19,16 @@ import { createProperty, deleteProperty } from "./fixtures/seed-data";
 interface UtilityPlanRow {
   id: string;
   provider_name: string;
+  account_number: string | null;
+  plan_name: string | null;
   renewal_status: string;
   is_current: boolean;
   days_until_term_end: number | null;
+  term_end_date: string | null;
   tdu_charge_cents_per_kwh: string | null;
+  min_usage_fee_cents: number | null;
+  min_usage_threshold_kwh: number | null;
+  notes: string | null;
 }
 
 interface RenewalAlerts {
@@ -218,6 +224,103 @@ test.describe("Utility Plans", () => {
       // And the "needs renewing" filter excludes it.
       await page.getByTestId("utility-plans-expiring-toggle").check();
       await expect(page.getByTestId(`utility-plan-item-${planId}`)).toBeHidden();
+    } finally {
+      if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+
+  test("editing a plan corrects it without erasing the terms the form cannot edit", async ({
+    authedPage: page,
+    api,
+  }) => {
+    // The seeded Peerless plans carry a minimum-usage clause and a provenance
+    // note that this dialog has no fields for. Because PATCH applies exactly
+    // the keys it is sent, a save that emitted them as null would silently
+    // erase both — so the plan is created with them set and asserted intact
+    // afterwards.
+    const runId = Date.now();
+    const propertyName = `E2E Edit Property ${runId}`;
+    const providerName = `E2E Edit Power ${runId}`;
+    const NOTE = "Account number unresolved — set it from a bill.";
+    let propertyId: string | null = null;
+    let planId: string | null = null;
+
+    try {
+      const property = await createProperty(api, { name: propertyName });
+      propertyId = property.id;
+
+      const created = await api.post("/utility-plans", {
+        data: {
+          property_id: propertyId,
+          service_type: "electricity",
+          rate_type: "fixed",
+          provider_name: providerName,
+          plan_name: "12 Month Fixed",
+          energy_charge_cents_per_kwh: "11.6",
+          tdu_charge_cents_per_kwh: "5.3509",
+          term_months: 12,
+          service_start_date: isoDateOffset(-400),
+          term_end_date: isoDateOffset(-35),
+          min_usage_fee_cents: 995,
+          min_usage_threshold_kwh: 999,
+          notes: NOTE,
+        },
+      });
+      expect(created.ok()).toBe(true);
+      planId = ((await created.json()) as UtilityPlanRow).id;
+
+      await page.goto("/utility-plans");
+      await waitForListPage(page);
+
+      const row = page.getByTestId(`utility-plan-item-${planId}`);
+      await expect(row).toBeVisible({ timeout: 10000 });
+      await expect(row.getByTestId("utility-plan-status-expired")).toBeVisible();
+
+      // 1) Open the editor and confirm it arrived prefilled, not blank.
+      await page.getByTestId(`utility-plan-edit-${planId}`).click();
+      await expect(page.getByTestId("edit-utility-plan-dialog")).toBeVisible();
+      await expect(page.getByTestId("utility-plan-provider-input")).toHaveValue(
+        providerName,
+        { timeout: 10000 },
+      );
+      await expect(page.getByTestId("utility-plan-tdu-input")).toHaveValue("5.3509");
+      await expect(page.getByTestId("edit-utility-plan-property")).toContainText(
+        propertyName,
+      );
+      // The property is fixed for the life of the plan.
+      await expect(page.getByTestId("utility-plan-property-select")).toBeHidden();
+
+      // 2) Fill in the account number the row was missing and renew the term.
+      const renewedEnd = isoDateOffset(300);
+      await page.getByTestId("utility-plan-account-input").fill("6403771807-5");
+      await page.getByTestId("utility-plan-end-date-input").fill(renewedEnd);
+      await page.getByTestId("utility-plan-save-button").click();
+
+      await expect(page.getByTestId("edit-utility-plan-dialog")).toBeHidden({
+        timeout: 10000,
+      });
+      await page.waitForLoadState("networkidle");
+
+      // 3) The list re-derives the status from the new term end.
+      await expect(row.getByTestId("utility-plan-status-active")).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(row).not.toContainText("Lapsed");
+
+      // 4) The backend agrees — the edits landed and everything the form does
+      //    not own is byte-identical to what was created.
+      const saved = await fetchPlan(api, planId);
+      // Stored in lookup-key form: the service strips dashes so a number typed
+      // as it appears on the bill still matches the learned bill→property link.
+      expect(saved.account_number).toBe("64037718075");
+      expect(saved.term_end_date).toBe(renewedEnd);
+      expect(saved.renewal_status).toBe("active");
+      expect(saved.plan_name).toBe("12 Month Fixed");
+      expect(Number(saved.tdu_charge_cents_per_kwh)).toBeCloseTo(5.3509, 4);
+      expect(saved.min_usage_fee_cents).toBe(995);
+      expect(saved.min_usage_threshold_kwh).toBe(999);
+      expect(saved.notes).toBe(NOTE);
     } finally {
       if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
       if (propertyId) await deleteProperty(api, propertyId);

--- a/apps/mybookkeeper/frontend/src/__tests__/EditUtilityPlanDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/EditUtilityPlanDialog.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for the utility-plan edit dialog.
+ *
+ * Verifies:
+ * - A skeleton stands in while the plan loads, and an error offers a retry
+ * - Fields are prefilled from the loaded plan
+ * - Save sends only the edited keys, leaving untouched terms alone
+ * - Success closes the dialog; failure keeps it open with the edits intact
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EditUtilityPlanDialog from "@/app/features/utility/EditUtilityPlanDialog";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import type { UtilityPlanDetail } from "@/shared/types/utility/utility-plan-detail";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockUpdate = vi.fn();
+const mockUpdateUnwrap = vi.fn();
+const mockRefetch = vi.fn();
+
+let mockPlan: UtilityPlanDetail | undefined;
+let mockIsLoading = false;
+let mockIsError = false;
+
+vi.mock("@/shared/store/utilityPlansApi", () => ({
+  useGetUtilityPlanByIdQuery: vi.fn(() => ({
+    data: mockPlan,
+    isLoading: mockIsLoading,
+    isError: mockIsError,
+    isFetching: false,
+    refetch: mockRefetch,
+  })),
+  useUpdateUtilityPlanMutation: vi.fn(() => [mockUpdate, { isLoading: false }]),
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+const PLAN: UtilityPlanDetail = {
+  id: "plan-a",
+  user_id: "user-1",
+  organization_id: "org-1",
+  property_id: "prop-1",
+  property_name: "6734 Peerless St",
+  service_type: "electricity",
+  provider_name: "Constellation",
+  account_number: "204430810",
+  plan_name: "FIXED Electricity Plan",
+  rate_type: "fixed",
+  energy_charge_cents_per_kwh: "11.6000",
+  tdu_charge_cents_per_kwh: "5.3509",
+  avg_price_cents_per_kwh_at_1000: "13.9000",
+  monthly_base_charge_cents: 439,
+  term_months: 12,
+  service_start_date: "2025-01-23",
+  term_end_date: "2026-01-23",
+  early_termination_fee_cents: 15000,
+  has_bill_credit: false,
+  bill_credit_amount_cents: null,
+  bill_credit_threshold_kwh: null,
+  min_usage_fee_cents: 0,
+  min_usage_threshold_kwh: 999,
+  notes: "Account number unresolved — set it from a bill.",
+  days_until_term_end: -196,
+  renewal_status: "expired",
+  is_current: true,
+  created_at: "2025-01-23T00:00:00Z",
+  updated_at: "2025-01-23T00:00:00Z",
+};
+
+const onClose = vi.fn();
+
+function renderDialog() {
+  return render(<EditUtilityPlanDialog planId="plan-a" onClose={onClose} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPlan = PLAN;
+  mockIsLoading = false;
+  mockIsError = false;
+  mockUpdateUnwrap.mockResolvedValue(PLAN);
+  mockUpdate.mockReturnValue({ unwrap: mockUpdateUnwrap });
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("EditUtilityPlanDialog — load states", () => {
+  it("shows a skeleton instead of an empty form while the plan loads", () => {
+    mockPlan = undefined;
+    mockIsLoading = true;
+
+    renderDialog();
+
+    const skeleton = screen.getByTestId("utility-plan-form-loading");
+    expect(skeleton).toHaveAttribute("aria-busy", "true");
+    // No inputs yet — a form seeded from absent data would blank the plan on
+    // save, so it must not render before the data lands.
+    expect(screen.queryByTestId("utility-plan-provider-input")).not.toBeInTheDocument();
+  });
+
+  it("offers a retry when the plan fails to load", async () => {
+    mockPlan = undefined;
+    mockIsError = true;
+    const user = userEvent.setup();
+
+    renderDialog();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("EditUtilityPlanDialog — prefill", () => {
+  it("fills every field from the loaded plan", () => {
+    renderDialog();
+
+    expect(screen.getByTestId("utility-plan-provider-input")).toHaveValue("Constellation");
+    expect(screen.getByTestId("utility-plan-name-input")).toHaveValue(
+      "FIXED Electricity Plan",
+    );
+    expect(screen.getByTestId("utility-plan-account-input")).toHaveValue("204430810");
+    expect(screen.getByTestId("utility-plan-energy-input")).toHaveValue(11.6);
+    expect(screen.getByTestId("utility-plan-tdu-input")).toHaveValue(5.3509);
+    expect(screen.getByTestId("utility-plan-base-charge-input")).toHaveValue(4.39);
+    expect(screen.getByTestId("utility-plan-etf-input")).toHaveValue(150);
+    expect(screen.getByTestId("utility-plan-end-date-input")).toHaveValue("2026-01-23");
+  });
+
+  it("shows the property as context rather than as a field to change", () => {
+    // A plan cannot be moved between properties — doing so would rewrite the
+    // other property's rate history.
+    renderDialog();
+
+    expect(screen.getByTestId("edit-utility-plan-property")).toHaveTextContent(
+      "6734 Peerless St",
+    );
+    expect(screen.queryByTestId("utility-plan-property-select")).not.toBeInTheDocument();
+  });
+});
+
+describe("EditUtilityPlanDialog — save", () => {
+  it("patches the edited field and leaves the rest as they were", async () => {
+    const user = userEvent.setup();
+
+    renderDialog();
+    const provider = screen.getByTestId("utility-plan-provider-input");
+    await user.clear(provider);
+    await user.type(provider, "Reliant");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    const [{ planId, data }] = mockUpdate.mock.calls[0] as [
+      { planId: string; data: Record<string, unknown> },
+    ];
+    expect(planId).toBe("plan-a");
+    expect(data.provider_name).toBe("Reliant");
+    expect(data.tdu_charge_cents_per_kwh).toBe("5.3509");
+    expect(data.term_end_date).toBe("2026-01-23");
+  });
+
+  /**
+   * PATCH applies exactly the keys it receives, so a key the form does not own
+   * must never appear — sending null would erase the minimum-usage terms and
+   * the provenance note this plan carries.
+   */
+  it("never sends the fields it cannot edit", async () => {
+    const user = userEvent.setup();
+
+    renderDialog();
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    const [{ data }] = mockUpdate.mock.calls[0] as [{ data: Record<string, unknown> }];
+    expect(data).not.toHaveProperty("min_usage_fee_cents");
+    expect(data).not.toHaveProperty("min_usage_threshold_kwh");
+    expect(data).not.toHaveProperty("notes");
+    expect(data).not.toHaveProperty("property_id");
+  });
+
+  it("confirms and closes on success", async () => {
+    const user = userEvent.setup();
+
+    renderDialog();
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() =>
+      expect(showSuccess).toHaveBeenCalledWith("Utility plan updated."),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the dialog open with the edits intact when the save fails", async () => {
+    const user = userEvent.setup();
+    mockUpdateUnwrap.mockRejectedValue(new Error("boom"));
+
+    renderDialog();
+    const provider = screen.getByTestId("utility-plan-provider-input");
+    await user.clear(provider);
+    await user.type(provider, "Reliant");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() =>
+      expect(showError).toHaveBeenCalledWith(
+        "Couldn't save the changes. Please try again.",
+      ),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId("utility-plan-provider-input")).toHaveValue("Reliant");
+  });
+
+  it("does not submit an emptied provider", async () => {
+    // The input is `required`, so this never reaches the handler — the guard
+    // that matters here is simply that nothing is sent.
+    const user = userEvent.setup();
+
+    renderDialog();
+    await user.clear(screen.getByTestId("utility-plan-provider-input"));
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("blocks a whitespace-only provider, which `required` lets through", async () => {
+    const user = userEvent.setup();
+
+    renderDialog();
+    const provider = screen.getByTestId("utility-plan-provider-input");
+    await user.clear(provider);
+    await user.type(provider, "   ");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() =>
+      expect(showError).toHaveBeenCalledWith("Provider is required."),
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("requires both halves of a bill credit once the box is ticked", async () => {
+    const user = userEvent.setup();
+
+    renderDialog();
+    await user.click(screen.getByTestId("utility-plan-bill-credit-toggle"));
+    await user.type(screen.getByTestId("utility-plan-credit-amount-input"), "35");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() =>
+      expect(showError).toHaveBeenCalledWith(
+        "A bill credit needs both an amount and a usage threshold.",
+      ),
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/UtilityPlans.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/UtilityPlans.test.tsx
@@ -42,6 +42,14 @@ vi.mock("@/shared/store/utilityPlansApi", () => ({
     { isLoading: false },
   ]),
   useCreateUtilityPlanMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useUpdateUtilityPlanMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useGetUtilityPlanByIdQuery: vi.fn(() => ({
+    data: undefined,
+    isLoading: true,
+    isError: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  })),
   useGetUtilityPlanRenewalAlertsQuery: vi.fn(() => ({ data: undefined })),
 }));
 
@@ -293,5 +301,44 @@ describe("UtilityPlans — add dialog", () => {
     await user.click(screen.getByTestId("add-utility-plan-button"));
 
     expect(screen.getByTestId("add-utility-plan-dialog")).toBeInTheDocument();
+  });
+});
+
+describe("UtilityPlans — edit dialog", () => {
+  it("opens for the row whose edit action was used", async () => {
+    const user = userEvent.setup();
+    mockPlans = [makePlan(), makePlan({ id: "plan-b", property_name: "6732 Peerless St" })];
+
+    renderPage();
+    await user.click(screen.getByTestId("utility-plan-edit-plan-b"));
+
+    expect(screen.getByTestId("edit-utility-plan-dialog")).toBeInTheDocument();
+  });
+
+  it("names the plan in the edit action so rows stay distinguishable", () => {
+    // Every row of a portfolio shares one regulated gas provider, so provider
+    // alone would read identically to a screen reader.
+    mockPlans = [GAS_PLAN];
+
+    renderPage();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Edit CenterPoint Energy natural gas plan for 6734 Peerless St",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes without leaving the dialog mounted", async () => {
+    const user = userEvent.setup();
+    mockPlans = [makePlan()];
+
+    renderPage();
+    await user.click(screen.getByTestId("utility-plan-edit-plan-a"));
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("edit-utility-plan-dialog")).not.toBeInTheDocument(),
+    );
   });
 });

--- a/apps/mybookkeeper/frontend/src/__tests__/utility-plan-form.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/utility-plan-form.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the utility-plan form conversions.
+ *
+ * These functions are the only place a plan crosses between the API's shape
+ * (integer cents, Decimal-as-string rates) and the form's (everything a
+ * string). A rounding slip here misprices every comparison built on the row,
+ * so the round trip is asserted field by field.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  EMPTY_UTILITY_PLAN_FORM,
+  toUtilityPlanFields,
+  toUtilityPlanFormValues,
+  validateUtilityPlanForm,
+} from "@/shared/lib/utility-plan-form";
+import type { UtilityPlanDetail } from "@/shared/types/utility/utility-plan-detail";
+
+function makeDetail(overrides: Partial<UtilityPlanDetail> = {}): UtilityPlanDetail {
+  return {
+    id: "plan-a",
+    user_id: "user-1",
+    organization_id: "org-1",
+    property_id: "prop-1",
+    property_name: "6734 Peerless St",
+    service_type: "electricity",
+    provider_name: "Constellation",
+    account_number: "204430810",
+    plan_name: "FIXED Electricity Plan",
+    rate_type: "fixed",
+    energy_charge_cents_per_kwh: "11.6000",
+    tdu_charge_cents_per_kwh: "5.3509",
+    avg_price_cents_per_kwh_at_1000: "13.9000",
+    monthly_base_charge_cents: 439,
+    term_months: 12,
+    service_start_date: "2025-01-23",
+    term_end_date: "2026-01-23",
+    early_termination_fee_cents: 15000,
+    has_bill_credit: false,
+    bill_credit_amount_cents: null,
+    bill_credit_threshold_kwh: null,
+    min_usage_fee_cents: 0,
+    min_usage_threshold_kwh: 999,
+    notes: "Account number unresolved — set it from a bill.",
+    days_until_term_end: -196,
+    renewal_status: "expired",
+    is_current: true,
+    created_at: "2025-01-23T00:00:00Z",
+    updated_at: "2025-01-23T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("toUtilityPlanFormValues", () => {
+  it("prefills every editable field from a saved plan", () => {
+    const values = toUtilityPlanFormValues(makeDetail());
+
+    expect(values).toEqual({
+      serviceType: "electricity",
+      rateType: "fixed",
+      providerName: "Constellation",
+      planName: "FIXED Electricity Plan",
+      accountNumber: "204430810",
+      energyCharge: "11.6",
+      tduCharge: "5.3509",
+      avgPrice: "13.9",
+      monthlyBase: "4.39",
+      termMonths: "12",
+      serviceStartDate: "2025-01-23",
+      termEndDate: "2026-01-23",
+      etf: "150.00",
+      hasBillCredit: false,
+      billCreditAmount: "",
+      billCreditThreshold: "",
+    });
+  });
+
+  it("keeps a sub-cent TDU rate intact rather than rounding to two places", () => {
+    // 5.3509 rounded to 5.35 would misprice a year of delivery charges.
+    const values = toUtilityPlanFormValues(makeDetail());
+    expect(values.tduCharge).toBe("5.3509");
+  });
+
+  it("renders an absent optional field as blank, not as zero", () => {
+    const values = toUtilityPlanFormValues(
+      makeDetail({
+        plan_name: null,
+        account_number: null,
+        energy_charge_cents_per_kwh: null,
+        monthly_base_charge_cents: null,
+        term_months: null,
+        service_start_date: null,
+        term_end_date: null,
+        early_termination_fee_cents: null,
+      }),
+    );
+
+    expect(values.planName).toBe("");
+    expect(values.accountNumber).toBe("");
+    expect(values.energyCharge).toBe("");
+    expect(values.monthlyBase).toBe("");
+    expect(values.termMonths).toBe("");
+    expect(values.serviceStartDate).toBe("");
+    expect(values.termEndDate).toBe("");
+    expect(values.etf).toBe("");
+  });
+
+  it("prefills bill-credit terms when the plan has one", () => {
+    const values = toUtilityPlanFormValues(
+      makeDetail({
+        has_bill_credit: true,
+        bill_credit_amount_cents: 3500,
+        bill_credit_threshold_kwh: 1000,
+      }),
+    );
+
+    expect(values.hasBillCredit).toBe(true);
+    expect(values.billCreditAmount).toBe("35.00");
+    expect(values.billCreditThreshold).toBe("1000");
+  });
+});
+
+describe("toUtilityPlanFields", () => {
+  it("round-trips a saved plan back to the same values", () => {
+    const plan = makeDetail();
+    const payload = toUtilityPlanFields(toUtilityPlanFormValues(plan));
+
+    expect(payload.provider_name).toBe(plan.provider_name);
+    expect(payload.plan_name).toBe(plan.plan_name);
+    expect(payload.account_number).toBe(plan.account_number);
+    expect(payload.monthly_base_charge_cents).toBe(439);
+    expect(payload.early_termination_fee_cents).toBe(15000);
+    expect(payload.term_months).toBe(12);
+    expect(payload.service_start_date).toBe("2025-01-23");
+    expect(payload.term_end_date).toBe("2026-01-23");
+  });
+
+  it("sends rates as strings so precision survives the JSON boundary", () => {
+    const payload = toUtilityPlanFields(toUtilityPlanFormValues(makeDetail()));
+
+    expect(payload.tdu_charge_cents_per_kwh).toBe("5.3509");
+    expect(typeof payload.tdu_charge_cents_per_kwh).toBe("string");
+  });
+
+  /**
+   * The API applies exactly the keys it receives (``exclude_unset``). Emitting
+   * these as null would erase the minimum-usage terms and the provenance note
+   * the seeded plans carry, neither of which this form can edit.
+   */
+  it("omits the fields the form does not edit rather than nulling them", () => {
+    const payload = toUtilityPlanFields(toUtilityPlanFormValues(makeDetail()));
+
+    expect(payload).not.toHaveProperty("min_usage_fee_cents");
+    expect(payload).not.toHaveProperty("min_usage_threshold_kwh");
+    expect(payload).not.toHaveProperty("notes");
+    expect(payload).not.toHaveProperty("property_id");
+  });
+
+  it("turns an untouched optional field into null, not an empty string", () => {
+    const payload = toUtilityPlanFields(EMPTY_UTILITY_PLAN_FORM);
+
+    expect(payload.plan_name).toBeNull();
+    expect(payload.account_number).toBeNull();
+    expect(payload.energy_charge_cents_per_kwh).toBeNull();
+    expect(payload.monthly_base_charge_cents).toBeNull();
+    expect(payload.term_months).toBeNull();
+    expect(payload.service_start_date).toBeNull();
+    expect(payload.term_end_date).toBeNull();
+  });
+
+  it("converts dollars to integer cents", () => {
+    const payload = toUtilityPlanFields({
+      ...EMPTY_UTILITY_PLAN_FORM,
+      providerName: "Reliant",
+      monthlyBase: "4.39",
+      etf: "150",
+    });
+
+    expect(payload.monthly_base_charge_cents).toBe(439);
+    expect(payload.early_termination_fee_cents).toBe(15000);
+  });
+
+  it("drops bill-credit figures when the credit is switched off", () => {
+    // Otherwise unchecking the box would leave a credit amount on the row and
+    // the backend would reject the half-recorded pair.
+    const payload = toUtilityPlanFields({
+      ...EMPTY_UTILITY_PLAN_FORM,
+      providerName: "Reliant",
+      hasBillCredit: false,
+      billCreditAmount: "35",
+      billCreditThreshold: "1000",
+    });
+
+    expect(payload.has_bill_credit).toBe(false);
+    expect(payload.bill_credit_amount_cents).toBeNull();
+    expect(payload.bill_credit_threshold_kwh).toBeNull();
+  });
+
+  it("trims surrounding whitespace off text fields", () => {
+    const payload = toUtilityPlanFields({
+      ...EMPTY_UTILITY_PLAN_FORM,
+      providerName: "  Constellation  ",
+      planName: "  12 Month Fixed  ",
+    });
+
+    expect(payload.provider_name).toBe("Constellation");
+    expect(payload.plan_name).toBe("12 Month Fixed");
+  });
+});
+
+describe("validateUtilityPlanForm", () => {
+  it("accepts a form with only a provider", () => {
+    expect(
+      validateUtilityPlanForm({ ...EMPTY_UTILITY_PLAN_FORM, providerName: "Reliant" }),
+    ).toBeNull();
+  });
+
+  it("rejects a blank provider", () => {
+    expect(
+      validateUtilityPlanForm({ ...EMPTY_UTILITY_PLAN_FORM, providerName: "   " }),
+    ).toBe("Provider is required.");
+  });
+
+  it("rejects a half-recorded bill credit", () => {
+    expect(
+      validateUtilityPlanForm({
+        ...EMPTY_UTILITY_PLAN_FORM,
+        providerName: "Reliant",
+        hasBillCredit: true,
+        billCreditAmount: "35",
+        billCreditThreshold: "",
+      }),
+    ).toBe("A bill credit needs both an amount and a usage threshold.");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/utility/AddUtilityPlanDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/AddUtilityPlanDialog.tsx
@@ -1,77 +1,27 @@
 import { useState } from "react";
-import { X } from "lucide-react";
-import { Button, LoadingButton } from "@platform/ui";
 import FormField from "@/shared/components/ui/FormField";
+import {
+  toUtilityPlanFields,
+  validateUtilityPlanForm,
+} from "@/shared/lib/utility-plan-form";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import { useGetPropertiesQuery } from "@/shared/store/propertiesApi";
 import { useCreateUtilityPlanMutation } from "@/shared/store/utilityPlansApi";
-import {
-  UTILITY_PLAN_RATE_TYPES,
-  UTILITY_PLAN_RATE_TYPE_HINTS,
-  UTILITY_PLAN_RATE_TYPE_LABELS,
-} from "@/shared/types/utility/utility-plan-rate-type";
-import {
-  UTILITY_SERVICE_TYPES,
-  UTILITY_SERVICE_TYPE_LABELS,
-} from "@/shared/types/utility/utility-service-type";
-import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-rate-type";
-import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+import UtilityPlanDialogShell from "./UtilityPlanDialogShell";
+import UtilityPlanFormActions from "./UtilityPlanFormActions";
+import UtilityPlanFormFields, { UTILITY_PLAN_INPUT_CLASS } from "./UtilityPlanFormFields";
+import { useUtilityPlanForm } from "./useUtilityPlanForm";
 
 export interface AddUtilityPlanDialogProps {
   onClose: () => void;
 }
 
-const INPUT_CLASS = "w-full px-3 py-2 text-sm border rounded-md";
-
-/** ``""`` → null so an untouched field is absent rather than zero. */
-function optionalText(value: string): string | null {
-  return value.trim() === "" ? null : value.trim();
-}
-
-/**
- * Dollars → integer cents. Kept separate from the rate fields, which are sent
- * as strings: a rate carries four decimal places and must not round-trip
- * through a float.
- */
-function dollarsToCents(value: string): number | null {
-  if (value.trim() === "") return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? Math.round(parsed * 100) : null;
-}
-
-function toInt(value: string): number | null {
-  if (value.trim() === "") return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? Math.round(parsed) : null;
-}
-
-/**
- * Modal dialog for recording a utility plan against a property.
- */
+/** Modal dialog for recording a utility plan against a property. */
 export default function AddUtilityPlanDialog({ onClose }: AddUtilityPlanDialogProps) {
   const { data: properties = [] } = useGetPropertiesQuery();
   const [createPlan, { isLoading }] = useCreateUtilityPlanMutation();
-
+  const { values, setField } = useUtilityPlanForm();
   const [propertyId, setPropertyId] = useState("");
-  const [serviceType, setServiceType] = useState<UtilityServiceType>("electricity");
-  const [rateType, setRateType] = useState<UtilityPlanRateType>("fixed");
-  const [providerName, setProviderName] = useState("");
-  const [planName, setPlanName] = useState("");
-  const [accountNumber, setAccountNumber] = useState("");
-
-  const [energyCharge, setEnergyCharge] = useState("");
-  const [tduCharge, setTduCharge] = useState("");
-  const [avgPrice, setAvgPrice] = useState("");
-  const [monthlyBase, setMonthlyBase] = useState("");
-
-  const [termMonths, setTermMonths] = useState("");
-  const [serviceStartDate, setServiceStartDate] = useState("");
-  const [termEndDate, setTermEndDate] = useState("");
-  const [etf, setEtf] = useState("");
-
-  const [hasBillCredit, setHasBillCredit] = useState(false);
-  const [billCreditAmount, setBillCreditAmount] = useState("");
-  const [billCreditThreshold, setBillCreditThreshold] = useState("");
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -79,37 +29,16 @@ export default function AddUtilityPlanDialog({ onClose }: AddUtilityPlanDialogPr
       showError("Pick a property.");
       return;
     }
-    if (!providerName.trim()) {
-      showError("Provider is required.");
-      return;
-    }
-    if (hasBillCredit && (billCreditAmount.trim() === "" || billCreditThreshold.trim() === "")) {
-      // The backend rejects a half-recorded credit too; catching it here saves
-      // a round trip and points at the field rather than the form.
-      showError("A bill credit needs both an amount and a usage threshold.");
+    const problem = validateUtilityPlanForm(values);
+    if (problem) {
+      showError(problem);
       return;
     }
 
     try {
       await createPlan({
         property_id: propertyId,
-        service_type: serviceType,
-        rate_type: rateType,
-        provider_name: providerName.trim(),
-        plan_name: optionalText(planName),
-        account_number: optionalText(accountNumber),
-        // Rates stay strings end-to-end so 5.3509 survives intact.
-        energy_charge_cents_per_kwh: optionalText(energyCharge),
-        tdu_charge_cents_per_kwh: optionalText(tduCharge),
-        avg_price_cents_per_kwh_at_1000: optionalText(avgPrice),
-        monthly_base_charge_cents: dollarsToCents(monthlyBase),
-        term_months: toInt(termMonths),
-        service_start_date: serviceStartDate || null,
-        term_end_date: termEndDate || null,
-        early_termination_fee_cents: dollarsToCents(etf),
-        has_bill_credit: hasBillCredit,
-        bill_credit_amount_cents: hasBillCredit ? dollarsToCents(billCreditAmount) : null,
-        bill_credit_threshold_kwh: hasBillCredit ? toInt(billCreditThreshold) : null,
+        ...toUtilityPlanFields(values),
       }).unwrap();
       showSuccess("Utility plan added.");
       onClose();
@@ -119,279 +48,37 @@ export default function AddUtilityPlanDialog({ onClose }: AddUtilityPlanDialogPr
   }
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
-      data-testid="add-utility-plan-dialog"
+    <UtilityPlanDialogShell
+      title="Add utility plan"
+      testId="add-utility-plan-dialog"
+      onClose={onClose}
     >
-      <div className="bg-background rounded-lg shadow-lg w-full max-w-lg max-h-[90vh] overflow-y-auto">
-        <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b">
-          <h2 className="text-base font-semibold">Add utility plan</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-muted-foreground hover:text-foreground min-h-[44px] min-w-[44px] flex items-center justify-center"
-            aria-label="Close"
+      <form onSubmit={(e) => void handleSubmit(e)} className="p-5 space-y-4">
+        <FormField label="Property" required>
+          <select
+            value={propertyId}
+            onChange={(e) => setPropertyId(e.target.value)}
+            className={UTILITY_PLAN_INPUT_CLASS}
+            required
+            data-testid="utility-plan-property-select"
           >
-            <X size={18} />
-          </button>
-        </div>
+            <option value="">Select a property…</option>
+            {properties.map((property) => (
+              <option key={property.id} value={property.id}>
+                {property.name}
+              </option>
+            ))}
+          </select>
+        </FormField>
 
-        <form onSubmit={(e) => void handleSubmit(e)} className="p-5 space-y-4">
-          <FormField label="Property" required>
-            <select
-              value={propertyId}
-              onChange={(e) => setPropertyId(e.target.value)}
-              className={INPUT_CLASS}
-              required
-              data-testid="utility-plan-property-select"
-            >
-              <option value="">Select a property…</option>
-              {properties.map((property) => (
-                <option key={property.id} value={property.id}>
-                  {property.name}
-                </option>
-              ))}
-            </select>
-          </FormField>
+        <UtilityPlanFormFields values={values} setField={setField} />
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <FormField label="Service" required>
-              <select
-                value={serviceType}
-                onChange={(e) => setServiceType(e.target.value as UtilityServiceType)}
-                className={INPUT_CLASS}
-                data-testid="utility-plan-service-select"
-              >
-                {UTILITY_SERVICE_TYPES.map((value) => (
-                  <option key={value} value={value}>
-                    {UTILITY_SERVICE_TYPE_LABELS[value]}
-                  </option>
-                ))}
-              </select>
-            </FormField>
-
-            <FormField label="Rate type" required>
-              <select
-                value={rateType}
-                onChange={(e) => setRateType(e.target.value as UtilityPlanRateType)}
-                className={INPUT_CLASS}
-                data-testid="utility-plan-rate-type-select"
-              >
-                {UTILITY_PLAN_RATE_TYPES.map((value) => (
-                  <option key={value} value={value}>
-                    {UTILITY_PLAN_RATE_TYPE_LABELS[value]}
-                  </option>
-                ))}
-              </select>
-            </FormField>
-          </div>
-
-          <p className="text-xs text-muted-foreground -mt-2" data-testid="utility-plan-rate-hint">
-            {UTILITY_PLAN_RATE_TYPE_HINTS[rateType]}
-          </p>
-
-          <FormField label="Provider" required>
-            <input
-              type="text"
-              value={providerName}
-              onChange={(e) => setProviderName(e.target.value)}
-              placeholder="e.g. Constellation"
-              className={INPUT_CLASS}
-              maxLength={255}
-              required
-              data-testid="utility-plan-provider-input"
-            />
-          </FormField>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <FormField label="Plan name">
-              <input
-                type="text"
-                value={planName}
-                onChange={(e) => setPlanName(e.target.value)}
-                placeholder="e.g. 12 Month Fixed"
-                className={INPUT_CLASS}
-                maxLength={255}
-                data-testid="utility-plan-name-input"
-              />
-            </FormField>
-
-            <FormField label="Account number">
-              <input
-                type="text"
-                value={accountNumber}
-                onChange={(e) => setAccountNumber(e.target.value)}
-                placeholder="e.g. 6403771807-5"
-                className={INPUT_CLASS}
-                maxLength={100}
-                data-testid="utility-plan-account-input"
-              />
-            </FormField>
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <FormField label="Energy charge (¢/kWh)">
-              <input
-                type="number"
-                value={energyCharge}
-                onChange={(e) => setEnergyCharge(e.target.value)}
-                placeholder="11.6"
-                min="0"
-                step="0.0001"
-                className={INPUT_CLASS}
-                data-testid="utility-plan-energy-input"
-              />
-            </FormField>
-
-            <FormField label="Delivery / TDU charge (¢/kWh)">
-              <input
-                type="number"
-                value={tduCharge}
-                onChange={(e) => setTduCharge(e.target.value)}
-                placeholder="5.3509"
-                min="0"
-                step="0.0001"
-                className={INPUT_CLASS}
-                data-testid="utility-plan-tdu-input"
-              />
-            </FormField>
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <FormField label="Average price at 1,000 kWh (¢/kWh)">
-              <input
-                type="number"
-                value={avgPrice}
-                onChange={(e) => setAvgPrice(e.target.value)}
-                placeholder="13.9"
-                min="0"
-                step="0.0001"
-                className={INPUT_CLASS}
-                data-testid="utility-plan-avg-price-input"
-              />
-            </FormField>
-
-            <FormField label="Monthly base charge (USD)">
-              <input
-                type="number"
-                value={monthlyBase}
-                onChange={(e) => setMonthlyBase(e.target.value)}
-                placeholder="4.39"
-                min="0"
-                step="0.01"
-                className={INPUT_CLASS}
-                data-testid="utility-plan-base-charge-input"
-              />
-            </FormField>
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            <FormField label="Term (months)">
-              <input
-                type="number"
-                value={termMonths}
-                onChange={(e) => setTermMonths(e.target.value)}
-                placeholder="12"
-                min="0"
-                max="600"
-                step="1"
-                className={INPUT_CLASS}
-                data-testid="utility-plan-term-months-input"
-              />
-            </FormField>
-
-            <FormField label="Service start">
-              <input
-                type="date"
-                value={serviceStartDate}
-                onChange={(e) => setServiceStartDate(e.target.value)}
-                className={INPUT_CLASS}
-                data-testid="utility-plan-start-date-input"
-              />
-            </FormField>
-
-            <FormField label="Term ends">
-              <input
-                type="date"
-                value={termEndDate}
-                onChange={(e) => setTermEndDate(e.target.value)}
-                className={INPUT_CLASS}
-                data-testid="utility-plan-end-date-input"
-              />
-            </FormField>
-          </div>
-
-          <FormField label="Early termination fee (USD)">
-            <input
-              type="number"
-              value={etf}
-              onChange={(e) => setEtf(e.target.value)}
-              placeholder="150"
-              min="0"
-              step="0.01"
-              className={INPUT_CLASS}
-              data-testid="utility-plan-etf-input"
-            />
-          </FormField>
-
-          <label className="flex items-center gap-2 text-sm cursor-pointer">
-            <input
-              type="checkbox"
-              checked={hasBillCredit}
-              onChange={(e) => setHasBillCredit(e.target.checked)}
-              className="rounded"
-              data-testid="utility-plan-bill-credit-toggle"
-            />
-            This plan has a usage-based bill credit
-          </label>
-
-          {hasBillCredit ? (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <FormField label="Credit amount (USD)" required>
-                <input
-                  type="number"
-                  value={billCreditAmount}
-                  onChange={(e) => setBillCreditAmount(e.target.value)}
-                  placeholder="35"
-                  min="0"
-                  step="0.01"
-                  className={INPUT_CLASS}
-                  data-testid="utility-plan-credit-amount-input"
-                />
-              </FormField>
-
-              <FormField label="Applies at or above (kWh)" required>
-                <input
-                  type="number"
-                  value={billCreditThreshold}
-                  onChange={(e) => setBillCreditThreshold(e.target.value)}
-                  placeholder="1000"
-                  min="0"
-                  step="1"
-                  className={INPUT_CLASS}
-                  data-testid="utility-plan-credit-threshold-input"
-                />
-              </FormField>
-            </div>
-          ) : null}
-
-          <div className="flex gap-3 pt-2 justify-end">
-            <Button type="button" variant="secondary" size="md" onClick={onClose}>
-              Cancel
-            </Button>
-            <LoadingButton
-              type="submit"
-              variant="primary"
-              size="md"
-              isLoading={isLoading}
-              loadingText="Saving..."
-              data-testid="utility-plan-save-button"
-            >
-              Save plan
-            </LoadingButton>
-          </div>
-        </form>
-      </div>
-    </div>
+        <UtilityPlanFormActions
+          isSaving={isLoading}
+          saveLabel="Save plan"
+          onCancel={onClose}
+        />
+      </form>
+    </UtilityPlanDialogShell>
   );
 }

--- a/apps/mybookkeeper/frontend/src/app/features/utility/EditUtilityPlanDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/EditUtilityPlanDialog.tsx
@@ -1,0 +1,54 @@
+import AlertBox from "@/shared/components/ui/AlertBox";
+import { useGetUtilityPlanByIdQuery } from "@/shared/store/utilityPlansApi";
+import EditUtilityPlanForm from "./EditUtilityPlanForm";
+import UtilityPlanDialogShell from "./UtilityPlanDialogShell";
+import UtilityPlanFormSkeleton from "./UtilityPlanFormSkeleton";
+
+export interface EditUtilityPlanDialogProps {
+  planId: string;
+  onClose: () => void;
+}
+
+/**
+ * Modal dialog for correcting a recorded utility plan.
+ *
+ * The list row carries only a summary, so the full plan is fetched here: the
+ * bill-credit terms and the account number are editable but absent from the
+ * summary, and submitting a form seeded from partial data would blank them.
+ */
+export default function EditUtilityPlanDialog({
+  planId,
+  onClose,
+}: EditUtilityPlanDialogProps) {
+  const { data: plan, isLoading, isError, refetch, isFetching } =
+    useGetUtilityPlanByIdQuery(planId);
+
+  return (
+    <UtilityPlanDialogShell
+      title="Edit utility plan"
+      testId="edit-utility-plan-dialog"
+      onClose={onClose}
+    >
+      {isLoading ? <UtilityPlanFormSkeleton /> : null}
+
+      {isError ? (
+        <div className="p-5">
+          <AlertBox variant="error" className="flex items-center justify-between gap-3">
+            <span>Couldn't load this plan.</span>
+            <button
+              type="button"
+              onClick={() => void refetch()}
+              className="text-sm font-medium hover:underline"
+            >
+              {isFetching ? "Retrying..." : "Retry"}
+            </button>
+          </AlertBox>
+        </div>
+      ) : null}
+
+      {plan ? (
+        <EditUtilityPlanForm plan={plan} onSaved={onClose} onCancel={onClose} />
+      ) : null}
+    </UtilityPlanDialogShell>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/EditUtilityPlanForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/EditUtilityPlanForm.tsx
@@ -1,0 +1,68 @@
+import {
+  toUtilityPlanFields,
+  toUtilityPlanFormValues,
+  validateUtilityPlanForm,
+} from "@/shared/lib/utility-plan-form";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { useUpdateUtilityPlanMutation } from "@/shared/store/utilityPlansApi";
+import type { UtilityPlanDetail } from "@/shared/types/utility/utility-plan-detail";
+import UtilityPlanFormActions from "./UtilityPlanFormActions";
+import UtilityPlanFormFields from "./UtilityPlanFormFields";
+import { useUtilityPlanForm } from "./useUtilityPlanForm";
+
+export interface EditUtilityPlanFormProps {
+  plan: UtilityPlanDetail;
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * The edit dialog's body, mounted only once its plan has loaded.
+ *
+ * Split from the dialog so the form's initial state can be seeded straight
+ * from ``plan`` — the fields are then owned by the operator, and a background
+ * refetch cannot overwrite what they have typed.
+ */
+export default function EditUtilityPlanForm({
+  plan,
+  onSaved,
+  onCancel,
+}: EditUtilityPlanFormProps) {
+  const [updatePlan, { isLoading }] = useUpdateUtilityPlanMutation();
+  const { values, setField } = useUtilityPlanForm(toUtilityPlanFormValues(plan));
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const problem = validateUtilityPlanForm(values);
+    if (problem) {
+      showError(problem);
+      return;
+    }
+
+    try {
+      await updatePlan({ planId: plan.id, data: toUtilityPlanFields(values) }).unwrap();
+      showSuccess("Utility plan updated.");
+      onSaved();
+    } catch {
+      showError("Couldn't save the changes. Please try again.");
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} className="p-5 space-y-4">
+      {/* The property is fixed for the life of the plan, so it reads as
+          context rather than as a field the operator can change. */}
+      <p className="text-sm text-muted-foreground" data-testid="edit-utility-plan-property">
+        {plan.property_name ?? "Unknown property"}
+      </p>
+
+      <UtilityPlanFormFields values={values} setField={setField} />
+
+      <UtilityPlanFormActions
+        isSaving={isLoading}
+        saveLabel="Save changes"
+        onCancel={onCancel}
+      />
+    </form>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDialogShell.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDialogShell.tsx
@@ -1,0 +1,38 @@
+import { X } from "lucide-react";
+
+export interface UtilityPlanDialogShellProps {
+  title: string;
+  testId: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+/** Modal chrome shared by the add and edit utility-plan dialogs. */
+export default function UtilityPlanDialogShell({
+  title,
+  testId,
+  onClose,
+  children,
+}: UtilityPlanDialogShellProps) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      data-testid={testId}
+    >
+      <div className="bg-background rounded-lg shadow-lg w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b">
+          <h2 className="text-base font-semibold">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground min-h-[44px] min-w-[44px] flex items-center justify-center"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormActions.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormActions.tsx
@@ -1,0 +1,32 @@
+import { Button, LoadingButton } from "@platform/ui";
+
+export interface UtilityPlanFormActionsProps {
+  isSaving: boolean;
+  saveLabel: string;
+  onCancel: () => void;
+}
+
+/** Cancel + save footer shared by the add and edit utility-plan dialogs. */
+export default function UtilityPlanFormActions({
+  isSaving,
+  saveLabel,
+  onCancel,
+}: UtilityPlanFormActionsProps) {
+  return (
+    <div className="flex gap-3 pt-2 justify-end">
+      <Button type="button" variant="secondary" size="md" onClick={onCancel}>
+        Cancel
+      </Button>
+      <LoadingButton
+        type="submit"
+        variant="primary"
+        size="md"
+        isLoading={isSaving}
+        loadingText="Saving..."
+        data-testid="utility-plan-save-button"
+      >
+        {saveLabel}
+      </LoadingButton>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormFields.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormFields.tsx
@@ -1,0 +1,254 @@
+import FormField from "@/shared/components/ui/FormField";
+import {
+  UTILITY_PLAN_RATE_TYPES,
+  UTILITY_PLAN_RATE_TYPE_HINTS,
+  UTILITY_PLAN_RATE_TYPE_LABELS,
+} from "@/shared/types/utility/utility-plan-rate-type";
+import {
+  UTILITY_SERVICE_TYPES,
+  UTILITY_SERVICE_TYPE_LABELS,
+} from "@/shared/types/utility/utility-service-type";
+import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-rate-type";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+import type { UtilityPlanFormState } from "./useUtilityPlanForm";
+
+export type UtilityPlanFormFieldsProps = UtilityPlanFormState;
+
+export const UTILITY_PLAN_INPUT_CLASS = "w-full px-3 py-2 text-sm border rounded-md";
+
+/**
+ * Every field of a utility plan except the property it belongs to.
+ *
+ * Shared verbatim by the add and edit dialogs — the property selector is
+ * add-only, because a saved plan cannot be moved to another property without
+ * rewriting that property's rate history.
+ */
+export default function UtilityPlanFormFields({
+  values,
+  setField,
+}: UtilityPlanFormFieldsProps) {
+  return (
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <FormField label="Service" required>
+          <select
+            value={values.serviceType}
+            onChange={(e) => setField("serviceType", e.target.value as UtilityServiceType)}
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-service-select"
+          >
+            {UTILITY_SERVICE_TYPES.map((value) => (
+              <option key={value} value={value}>
+                {UTILITY_SERVICE_TYPE_LABELS[value]}
+              </option>
+            ))}
+          </select>
+        </FormField>
+
+        <FormField label="Rate type" required>
+          <select
+            value={values.rateType}
+            onChange={(e) => setField("rateType", e.target.value as UtilityPlanRateType)}
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-rate-type-select"
+          >
+            {UTILITY_PLAN_RATE_TYPES.map((value) => (
+              <option key={value} value={value}>
+                {UTILITY_PLAN_RATE_TYPE_LABELS[value]}
+              </option>
+            ))}
+          </select>
+        </FormField>
+      </div>
+
+      <p className="text-xs text-muted-foreground -mt-2" data-testid="utility-plan-rate-hint">
+        {UTILITY_PLAN_RATE_TYPE_HINTS[values.rateType]}
+      </p>
+
+      <FormField label="Provider" required>
+        <input
+          type="text"
+          value={values.providerName}
+          onChange={(e) => setField("providerName", e.target.value)}
+          placeholder="e.g. Constellation"
+          className={UTILITY_PLAN_INPUT_CLASS}
+          maxLength={255}
+          required
+          data-testid="utility-plan-provider-input"
+        />
+      </FormField>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <FormField label="Plan name">
+          <input
+            type="text"
+            value={values.planName}
+            onChange={(e) => setField("planName", e.target.value)}
+            placeholder="e.g. 12 Month Fixed"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            maxLength={255}
+            data-testid="utility-plan-name-input"
+          />
+        </FormField>
+
+        <FormField label="Account number">
+          <input
+            type="text"
+            value={values.accountNumber}
+            onChange={(e) => setField("accountNumber", e.target.value)}
+            placeholder="e.g. 6403771807-5"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            maxLength={100}
+            data-testid="utility-plan-account-input"
+          />
+        </FormField>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <FormField label="Energy charge (¢/kWh)">
+          <input
+            type="number"
+            value={values.energyCharge}
+            onChange={(e) => setField("energyCharge", e.target.value)}
+            placeholder="11.6"
+            min="0"
+            step="0.0001"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-energy-input"
+          />
+        </FormField>
+
+        <FormField label="Delivery / TDU charge (¢/kWh)">
+          <input
+            type="number"
+            value={values.tduCharge}
+            onChange={(e) => setField("tduCharge", e.target.value)}
+            placeholder="5.3509"
+            min="0"
+            step="0.0001"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-tdu-input"
+          />
+        </FormField>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <FormField label="Average price at 1,000 kWh (¢/kWh)">
+          <input
+            type="number"
+            value={values.avgPrice}
+            onChange={(e) => setField("avgPrice", e.target.value)}
+            placeholder="13.9"
+            min="0"
+            step="0.0001"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-avg-price-input"
+          />
+        </FormField>
+
+        <FormField label="Monthly base charge (USD)">
+          <input
+            type="number"
+            value={values.monthlyBase}
+            onChange={(e) => setField("monthlyBase", e.target.value)}
+            placeholder="4.39"
+            min="0"
+            step="0.01"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-base-charge-input"
+          />
+        </FormField>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <FormField label="Term (months)">
+          <input
+            type="number"
+            value={values.termMonths}
+            onChange={(e) => setField("termMonths", e.target.value)}
+            placeholder="12"
+            min="0"
+            max="600"
+            step="1"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-term-months-input"
+          />
+        </FormField>
+
+        <FormField label="Service start">
+          <input
+            type="date"
+            value={values.serviceStartDate}
+            onChange={(e) => setField("serviceStartDate", e.target.value)}
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-start-date-input"
+          />
+        </FormField>
+
+        <FormField label="Term ends">
+          <input
+            type="date"
+            value={values.termEndDate}
+            onChange={(e) => setField("termEndDate", e.target.value)}
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-end-date-input"
+          />
+        </FormField>
+      </div>
+
+      <FormField label="Early termination fee (USD)">
+        <input
+          type="number"
+          value={values.etf}
+          onChange={(e) => setField("etf", e.target.value)}
+          placeholder="150"
+          min="0"
+          step="0.01"
+          className={UTILITY_PLAN_INPUT_CLASS}
+          data-testid="utility-plan-etf-input"
+        />
+      </FormField>
+
+      <label className="flex items-center gap-2 text-sm cursor-pointer">
+        <input
+          type="checkbox"
+          checked={values.hasBillCredit}
+          onChange={(e) => setField("hasBillCredit", e.target.checked)}
+          className="rounded"
+          data-testid="utility-plan-bill-credit-toggle"
+        />
+        This plan has a usage-based bill credit
+      </label>
+
+      {values.hasBillCredit ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <FormField label="Credit amount (USD)" required>
+            <input
+              type="number"
+              value={values.billCreditAmount}
+              onChange={(e) => setField("billCreditAmount", e.target.value)}
+              placeholder="35"
+              min="0"
+              step="0.01"
+              className={UTILITY_PLAN_INPUT_CLASS}
+              data-testid="utility-plan-credit-amount-input"
+            />
+          </FormField>
+
+          <FormField label="Applies at or above (kWh)" required>
+            <input
+              type="number"
+              value={values.billCreditThreshold}
+              onChange={(e) => setField("billCreditThreshold", e.target.value)}
+              placeholder="1000"
+              min="0"
+              step="1"
+              className={UTILITY_PLAN_INPUT_CLASS}
+              data-testid="utility-plan-credit-threshold-input"
+            />
+          </FormField>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormSkeleton.tsx
@@ -1,0 +1,46 @@
+/**
+ * Placeholder shown while the edit dialog loads the plan.
+ *
+ * Mirrors the loaded form — two-across pairs, the three-across term row, the
+ * full-width provider and fee fields, and the footer — so the dialog does not
+ * resize under the operator when the data lands.
+ */
+export default function UtilityPlanFormSkeleton() {
+  return (
+    <div
+      className="p-5 space-y-4 animate-pulse"
+      aria-busy="true"
+      data-testid="utility-plan-form-loading"
+    >
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="h-14 bg-muted rounded" />
+        <div className="h-14 bg-muted rounded" />
+      </div>
+      <div className="h-3 bg-muted rounded w-3/5" />
+      <div className="h-14 bg-muted rounded" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="h-14 bg-muted rounded" />
+        <div className="h-14 bg-muted rounded" />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="h-14 bg-muted rounded" />
+        <div className="h-14 bg-muted rounded" />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="h-14 bg-muted rounded" />
+        <div className="h-14 bg-muted rounded" />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="h-14 bg-muted rounded" />
+        <div className="h-14 bg-muted rounded" />
+        <div className="h-14 bg-muted rounded" />
+      </div>
+      <div className="h-14 bg-muted rounded" />
+      <div className="h-5 bg-muted rounded w-2/5" />
+      <div className="flex gap-3 pt-2 justify-end">
+        <div className="h-10 w-24 bg-muted rounded" />
+        <div className="h-10 w-32 bg-muted rounded" />
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRow.tsx
@@ -1,4 +1,4 @@
-import { Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import {
   formatCentsPerKwh,
   formatPlanDate,
@@ -12,10 +12,23 @@ import UtilityPlanRenewalBadge from "./UtilityPlanRenewalBadge";
 export interface UtilityPlanRowProps {
   plan: UtilityPlanSummary;
   isDeleting: boolean;
+  onEdit: (plan: UtilityPlanSummary) => void;
   onDelete: (plan: UtilityPlanSummary) => void;
 }
 
-export default function UtilityPlanRow({ plan, isDeleting, onDelete }: UtilityPlanRowProps) {
+export default function UtilityPlanRow({
+  plan,
+  isDeleting,
+  onEdit,
+  onDelete,
+}: UtilityPlanRowProps) {
+  // Provider alone is ambiguous: the same regulated utility serves every
+  // property, so several rows would all read "CenterPoint Energy plan" to a
+  // screen reader. Property and service disambiguate them.
+  const planLabel = `${plan.provider_name} ${UTILITY_SERVICE_TYPE_LABELS[
+    plan.service_type
+  ].toLowerCase()} plan for ${plan.property_name ?? "unknown property"}`;
+
   return (
     <li
       className="border rounded-lg px-4 py-3 text-sm"
@@ -57,17 +70,20 @@ export default function UtilityPlanRow({ plan, isDeleting, onDelete }: UtilityPl
 
         <div className="flex items-center gap-2 shrink-0">
           <UtilityPlanRenewalBadge status={plan.renewal_status} />
-          {/* Provider alone is ambiguous: the same regulated utility serves
-              every property, so several rows would all read "Delete
-              CenterPoint Energy plan" to a screen reader. Property and
-              service disambiguate them. */}
+          <button
+            type="button"
+            onClick={() => onEdit(plan)}
+            aria-label={`Edit ${planLabel}`}
+            className="text-muted-foreground hover:text-foreground min-h-[44px] min-w-[44px] flex items-center justify-center"
+            data-testid={`utility-plan-edit-${plan.id}`}
+          >
+            <Pencil size={16} />
+          </button>
           <button
             type="button"
             onClick={() => onDelete(plan)}
             disabled={isDeleting}
-            aria-label={`Delete ${plan.provider_name} ${UTILITY_SERVICE_TYPE_LABELS[
-              plan.service_type
-            ].toLowerCase()} plan for ${plan.property_name ?? "unknown property"}`}
+            aria-label={`Delete ${planLabel}`}
             className="text-muted-foreground hover:text-red-600 disabled:opacity-50 min-h-[44px] min-w-[44px] flex items-center justify-center"
             data-testid={`utility-plan-delete-${plan.id}`}
           >

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlansListBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlansListBody.tsx
@@ -7,6 +7,7 @@ export interface UtilityPlansListBodyProps {
   plans: UtilityPlanSummary[];
   showExpiringOnly: boolean;
   deletingPlanId: string | null;
+  onEdit: (plan: UtilityPlanSummary) => void;
   onDelete: (plan: UtilityPlanSummary) => void;
 }
 
@@ -15,13 +16,16 @@ export default function UtilityPlansListBody({
   plans,
   showExpiringOnly,
   deletingPlanId,
+  onEdit,
   onDelete,
 }: UtilityPlansListBodyProps) {
   switch (mode) {
     case "loading":
       return (
-        // Mirrors the loaded row: two-line left block plus a badge on the
-        // right, so nothing shifts when the data lands.
+        // Mirrors the loaded row: two-line left block, then a badge and the
+        // edit/delete actions on the right, so nothing shifts when the data
+        // lands. Only the badge placeholder is a pill — the action slots are
+        // square, matching the icon buttons they stand in for.
         <div
           className="space-y-2 animate-pulse"
           aria-busy="true"
@@ -35,7 +39,11 @@ export default function UtilityPlansListBody({
                   <div className="h-3 bg-muted rounded w-1/3" />
                   <div className="h-3 bg-muted rounded w-2/5" />
                 </div>
-                <div className="h-5 w-20 bg-muted rounded-full shrink-0" />
+                <div className="flex items-center gap-2 shrink-0">
+                  <div className="h-5 w-20 bg-muted rounded-full" />
+                  <div className="h-6 w-6 bg-muted rounded" />
+                  <div className="h-6 w-6 bg-muted rounded" />
+                </div>
               </div>
             </div>
           ))}
@@ -57,6 +65,7 @@ export default function UtilityPlansListBody({
               key={plan.id}
               plan={plan}
               isDeleting={deletingPlanId === plan.id}
+              onEdit={onEdit}
               onDelete={onDelete}
             />
           ))}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlanForm.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlanForm.ts
@@ -1,0 +1,34 @@
+import { useCallback, useState } from "react";
+import { EMPTY_UTILITY_PLAN_FORM } from "@/shared/lib/utility-plan-form";
+import type { UtilityPlanFormValues } from "@/shared/types/utility/utility-plan-form-values";
+
+export interface UtilityPlanFormState {
+  values: UtilityPlanFormValues;
+  setField: <K extends keyof UtilityPlanFormValues>(
+    key: K,
+    value: UtilityPlanFormValues[K],
+  ) => void;
+}
+
+/**
+ * Field state for the utility-plan form, shared by the add and edit dialogs.
+ *
+ * ``initialValues`` is read once, at mount. The edit dialog therefore mounts
+ * its form only after the plan has loaded rather than syncing later through an
+ * effect — an effect that overwrote state on refetch would discard whatever the
+ * operator had typed in the meantime.
+ */
+export function useUtilityPlanForm(
+  initialValues: UtilityPlanFormValues = EMPTY_UTILITY_PLAN_FORM,
+): UtilityPlanFormState {
+  const [values, setValues] = useState<UtilityPlanFormValues>(initialValues);
+
+  const setField = useCallback(
+    <K extends keyof UtilityPlanFormValues>(key: K, value: UtilityPlanFormValues[K]) => {
+      setValues((previous) => ({ ...previous, [key]: value }));
+    },
+    [],
+  );
+
+  return { values, setField };
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/UtilityPlans.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/UtilityPlans.tsx
@@ -8,6 +8,7 @@ import {
   useGetUtilityPlansQuery,
 } from "@/shared/store/utilityPlansApi";
 import AddUtilityPlanDialog from "@/app/features/utility/AddUtilityPlanDialog";
+import EditUtilityPlanDialog from "@/app/features/utility/EditUtilityPlanDialog";
 import UtilityPlansListBody from "@/app/features/utility/UtilityPlansListBody";
 import { useUtilityPlansListMode } from "@/app/features/utility/useUtilityPlansListMode";
 import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
@@ -21,6 +22,7 @@ import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-sum
 export default function UtilityPlans() {
   const [showExpiringOnly, setShowExpiringOnly] = useState(false);
   const [showAddDialog, setShowAddDialog] = useState(false);
+  const [editingPlanId, setEditingPlanId] = useState<string | null>(null);
   const [deletingPlanId, setDeletingPlanId] = useState<string | null>(null);
   const [planPendingDelete, setPlanPendingDelete] = useState<UtilityPlanSummary | null>(null);
 
@@ -106,11 +108,19 @@ export default function UtilityPlans() {
         plans={plans}
         showExpiringOnly={showExpiringOnly}
         deletingPlanId={deletingPlanId}
+        onEdit={(plan) => setEditingPlanId(plan.id)}
         onDelete={(plan) => setPlanPendingDelete(plan)}
       />
 
       {showAddDialog ? (
         <AddUtilityPlanDialog onClose={() => setShowAddDialog(false)} />
+      ) : null}
+
+      {editingPlanId ? (
+        <EditUtilityPlanDialog
+          planId={editingPlanId}
+          onClose={() => setEditingPlanId(null)}
+        />
       ) : null}
 
       <ConfirmDialog

--- a/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-form.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-form.ts
@@ -1,0 +1,142 @@
+import type { UtilityPlanDetail } from "@/shared/types/utility/utility-plan-detail";
+import type { UtilityPlanFieldsPayload } from "@/shared/types/utility/utility-plan-fields-payload";
+import type { UtilityPlanFormValues } from "@/shared/types/utility/utility-plan-form-values";
+
+/**
+ * Conversions between a utility plan and the form that edits it.
+ *
+ * Kept pure and separate from the dialogs so both the add and the edit flow
+ * produce byte-identical payloads from the same field values — a rate that
+ * survives creation must survive an edit too.
+ */
+
+/** A blank form. Electricity/fixed is the case the operator records most. */
+export const EMPTY_UTILITY_PLAN_FORM: UtilityPlanFormValues = {
+  serviceType: "electricity",
+  rateType: "fixed",
+  providerName: "",
+  planName: "",
+  accountNumber: "",
+  energyCharge: "",
+  tduCharge: "",
+  avgPrice: "",
+  monthlyBase: "",
+  termMonths: "",
+  serviceStartDate: "",
+  termEndDate: "",
+  etf: "",
+  hasBillCredit: false,
+  billCreditAmount: "",
+  billCreditThreshold: "",
+};
+
+/** ``""`` → null so an untouched field is absent rather than zero. */
+function optionalText(value: string): string | null {
+  return value.trim() === "" ? null : value.trim();
+}
+
+/**
+ * Dollars → integer cents. Kept separate from the rate fields, which are sent
+ * as strings: a rate carries four decimal places and must not round-trip
+ * through a float.
+ */
+function dollarsToCents(value: string): number | null {
+  if (value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.round(parsed * 100) : null;
+}
+
+function toInt(value: string): number | null {
+  if (value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.round(parsed) : null;
+}
+
+/** Integer cents → the dollar string a money input expects: 439 → ``"4.39"``. */
+function centsToDollarString(value: number | null): string {
+  if (value === null) return "";
+  return (value / 100).toFixed(2);
+}
+
+/**
+ * ``"11.6000"`` → ``"11.6"``.
+ *
+ * A number input normalizes its own value on edit, so seeding it with the
+ * padded form makes an untouched field look dirty. The trimmed string is
+ * numerically identical, and the backend's four-decimal limit is a maximum.
+ */
+function rateToInputString(value: string | null): string {
+  if (value === null || value.trim() === "") return "";
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? String(parsed) : "";
+}
+
+/** Prefill the form from a saved plan. */
+export function toUtilityPlanFormValues(plan: UtilityPlanDetail): UtilityPlanFormValues {
+  return {
+    serviceType: plan.service_type,
+    rateType: plan.rate_type,
+    providerName: plan.provider_name,
+    planName: plan.plan_name ?? "",
+    accountNumber: plan.account_number ?? "",
+    energyCharge: rateToInputString(plan.energy_charge_cents_per_kwh),
+    tduCharge: rateToInputString(plan.tdu_charge_cents_per_kwh),
+    avgPrice: rateToInputString(plan.avg_price_cents_per_kwh_at_1000),
+    monthlyBase: centsToDollarString(plan.monthly_base_charge_cents),
+    termMonths: plan.term_months === null ? "" : String(plan.term_months),
+    serviceStartDate: plan.service_start_date ?? "",
+    termEndDate: plan.term_end_date ?? "",
+    etf: centsToDollarString(plan.early_termination_fee_cents),
+    hasBillCredit: plan.has_bill_credit,
+    billCreditAmount: centsToDollarString(plan.bill_credit_amount_cents),
+    billCreditThreshold:
+      plan.bill_credit_threshold_kwh === null
+        ? ""
+        : String(plan.bill_credit_threshold_kwh),
+  };
+}
+
+/** The fields both requests share, as the API wants them. */
+export function toUtilityPlanFields(
+  values: UtilityPlanFormValues,
+): UtilityPlanFieldsPayload {
+  return {
+    service_type: values.serviceType,
+    rate_type: values.rateType,
+    provider_name: values.providerName.trim(),
+    plan_name: optionalText(values.planName),
+    account_number: optionalText(values.accountNumber),
+    // Rates stay strings end-to-end so 5.3509 survives intact.
+    energy_charge_cents_per_kwh: optionalText(values.energyCharge),
+    tdu_charge_cents_per_kwh: optionalText(values.tduCharge),
+    avg_price_cents_per_kwh_at_1000: optionalText(values.avgPrice),
+    monthly_base_charge_cents: dollarsToCents(values.monthlyBase),
+    term_months: toInt(values.termMonths),
+    service_start_date: values.serviceStartDate || null,
+    term_end_date: values.termEndDate || null,
+    early_termination_fee_cents: dollarsToCents(values.etf),
+    has_bill_credit: values.hasBillCredit,
+    bill_credit_amount_cents: values.hasBillCredit
+      ? dollarsToCents(values.billCreditAmount)
+      : null,
+    bill_credit_threshold_kwh: values.hasBillCredit
+      ? toInt(values.billCreditThreshold)
+      : null,
+  };
+}
+
+/**
+ * Client-side guard, returning the message to show or null when the form is
+ * submittable. The backend rejects the same shapes; catching them here points
+ * at the field instead of costing a round trip.
+ */
+export function validateUtilityPlanForm(values: UtilityPlanFormValues): string | null {
+  if (!values.providerName.trim()) return "Provider is required.";
+  if (
+    values.hasBillCredit &&
+    (values.billCreditAmount.trim() === "" || values.billCreditThreshold.trim() === "")
+  ) {
+    return "A bill credit needs both an amount and a usage threshold.";
+  }
+  return null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-fields-payload.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-fields-payload.ts
@@ -1,0 +1,36 @@
+import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-rate-type";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+/**
+ * The plan fields the form edits, in API shape.
+ *
+ * This is the intersection of ``UtilityPlanCreateRequest`` and
+ * ``UtilityPlanUpdateRequest``: adding ``property_id`` makes it a create body,
+ * and it is assignable to an update body as is.
+ *
+ * ``min_usage_fee_cents``, ``min_usage_threshold_kwh`` and ``notes`` are
+ * deliberately absent. The form does not edit them and ``PATCH`` applies
+ * exactly the keys it is sent, so including them would erase what a seeded
+ * plan records.
+ */
+export interface UtilityPlanFieldsPayload {
+  service_type: UtilityServiceType;
+  rate_type: UtilityPlanRateType;
+  provider_name: string;
+  plan_name: string | null;
+  account_number: string | null;
+
+  energy_charge_cents_per_kwh: string | null;
+  tdu_charge_cents_per_kwh: string | null;
+  avg_price_cents_per_kwh_at_1000: string | null;
+  monthly_base_charge_cents: number | null;
+
+  term_months: number | null;
+  service_start_date: string | null;
+  term_end_date: string | null;
+  early_termination_fee_cents: number | null;
+
+  has_bill_credit: boolean;
+  bill_credit_amount_cents: number | null;
+  bill_credit_threshold_kwh: number | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-form-values.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-form-values.ts
@@ -1,0 +1,35 @@
+import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-rate-type";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+/**
+ * The utility-plan form's field state, in the shape the inputs hold it.
+ *
+ * Every money and rate field is a string rather than a number: that is what an
+ * ``<input>`` yields, and a rate carries four decimal places that must not
+ * round-trip through a float on the way to the API. Conversion to the request
+ * shape happens once, in ``shared/lib/utility-plan-form``.
+ *
+ * ``property_id`` is absent because only the add flow chooses one — a plan
+ * cannot be moved between properties (see ``UtilityPlanUpdateRequest``).
+ */
+export interface UtilityPlanFormValues {
+  serviceType: UtilityServiceType;
+  rateType: UtilityPlanRateType;
+  providerName: string;
+  planName: string;
+  accountNumber: string;
+
+  energyCharge: string;
+  tduCharge: string;
+  avgPrice: string;
+  monthlyBase: string;
+
+  termMonths: string;
+  serviceStartDate: string;
+  termEndDate: string;
+  etf: string;
+
+  hasBillCredit: boolean;
+  billCreditAmount: string;
+  billCreditThreshold: string;
+}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -640,7 +640,8 @@
         "frontend/src/app/features/utility/",
         "frontend/src/shared/types/utility/",
         "frontend/src/shared/store/utilityPlansApi.ts",
-        "frontend/src/shared/lib/utility-plan-format.ts"
+        "frontend/src/shared/lib/utility-plan-format.ts",
+        "frontend/src/shared/lib/utility-plan-form.ts"
       ],
       "backend_tests": [
         "test_utility_plan_service.py",
@@ -651,8 +652,10 @@
       ],
       "frontend_tests": [
         "UtilityPlans.test.tsx",
+        "EditUtilityPlanDialog.test.tsx",
         "UtilityPlanRenewalAlertCard.test.tsx",
         "utility-plan-format.test.ts",
+        "utility-plan-form.test.ts",
         "Dashboard.test.tsx"
       ],
       "e2e_specs": [


### PR DESCRIPTION
## Why

The utility-plans list could add and delete, nothing else. A rate keyed in wrong, or an account number that only turns up later on a bill, meant deleting the plan and retyping it — which throws away the rate history the whole feature exists to measure a new offer against.

`useUpdateUtilityPlanMutation` and `useGetUtilityPlanByIdQuery` shipped earlier with zero consumers. This wires them.

## What

A pencil button on each row opens an edit dialog prefilled from the plan.

**The load-bearing detail is what the payload leaves out.** `PATCH /utility-plans/{id}` applies `model_dump(exclude_unset=True)` — an omitted key is preserved, an explicit `null` overwrites. The seeded Peerless plans carry a minimum-usage clause and provenance notes that the form has no field for. A payload built naively from the form's shape would have sent those as `null` and silently wiped them on the first edit.

`UtilityPlanFieldsPayload` structurally excludes `min_usage_fee_cents`, `min_usage_threshold_kwh` and `notes`, so they cannot be sent by accident. A unit test and an E2E assertion both hold that line.

Other decisions worth naming:

- **Property is read-only context, not a select.** A plan belongs to the meter it was signed for; moving one between properties would corrupt the rate history on both sides.
- **The form body mounts only once the plan resolves**, so `useState`'s initializer receives real data. A `useEffect` sync would clobber whatever the operator was typing on any background refetch.
- **Sub-cent rates survive the round trip.** TDU at `5.3509` stays `5.3509` — rounding it to `5.35` misprices the plan.

## Refactor

Add and Edit now share `UtilityPlanFormFields`, `useUtilityPlanForm`, `UtilityPlanDialogShell` and `UtilityPlanFormActions`. `AddUtilityPlanDialog` drops from 397 lines to ~85 instead of the alternative — a second copy of ~250 lines of field markup.

## Tests

- 14 unit tests on the conversion/validation layer, including "omits the fields the form does not edit rather than nulling them"
- 11 on the dialog: skeleton before load, retry on error, full prefill, patch payload shape, failure keeps the operator's edits
- 3 added to the list page (opens for the right row, aria-label names the plan unambiguously, closes cleanly)
- 2 E2E: one edits a plan through the UI and asserts `min_usage_fee_cents` / `min_usage_threshold_kwh` / `notes` are all intact afterwards; one holds the dialog's shape at 375px while it loads

Verified against the running app — typecheck clean, lint 0 errors, 63 utility-plan unit tests green, all 6 Playwright specs green. The 6 unrelated unit failures on this branch (`hourly-rate`, `PromoteFromInquiryPanel`, `LeaseTemplateUploadDialog`) reproduce identically on clean `origin/main`.

## Operational migration

None. Frontend-only; no env, schema or config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sr27bfGYRjFvsRc9JuBwKk