### PR TITLE
fix(mybookkeeper): clip rent-receipt period to the tenant's lease term

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/rcptclamp260809_clamp_pending_receipt_periods.py
+++ b/apps/mybookkeeper/backend/alembic/versions/rcptclamp260809_clamp_pending_receipt_periods.py
@@ -1,0 +1,75 @@
+"""clamp pending rent receipt periods to the tenant's lease term
+
+Until this PR the receipt period defaulted to the whole calendar month of
+the transaction date and never consulted the lease, so a payment made in a
+move-in or move-out month produced a receipt overstating the coverage — a
+tenant whose term ended Aug 9 got "Aug 1 – Aug 31".
+
+The service now clips the default to the lease term. This migration applies
+the same clipping to receipts already sitting in the queue.
+
+Deliberately narrow. It only touches rows that are:
+  - still ``pending`` (never sent, so no PDF has gone out with these dates)
+  - still holding the *exact* untouched calendar-month default, so a host
+    who already edited the period in the dialog keeps their edit
+  - covered by a lease whose term actually clips the month
+
+Revision ID: rcptclamp260809
+Revises: txnusage260807
+Create Date: 2026-08-09 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "rcptclamp260809"
+down_revision: Union[str, None] = "txnusage260807"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE pending_rent_receipts prr
+           SET period_start_date = GREATEST(prr.period_start_date, sl.starts_on),
+               period_end_date   = LEAST(prr.period_end_date, sl.ends_on),
+               updated_at        = NOW()
+          FROM transactions t
+          JOIN LATERAL (
+                SELECT s.starts_on, s.ends_on
+                  FROM signed_leases s
+                 WHERE s.applicant_id    = t.applicant_id
+                   AND s.organization_id = t.organization_id
+                   AND s.deleted_at IS NULL
+                   AND s.starts_on IS NOT NULL
+                   AND s.ends_on   IS NOT NULL
+                   AND s.starts_on <= t.transaction_date
+                   AND s.ends_on   >= t.transaction_date
+                 ORDER BY s.created_at DESC
+                 LIMIT 1
+               ) sl ON TRUE
+         WHERE prr.transaction_id = t.id
+           AND prr.status = 'pending'
+           AND prr.deleted_at IS NULL
+           -- Only rows still holding the untouched calendar-month default.
+           AND prr.period_start_date = DATE_TRUNC('month', t.transaction_date)::date
+           AND prr.period_end_date =
+               (DATE_TRUNC('month', t.transaction_date)
+                + INTERVAL '1 month - 1 day')::date
+           -- Only when the term genuinely clips the month.
+           AND (sl.starts_on > prr.period_start_date
+                OR sl.ends_on < prr.period_end_date)
+           -- Never write an inverted range.
+           AND GREATEST(prr.period_start_date, sl.starts_on)
+               <= LEAST(prr.period_end_date, sl.ends_on);
+        """
+    )
+
+
+def downgrade() -> None:
+    # Conservative: leave the clamped periods in place. Re-widening them to
+    # the calendar month is indistinguishable from clobbering a host's own
+    # edit, and the clamped values are the correct ones either way.
+    pass

--- a/apps/mybookkeeper/backend/app/models/leases/pending_rent_receipt.py
+++ b/apps/mybookkeeper/backend/app/models/leases/pending_rent_receipt.py
@@ -71,8 +71,10 @@ class PendingRentReceipt(Base):
         nullable=True,
     )
 
-    # Default period is the calendar month of the transaction date; host can
-    # override in the SendReceiptDialog before sending.
+    # Default period is the calendar month of the transaction date, clipped to
+    # the covering lease's term so a move-in/move-out month reports only the
+    # days under lease (see ``receipt_period_resolver``). Host can override in
+    # the SendReceiptDialog before sending.
     period_start_date: Mapped[_dt.date] = mapped_column(Date, nullable=False)
     period_end_date: Mapped[_dt.date] = mapped_column(Date, nullable=False)
 

--- a/apps/mybookkeeper/backend/app/repositories/leases/signed_lease_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/leases/signed_lease_repo.py
@@ -121,6 +121,40 @@ async def get(
     return result.scalar_one_or_none()
 
 
+async def get_covering_date(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    applicant_id: uuid.UUID,
+    on_date: _dt.date,
+) -> SignedLease | None:
+    """Return the tenant's lease whose term contains ``on_date``.
+
+    Terms are inclusive on both ends. Leases with an open ``starts_on`` or
+    ``ends_on`` are skipped — an unbounded term cannot be said to cover a
+    specific day, and callers fall back to the most recent lease anyway.
+
+    When terms overlap (a successor signed before its parent ended) the most
+    recently created lease wins, matching ``list_for_tenant``'s ordering.
+    """
+    stmt = (
+        select(SignedLease)
+        .where(
+            SignedLease.user_id == user_id,
+            SignedLease.organization_id == organization_id,
+            SignedLease.applicant_id == applicant_id,
+            SignedLease.deleted_at.is_(None),
+            SignedLease.starts_on <= on_date,
+            SignedLease.ends_on >= on_date,
+        )
+        .order_by(desc(SignedLease.created_at))
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalars().first()
+
+
 async def list_for_tenant(
     db: AsyncSession,
     *,

--- a/apps/mybookkeeper/backend/app/services/leases/receipt_formatting.py
+++ b/apps/mybookkeeper/backend/app/services/leases/receipt_formatting.py
@@ -17,6 +17,36 @@ def default_period(txn_date: _dt.date) -> tuple[_dt.date, _dt.date]:
     return first, last
 
 
+def clamp_period_to_term(
+    start: _dt.date,
+    end: _dt.date,
+    *,
+    term_start: _dt.date | None,
+    term_end: _dt.date | None,
+) -> tuple[_dt.date, _dt.date]:
+    """Clip a candidate receipt period to the tenant's occupancy window.
+
+    A receipt must never claim coverage for days the tenant was not under
+    lease. Without this, a payment recorded in a move-out month defaults to
+    the whole calendar month and the PDF overstates the period — e.g. a
+    tenant whose term ended Aug 9 gets a receipt reading "Aug 1–31".
+
+    Lease terms are inclusive on both ends, so a term running 05-03 → 11-10
+    covers both of those days. Either bound may be ``None`` (open-ended
+    leases exist in the data); an absent bound simply does not clip.
+
+    Returns the period unchanged when the term and the period do not overlap
+    at all. A payment dated outside the lease window is a data question for
+    the host to resolve in the dialog, not something to silently rewrite
+    into an inverted or zero-day range.
+    """
+    clamped_start = max(start, term_start) if term_start is not None else start
+    clamped_end = min(end, term_end) if term_end is not None else end
+    if clamped_start > clamped_end:
+        return start, end
+    return clamped_start, clamped_end
+
+
 def resolve_landlord_name(host_user) -> str:  # type: ignore[no-untyped-def]
     """Pick the landlord display name for the receipt.
 

--- a/apps/mybookkeeper/backend/app/services/leases/receipt_period_resolver.py
+++ b/apps/mybookkeeper/backend/app/services/leases/receipt_period_resolver.py
@@ -1,0 +1,94 @@
+"""Decide which lease a rent receipt belongs to and what period it covers.
+
+Split out of ``receipt_service`` (file-size no-growth policy) so the lease
+lookup and the period defaulting live together — they answer one question
+and share the same lease row.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.leases.signed_lease import SignedLease
+from app.repositories.leases import signed_lease_repo
+from app.services.leases.receipt_formatting import clamp_period_to_term, default_period
+
+
+async def _resolve_lease(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    applicant_id: uuid.UUID,
+    txn_date: _dt.date,
+) -> SignedLease | None:
+    """Pick the lease a payment on ``txn_date`` belongs to.
+
+    Prefers the lease whose term actually contains the payment date, so a
+    payment made under a parent lease is not attributed to the successor
+    that replaced it. Falls back to the tenant's most recent lease when no
+    term covers the date — that is the pre-existing behaviour and still the
+    best guess for open-ended or off-term payments.
+    """
+    covering = await signed_lease_repo.get_covering_date(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+        applicant_id=applicant_id,
+        on_date=txn_date,
+    )
+    if covering is not None:
+        return covering
+
+    leases = await signed_lease_repo.list_for_tenant(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+        applicant_id=applicant_id,
+        include_deleted=False,
+        limit=1,
+    )
+    return leases[0] if leases else None
+
+
+async def resolve_lease_and_period(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    applicant_id: uuid.UUID,
+    txn_date: _dt.date,
+    period_start_date: _dt.date | None = None,
+    period_end_date: _dt.date | None = None,
+) -> tuple[uuid.UUID | None, _dt.date, _dt.date]:
+    """Return ``(signed_lease_id, period_start, period_end)`` for a receipt.
+
+    An explicit period from the caller always wins — the host may
+    deliberately issue a receipt for a range that does not match the lease.
+    Otherwise the period defaults to the calendar month of the payment,
+    clipped to the lease term so a move-in or move-out month reports the
+    days actually under lease rather than the whole month.
+    """
+    lease = await _resolve_lease(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+        applicant_id=applicant_id,
+        txn_date=txn_date,
+    )
+    lease_id = lease.id if lease is not None else None
+
+    if period_start_date and period_end_date:
+        return lease_id, period_start_date, period_end_date
+
+    start, end = default_period(txn_date)
+    if lease is not None:
+        start, end = clamp_period_to_term(
+            start,
+            end,
+            term_start=lease.starts_on,
+            term_end=lease.ends_on,
+        )
+    return lease_id, start, end

--- a/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
@@ -52,12 +52,12 @@ from app.services.email.exceptions import (
 )
 from app.services.integrations import integration_service
 from app.services.leases.receipt_formatting import (
-    default_period as _default_period,
     format_period_long as _format_period_long,
     format_period_short as _format_period_short,
     resolve_landlord_name as _resolve_landlord_name,
 )
 from app.services.leases.receipt_pdf_service import ReceiptData, generate_receipt_pdf
+from app.services.leases.receipt_period_resolver import resolve_lease_and_period
 from app.core import storage as _storage_module
 
 logger = logging.getLogger(__name__)
@@ -165,20 +165,15 @@ async def create_pending_receipt_in_session(
     if not txn:
         return  # transaction disappeared; nothing to do
 
-    leases = await signed_lease_repo.list_for_tenant(
+    signed_lease_id, start, end = await resolve_lease_and_period(
         db,
         user_id=user_id,
         organization_id=organization_id,
         applicant_id=applicant_id,
-        include_deleted=False,
-        limit=1,
+        txn_date=txn.transaction_date,
+        period_start_date=period_start_date,
+        period_end_date=period_end_date,
     )
-    signed_lease_id = leases[0].id if leases else None
-
-    if not period_start_date or not period_end_date:
-        start, end = _default_period(txn.transaction_date)
-    else:
-        start, end = period_start_date, period_end_date
 
     await pending_rent_receipt_repo.create_idempotent(
         db,

--- a/apps/mybookkeeper/backend/tests/test_receipt_period_resolver.py
+++ b/apps/mybookkeeper/backend/tests/test_receipt_period_resolver.py
@@ -1,0 +1,182 @@
+"""Tests for the rent-receipt period defaulting.
+
+The receipt period used to default to the whole calendar month of the
+payment regardless of the lease, so a move-out month overstated coverage
+("Aug 1 – Aug 31" for a tenant whose term ended Aug 9). These cover the
+clipping that fixes that, plus the lease-selection it depends on.
+
+Repository calls are patched — no DB connection required.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.leases.receipt_formatting import clamp_period_to_term
+from app.services.leases.receipt_period_resolver import resolve_lease_and_period
+
+
+def _lease(
+    starts_on: date | None,
+    ends_on: date | None,
+    lease_id: uuid.UUID | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=lease_id or uuid.uuid4(), starts_on=starts_on, ends_on=ends_on,
+    )
+
+
+# ---------------------------------------------------------------------------
+# clamp_period_to_term — pure
+# ---------------------------------------------------------------------------
+
+def test_clamps_end_to_move_out_date() -> None:
+    """The reported bug: term ends mid-month, receipt claimed the whole month."""
+    start, end = clamp_period_to_term(
+        date(2026, 8, 1),
+        date(2026, 8, 31),
+        term_start=date(2026, 5, 3),
+        term_end=date(2026, 8, 9),
+    )
+    assert (start, end) == (date(2026, 8, 1), date(2026, 8, 9))
+
+
+def test_clamps_start_to_move_in_date() -> None:
+    start, end = clamp_period_to_term(
+        date(2026, 8, 1),
+        date(2026, 8, 31),
+        term_start=date(2026, 8, 15),
+        term_end=date(2027, 2, 14),
+    )
+    assert (start, end) == (date(2026, 8, 15), date(2026, 8, 31))
+
+
+def test_leaves_period_alone_when_term_spans_the_whole_month() -> None:
+    start, end = clamp_period_to_term(
+        date(2026, 8, 1),
+        date(2026, 8, 31),
+        term_start=date(2026, 5, 3),
+        term_end=date(2026, 11, 10),
+    )
+    assert (start, end) == (date(2026, 8, 1), date(2026, 8, 31))
+
+
+def test_term_end_on_the_last_day_of_the_month_is_inclusive() -> None:
+    """Terms are inclusive on both ends — Aug 31 still covers Aug 31."""
+    start, end = clamp_period_to_term(
+        date(2026, 8, 1),
+        date(2026, 8, 31),
+        term_start=date(2026, 8, 1),
+        term_end=date(2026, 8, 31),
+    )
+    assert (start, end) == (date(2026, 8, 1), date(2026, 8, 31))
+
+
+@pytest.mark.parametrize(
+    ("term_start", "term_end"),
+    [
+        (None, date(2026, 8, 9)),
+        (date(2026, 8, 15), None),
+        (None, None),
+    ],
+)
+def test_open_ended_bounds_do_not_clip(
+    term_start: date | None, term_end: date | None,
+) -> None:
+    start, end = clamp_period_to_term(
+        date(2026, 8, 1), date(2026, 8, 31),
+        term_start=term_start, term_end=term_end,
+    )
+    expected_start = term_start or date(2026, 8, 1)
+    expected_end = term_end or date(2026, 8, 31)
+    assert (start, end) == (expected_start, expected_end)
+
+
+def test_non_overlapping_term_returns_the_period_unchanged() -> None:
+    """A payment dated outside the lease must not produce an inverted range."""
+    start, end = clamp_period_to_term(
+        date(2026, 9, 1),
+        date(2026, 9, 30),
+        term_start=date(2026, 5, 3),
+        term_end=date(2026, 8, 9),
+    )
+    assert (start, end) == (date(2026, 9, 1), date(2026, 9, 30))
+
+
+# ---------------------------------------------------------------------------
+# resolve_lease_and_period — orchestration
+# ---------------------------------------------------------------------------
+
+_IDS = {
+    "user_id": uuid.uuid4(),
+    "organization_id": uuid.uuid4(),
+    "applicant_id": uuid.uuid4(),
+}
+
+
+async def _resolve(covering, newest=None, **overrides):
+    with patch(
+        "app.services.leases.receipt_period_resolver.signed_lease_repo",
+    ) as repo:
+        repo.get_covering_date = AsyncMock(return_value=covering)
+        repo.list_for_tenant = AsyncMock(
+            return_value=[newest] if newest is not None else [],
+        )
+        result = await resolve_lease_and_period(
+            AsyncMock(),
+            **_IDS,
+            txn_date=overrides.pop("txn_date", date(2026, 8, 5)),
+            **overrides,
+        )
+    return result
+
+
+@pytest.mark.asyncio
+async def test_default_period_is_clipped_to_the_covering_lease() -> None:
+    lease = _lease(date(2026, 5, 3), date(2026, 8, 9))
+    lease_id, start, end = await _resolve(lease)
+    assert lease_id == lease.id
+    assert (start, end) == (date(2026, 8, 1), date(2026, 8, 9))
+
+
+@pytest.mark.asyncio
+async def test_explicit_period_from_the_host_is_never_clipped() -> None:
+    """The host may deliberately issue a receipt outside the lease term."""
+    lease = _lease(date(2026, 5, 3), date(2026, 8, 9))
+    lease_id, start, end = await _resolve(
+        lease,
+        period_start_date=date(2026, 8, 1),
+        period_end_date=date(2026, 8, 31),
+    )
+    assert lease_id == lease.id
+    assert (start, end) == (date(2026, 8, 1), date(2026, 8, 31))
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_the_newest_lease_when_none_covers_the_date() -> None:
+    newest = _lease(date(2026, 9, 1), date(2027, 2, 28))
+    lease_id, start, end = await _resolve(None, newest=newest)
+    assert lease_id == newest.id
+    # The fallback lease does not cover August, so clipping is a no-op.
+    assert (start, end) == (date(2026, 8, 1), date(2026, 8, 31))
+
+
+@pytest.mark.asyncio
+async def test_prefers_the_covering_lease_over_the_newest_one() -> None:
+    """A payment under a parent lease must not adopt its successor's term."""
+    parent = _lease(date(2026, 5, 3), date(2026, 8, 9))
+    successor = _lease(date(2026, 8, 10), date(2027, 2, 9))
+    lease_id, start, end = await _resolve(parent, newest=successor)
+    assert lease_id == parent.id
+    assert (start, end) == (date(2026, 8, 1), date(2026, 8, 9))
+
+
+@pytest.mark.asyncio
+async def test_no_lease_at_all_keeps_the_plain_calendar_month() -> None:
+    lease_id, start, end = await _resolve(None)
+    assert lease_id is None
+    assert (start, end) == (date(2026, 8, 1), date(2026, 8, 31))

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -771,6 +771,8 @@
         "backend/app/schemas/leases/receipt_response.py",
         "backend/app/services/leases/receipt_service.py",
         "backend/app/services/leases/receipt_pdf_service.py",
+        "backend/app/services/leases/receipt_formatting.py",
+        "backend/app/services/leases/receipt_period_resolver.py",
         "backend/app/api/rent_receipts.py",
         "backend/alembic/versions/rcpt260504_rent_receipts.py",
         "frontend/src/app/pages/PendingReceipts.tsx",
@@ -782,7 +784,8 @@
         "test_receipt_pdf_service.py",
         "test_receipt_sequence_repo.py",
         "test_receipt_routes.py",
-        "test_receipt_service_app_sent.py"
+        "test_receipt_service_app_sent.py",
+        "test_receipt_period_resolver.py"
       ],
       "frontend_tests": [
         "SendReceiptDialog.test.tsx",


### PR DESCRIPTION
## Problem

A rent receipt for a tenant whose lease ended **Aug 9** rendered as **"Aug 1 – Aug 31"**.

The period never consulted the lease. `receipt_formatting.default_period()` derives it purely from the transaction date's calendar month:

```python
def default_period(txn_date):
    first = txn_date.replace(day=1)
    last_day = monthrange(txn_date.year, txn_date.month)[1]
    return first, txn_date.replace(day=last_day)
```

So every move-in and move-out month overstated the period unless the host caught it in the dialog.

## Fix

New `receipt_period_resolver.resolve_lease_and_period()`:

1. Picks the lease whose term **contains the payment date** (new `signed_lease_repo.get_covering_date`), falling back to the tenant's most recent lease — the old behaviour.
2. Clips the calendar-month default to that term via `clamp_period_to_term()`.

An explicit period from the host is still passed through untouched, so deliberately issuing a receipt outside the lease term stays possible.

Selecting by covering date also fixes a quieter bug: a payment made under a **parent** lease was linked to the **successor** that replaced it, because the old lookup always took the most recently created row.

Lease bounds are nullable, so an open-ended term simply does not clip. A payment dated entirely outside the term returns the period unchanged rather than producing an inverted range.

### Why a new module

`receipt_service.py` was at 554 LOC, over the growth guard in `scripts/file-size-allowlist.yml`. The resolver lives in its own module and the service **shrinks by 5 lines** (554 → 549). `check-file-size.py` passes.

## Migration — `rcptclamp260809`

Re-clips receipts already sitting in the queue. Deliberately narrow — only rows that are:

- still `pending` (no PDF has gone out with these dates)
- still holding the **exact** untouched calendar-month default, so a host who already edited the period keeps their edit
- covered by a lease that genuinely clips the month

Downgrade is a conservative no-op: re-widening is indistinguishable from clobbering a host's edit, and the clamped values are correct either way.

## Verification

Applied against the local schema (`txnusage260807` → `rcptclamp260809`), then the migration SQL was exercised on synthetic rows inside a rolled-back transaction:

| case | lease | before | after |
|---|---|---|---|
| move-out month | 05-03 → 08-09 | Aug 1 – Aug 31 | **Aug 1 – Aug 9** ✅ |
| move-in month | 05-03 → 08-09 | May 1 – May 31 | **May 3 – May 31** ✅ |
| mid-term month | 05-03 → 08-09 | Jun 1 – Jun 30 | unchanged ✅ |
| host already edited | 05-03 → 08-09 | Aug 1 – Aug 20 | unchanged ✅ |
| already sent | 05-03 → 08-09 | Aug 1 – Aug 31 | unchanged ✅ |
| payment off-term | 05-03 → 08-09 | Sep 1 – Sep 30 | unchanged ✅ |

Re-running the statement updated **0 rows** (idempotent). All synthetic data rolled back.

Tests: 13 new in `test_receipt_period_resolver.py`; 281 passed / 4 skipped across the lease + receipt suites.

## Operational migration

None. No new env vars, no config changes — `alembic upgrade head` runs in the normal deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ML9WSmCrU3dyjH9BWZRQmG