### PR TITLE
feat(mybookkeeper): show tenant leases on the calendar

### DIFF
--- a/apps/mybookkeeper/backend/app/core/calendar_constants.py
+++ b/apps/mybookkeeper/backend/app/core/calendar_constants.py
@@ -16,3 +16,23 @@ DEFAULT_WINDOW_DAYS: int = 90
 # in one go. 365 days is a year — anything beyond that is almost
 # certainly a mistake.
 MAX_WINDOW_DAYS: int = 365
+
+# Source slug for occupancy derived from a signed lease. Unlike every other
+# slug this is NOT a channel — leases arrive through the lease flow, not an
+# iCal poll, and have no ``listing_blackouts`` row. The viewer unions them in
+# from ``signed_leases`` so a host sees tenant occupancy next to channel
+# bookings. Events carrying this source are read-only: their ``id`` is a lease
+# id, so the blackout notes/attachment endpoints do not apply to them.
+LEASE_SOURCE: str = "lease"
+
+# Lease statuses that represent real occupancy on the calendar.
+#
+# ``draft`` / ``generated`` / ``sent`` are still being negotiated — nobody has
+# moved in, so blocking the dates would be wrong. ``terminated`` ended early,
+# meaning the stored ``ends_on`` no longer describes the stay.
+#
+# Same three statuses as ``services.leases._lease_helpers``'s
+# PARENT_ALLOWED_STATUSES, but deliberately a separate constant: that one
+# answers "can this lease have a successor", this one answers "did someone
+# actually live here". They agree today for unrelated reasons.
+LEASE_OCCUPANCY_STATUSES: frozenset[str] = frozenset({"signed", "active", "ended"})

--- a/apps/mybookkeeper/backend/app/mappers/calendar_event_mapper.py
+++ b/apps/mybookkeeper/backend/app/mappers/calendar_event_mapper.py
@@ -1,0 +1,101 @@
+"""Convert calendar source rows into ``CalendarEventResponse``.
+
+The viewer unions two unrelated tables into one event list, so the shape
+conversion lives here rather than in the service: ``listing_blackouts`` rows
+map almost field-for-field, while ``signed_leases`` rows need a tenant name
+and an end-date convention change.
+
+``CalendarEventResponse.ends_on`` is EXCLUSIVE (iCal RFC 5545), matching
+``ListingBlackout``. ``SignedLease.ends_on`` is INCLUSIVE. ``lease_to_event``
+is the single place that bridges the two — a lease running through Aug 9 is
+emitted as ``ends_on = Aug 10`` so the grid draws it over Aug 9 and stops.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+from app.core.calendar_constants import LEASE_SOURCE
+from app.models.applicants.applicant import Applicant
+from app.models.leases.signed_lease import SignedLease
+from app.models.listings.listing import Listing
+from app.models.listings.listing_blackout import ListingBlackout
+from app.models.properties.property import Property
+from app.schemas.calendar.calendar_event_response import CalendarEventResponse
+
+# Shown when a tenant has no ``legal_name`` on file. Matches the fallback
+# ``receipt_service`` uses on receipt PDFs so the same tenant does not read
+# as two different people across the app.
+UNNAMED_TENANT_LABEL = "Tenant"
+
+
+def blackout_to_event(
+    blackout: ListingBlackout,
+    listing: Listing,
+    prop: Property,
+    attachment_count: int,
+) -> CalendarEventResponse:
+    """Map a channel booking or manual block."""
+    return CalendarEventResponse(
+        id=blackout.id,
+        listing_id=blackout.listing_id,
+        listing_name=listing.title,
+        property_id=prop.id,
+        property_name=prop.name,
+        starts_on=blackout.starts_on,
+        ends_on=blackout.ends_on,
+        source=blackout.source,
+        source_event_id=blackout.source_event_id,
+        summary=None,
+        host_notes=blackout.host_notes,
+        attachment_count=attachment_count,
+        updated_at=blackout.updated_at,
+    )
+
+
+def lease_to_event(
+    lease: SignedLease,
+    listing: Listing,
+    prop: Property,
+    applicant: Applicant,
+) -> CalendarEventResponse:
+    """Map tenant occupancy from a signed lease.
+
+    ``summary`` carries the tenant's name — the whole point of surfacing
+    leases here is seeing *who* is in a room, not just that it is taken.
+
+    Notes and attachments stay empty: those endpoints are keyed by blackout
+    id, and this event's id is a lease id. The frontend hides both sections
+    for this source rather than offering an edit that would 404.
+
+    The caller guarantees non-null dates (``query_lease_events`` filters
+    them out), so the ``+ 1 day`` conversion is always safe.
+    """
+    assert lease.starts_on is not None and lease.ends_on is not None
+    return CalendarEventResponse(
+        id=lease.id,
+        listing_id=listing.id,
+        listing_name=listing.title,
+        property_id=prop.id,
+        property_name=prop.name,
+        starts_on=lease.starts_on,
+        ends_on=lease.ends_on + timedelta(days=1),
+        source=LEASE_SOURCE,
+        source_event_id=None,
+        summary=applicant.legal_name or UNNAMED_TENANT_LABEL,
+        host_notes=None,
+        attachment_count=0,
+        updated_at=lease.updated_at,
+    )
+
+
+def event_sort_key(
+    event: CalendarEventResponse,
+) -> tuple[str, str, object, uuid.UUID]:
+    """Ordering for the merged list.
+
+    Mirrors what each repository query orders by, applied after the union so
+    blackouts and leases interleave correctly instead of arriving in two
+    separate blocks.
+    """
+    return (event.property_name, event.listing_name, event.starts_on, event.id)

--- a/apps/mybookkeeper/backend/app/repositories/calendar/calendar_repository.py
+++ b/apps/mybookkeeper/backend/app/repositories/calendar/calendar_repository.py
@@ -1,15 +1,23 @@
 """Repository for the unified calendar viewer.
 
-One query joins ``listing_blackouts`` → ``listings`` → ``properties`` and
-returns the rows the viewer needs (per-event listing name + property name)
-in a single round trip. Tenant-scoped via ``listings.organization_id`` —
-the blackout itself has no tenant column, so isolation must be enforced
-on the listing's organization.
+Two queries feed the viewer, one per event source:
 
-Date overlap semantics: an event is in the window when
-``starts_on < window_to AND ends_on > window_from`` — this is the
-half-open interval intersection, consistent with the iCal exclusive-end
-convention used by ``ListingBlackout``.
+``query_events`` joins ``listing_blackouts`` → ``listings`` → ``properties``
+— channel bookings and manual blocks. ``query_lease_events`` joins
+``signed_leases`` → ``listings`` → ``properties`` → ``applicants`` — tenant
+occupancy. Both return the per-event listing name + property name the viewer
+needs in a single round trip, and both are tenant-scoped via
+``listings.organization_id``.
+
+Date overlap semantics differ between the two, and the difference matters:
+
+- ``ListingBlackout.ends_on`` is EXCLUSIVE (iCal RFC 5545), so a blackout is
+  in the window when ``starts_on < window_to AND ends_on > window_from``.
+- ``SignedLease.ends_on`` is INCLUSIVE — a lease running through Aug 9 covers
+  Aug 9 — so the test is ``starts_on < window_to AND ends_on >= window_from``.
+
+The mapper converts a lease's inclusive end to the exclusive end the response
+schema promises; nothing downstream should have to remember this.
 """
 from __future__ import annotations
 
@@ -20,6 +28,9 @@ from datetime import date
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.calendar_constants import LEASE_OCCUPANCY_STATUSES
+from app.models.applicants.applicant import Applicant
+from app.models.leases.signed_lease import SignedLease
 from app.models.listings.listing import Listing
 from app.models.listings.listing_blackout import ListingBlackout
 from app.models.properties.property import Property
@@ -74,3 +85,61 @@ async def query_events(
 
     result = await db.execute(stmt)
     return [(blackout, listing, prop) for blackout, listing, prop in result.all()]
+
+
+async def query_lease_events(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    from_: date,
+    to: date,
+    listing_ids: Sequence[uuid.UUID] | None = None,
+    property_ids: Sequence[uuid.UUID] | None = None,
+) -> list[tuple[SignedLease, Listing, Property, Applicant]]:
+    """Return occupying leases + listing + property + tenant within the window.
+
+    ``listing_ids`` / ``property_ids`` narrow the result the same way they do
+    for blackouts. There is no ``sources`` parameter — every row this returns
+    has source ``lease`` by construction, so the caller decides whether to run
+    this query at all rather than filtering inside it.
+
+    Excluded, all for the same reason (they do not describe someone living in
+    the listing on those dates):
+
+    - statuses outside ``LEASE_OCCUPANCY_STATUSES``
+    - soft-deleted leases and soft-deleted listings
+    - leases with no ``listing_id`` — the grid is listing-rows, so a lease
+      with nothing to sit on cannot be drawn (the join drops these)
+    - leases missing either date bound, which have no extent to draw
+    """
+    stmt = (
+        select(SignedLease, Listing, Property, Applicant)
+        .join(Listing, Listing.id == SignedLease.listing_id)
+        .join(Property, Property.id == Listing.property_id)
+        .join(Applicant, Applicant.id == SignedLease.applicant_id)
+        .where(
+            Listing.organization_id == organization_id,
+            Listing.deleted_at.is_(None),
+            SignedLease.deleted_at.is_(None),
+            SignedLease.status.in_(sorted(LEASE_OCCUPANCY_STATUSES)),
+            SignedLease.starts_on.is_not(None),
+            SignedLease.ends_on.is_not(None),
+            # Inclusive end — see module docstring.
+            SignedLease.starts_on < to,
+            SignedLease.ends_on >= from_,
+        )
+        .order_by(
+            Property.name.asc(),
+            Listing.title.asc(),
+            SignedLease.starts_on.asc(),
+            SignedLease.id.asc(),
+        )
+    )
+
+    if listing_ids:
+        stmt = stmt.where(SignedLease.listing_id.in_(list(listing_ids)))
+    if property_ids:
+        stmt = stmt.where(Listing.property_id.in_(list(property_ids)))
+
+    result = await db.execute(stmt)
+    return [(lease, listing, prop, applicant) for lease, listing, prop, applicant in result.all()]

--- a/apps/mybookkeeper/backend/app/services/calendar/calendar_service.py
+++ b/apps/mybookkeeper/backend/app/services/calendar/calendar_service.py
@@ -1,8 +1,10 @@
 """Service layer for the unified calendar viewer.
 
-Orchestration only — defaults the window when omitted, validates the
-window cap, delegates the joined query to the repository, and maps ORM
-rows to the response schema. No SQL here.
+Orchestration only — defaults the window when omitted, validates the window
+cap, delegates the joined queries to the repository, and merges the two event
+sources (channel/manual blackouts and tenant leases) into one ordered list.
+Row-to-schema conversion lives in ``mappers.calendar_event_mapper``. No SQL
+here.
 """
 from __future__ import annotations
 
@@ -10,8 +12,17 @@ import uuid
 from collections.abc import Sequence
 from datetime import date, timedelta
 
-from app.core.calendar_constants import DEFAULT_WINDOW_DAYS, MAX_WINDOW_DAYS
+from app.core.calendar_constants import (
+    DEFAULT_WINDOW_DAYS,
+    LEASE_SOURCE,
+    MAX_WINDOW_DAYS,
+)
 from app.db.session import AsyncSessionLocal
+from app.mappers.calendar_event_mapper import (
+    blackout_to_event,
+    event_sort_key,
+    lease_to_event,
+)
 from app.repositories.calendar import calendar_repository
 from app.repositories.listings import listing_blackout_attachment_repo
 from app.schemas.calendar.calendar_event_response import CalendarEventResponse
@@ -51,6 +62,20 @@ def _resolve_window(from_: date | None, to: date | None) -> tuple[date, date]:
     return from_, to
 
 
+def _blackout_sources(sources: Sequence[str] | None) -> tuple[list[str] | None, bool]:
+    """Split a ``sources`` filter into its blackout half.
+
+    Returns the slugs to pass to the blackout query and whether to run it at
+    all. ``lease`` is stripped because no blackout carries that source — left
+    in, a "leases only" filter would still scan the blackout table and a
+    "lease + airbnb" filter would read as if lease were a channel.
+    """
+    if not sources:
+        return None, True
+    channel_slugs = [s for s in sources if s != LEASE_SOURCE]
+    return channel_slugs, bool(channel_slugs)
+
+
 async def list_events(
     organization_id: uuid.UUID,
     user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
@@ -63,42 +88,53 @@ async def list_events(
 ) -> list[CalendarEventResponse]:
     """Return calendar events for the active organization.
 
+    Unions two sources: channel/manual blackouts and tenant occupancy derived
+    from signed leases. Both honour the same window and listing/property
+    filters; ``sources`` selects between them.
+
     Raises ``CalendarWindowError`` for an invalid or oversize window.
     """
     resolved_from, resolved_to = _resolve_window(from_, to)
+    channel_slugs, want_blackouts = _blackout_sources(sources)
+    want_leases = not sources or LEASE_SOURCE in sources
+
+    events: list[CalendarEventResponse] = []
 
     async with AsyncSessionLocal() as db:
-        rows = await calendar_repository.query_events(
-            db,
-            organization_id=organization_id,
-            from_=resolved_from,
-            to=resolved_to,
-            listing_ids=listing_ids,
-            property_ids=property_ids,
-            sources=sources,
-        )
+        if want_blackouts:
+            rows = await calendar_repository.query_events(
+                db,
+                organization_id=organization_id,
+                from_=resolved_from,
+                to=resolved_to,
+                listing_ids=listing_ids,
+                property_ids=property_ids,
+                sources=channel_slugs,
+            )
 
-        # Batch-load attachment counts in one round-trip to avoid N+1.
-        blackout_ids = [blackout.id for blackout, _listing, _prop in rows]
-        attachment_counts = await listing_blackout_attachment_repo.count_by_blackout_ids(
-            db, blackout_ids,
-        )
+            # Batch-load attachment counts in one round-trip to avoid N+1.
+            blackout_ids = [blackout.id for blackout, _listing, _prop in rows]
+            counts = await listing_blackout_attachment_repo.count_by_blackout_ids(
+                db, blackout_ids,
+            )
+            events.extend(
+                blackout_to_event(blackout, listing, prop, counts.get(blackout.id, 0))
+                for blackout, listing, prop in rows
+            )
 
-    return [
-        CalendarEventResponse(
-            id=blackout.id,
-            listing_id=blackout.listing_id,
-            listing_name=listing.title,
-            property_id=prop.id,
-            property_name=prop.name,
-            starts_on=blackout.starts_on,
-            ends_on=blackout.ends_on,
-            source=blackout.source,
-            source_event_id=blackout.source_event_id,
-            summary=None,
-            host_notes=blackout.host_notes,
-            attachment_count=attachment_counts.get(blackout.id, 0),
-            updated_at=blackout.updated_at,
-        )
-        for blackout, listing, prop in rows
-    ]
+        if want_leases:
+            lease_rows = await calendar_repository.query_lease_events(
+                db,
+                organization_id=organization_id,
+                from_=resolved_from,
+                to=resolved_to,
+                listing_ids=listing_ids,
+                property_ids=property_ids,
+            )
+            events.extend(
+                lease_to_event(lease, listing, prop, applicant)
+                for lease, listing, prop, applicant in lease_rows
+            )
+
+    events.sort(key=event_sort_key)
+    return events

--- a/apps/mybookkeeper/backend/app/test_helpers/seed.py
+++ b/apps/mybookkeeper/backend/app/test_helpers/seed.py
@@ -592,6 +592,9 @@ class _SeedSignedLeaseRequest(BaseModel):
     applicant_id: uuid.UUID | None = None
     kind: str = "imported"
     status: str = "signed"
+    # The only property linkage a lease has — a lease without it cannot
+    # appear on the (listing-keyed) calendar.
+    listing_id: uuid.UUID | None = None
     starts_on: _dt.date | None = None
     ends_on: _dt.date | None = None
     attachments: list[_SeedAttachmentSpec] = []
@@ -624,7 +627,7 @@ async def seed_signed_lease(
             user_id=ctx.user_id,
             organization_id=ctx.organization_id,
             applicant_id=payload.applicant_id,
-            listing_id=None,
+            listing_id=payload.listing_id,
             kind=payload.kind,
             values={},
             status=payload.status,

--- a/apps/mybookkeeper/backend/tests/test_calendar_event_mapper.py
+++ b/apps/mybookkeeper/backend/tests/test_calendar_event_mapper.py
@@ -1,0 +1,168 @@
+"""Tests for calendar row → event conversion.
+
+The interesting case is the end-date convention. ``CalendarEventResponse``
+promises an EXCLUSIVE ``ends_on`` (iCal RFC 5545) but ``SignedLease.ends_on``
+is INCLUSIVE, so the mapper is the one place that bridges them. Getting this
+wrong renders every tenancy a day short.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+
+from app.core.calendar_constants import LEASE_SOURCE
+from app.mappers.calendar_event_mapper import (
+    UNNAMED_TENANT_LABEL,
+    blackout_to_event,
+    event_sort_key,
+    lease_to_event,
+)
+
+_NOW = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+
+
+def _listing(title: str = "Room A") -> SimpleNamespace:
+    return SimpleNamespace(id=uuid.uuid4(), title=title)
+
+
+def _property(name: str = "6734 Peerless") -> SimpleNamespace:
+    return SimpleNamespace(id=uuid.uuid4(), name=name)
+
+
+def _lease(starts_on: date, ends_on: date) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(), starts_on=starts_on, ends_on=ends_on, updated_at=_NOW,
+    )
+
+
+def _blackout(starts_on: date, ends_on: date, source: str = "airbnb") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        listing_id=uuid.uuid4(),
+        starts_on=starts_on,
+        ends_on=ends_on,
+        source=source,
+        source_event_id="uid-123",
+        host_notes="left key under mat",
+        updated_at=_NOW,
+    )
+
+
+class TestLeaseToEvent:
+    def test_inclusive_lease_end_becomes_exclusive_event_end(self) -> None:
+        """A lease running through Aug 9 must cover Aug 9, so ends_on is Aug 10."""
+        event = lease_to_event(
+            _lease(date(2026, 5, 3), date(2026, 8, 9)),
+            _listing(),
+            _property(),
+            SimpleNamespace(legal_name="Sonu King"),
+        )
+        assert event.starts_on == date(2026, 5, 3)
+        assert event.ends_on == date(2026, 8, 10)
+
+    def test_single_day_lease_spans_one_day(self) -> None:
+        event = lease_to_event(
+            _lease(date(2026, 8, 9), date(2026, 8, 9)),
+            _listing(),
+            _property(),
+            SimpleNamespace(legal_name="Sonu King"),
+        )
+        assert (event.ends_on - event.starts_on).days == 1
+
+    def test_carries_the_tenant_name_as_summary(self) -> None:
+        event = lease_to_event(
+            _lease(date(2026, 5, 3), date(2026, 8, 9)),
+            _listing(),
+            _property(),
+            SimpleNamespace(legal_name="Sonu King"),
+        )
+        assert event.summary == "Sonu King"
+        assert event.source == LEASE_SOURCE
+
+    def test_unnamed_tenant_falls_back_to_a_label(self) -> None:
+        event = lease_to_event(
+            _lease(date(2026, 5, 3), date(2026, 8, 9)),
+            _listing(),
+            _property(),
+            SimpleNamespace(legal_name=None),
+        )
+        assert event.summary == UNNAMED_TENANT_LABEL
+
+    def test_exposes_no_editable_blackout_fields(self) -> None:
+        """Notes/attachments are blackout-keyed; a lease event has neither."""
+        event = lease_to_event(
+            _lease(date(2026, 5, 3), date(2026, 8, 9)),
+            _listing(),
+            _property(),
+            SimpleNamespace(legal_name="Sonu King"),
+        )
+        assert event.host_notes is None
+        assert event.attachment_count == 0
+        assert event.source_event_id is None
+
+    def test_uses_the_listing_from_the_join_not_the_lease(self) -> None:
+        listing = _listing("Room B")
+        prop = _property("Elsewhere")
+        event = lease_to_event(
+            _lease(date(2026, 5, 3), date(2026, 8, 9)),
+            listing,
+            prop,
+            SimpleNamespace(legal_name="Sonu King"),
+        )
+        assert event.listing_id == listing.id
+        assert event.listing_name == "Room B"
+        assert event.property_id == prop.id
+        assert event.property_name == "Elsewhere"
+
+
+class TestBlackoutToEvent:
+    def test_passes_the_exclusive_end_through_untouched(self) -> None:
+        blackout = _blackout(date(2026, 8, 1), date(2026, 8, 10))
+        event = blackout_to_event(blackout, _listing(), _property(), 2)
+        assert event.starts_on == date(2026, 8, 1)
+        assert event.ends_on == date(2026, 8, 10)
+
+    def test_carries_channel_metadata_and_attachment_count(self) -> None:
+        blackout = _blackout(date(2026, 8, 1), date(2026, 8, 10))
+        event = blackout_to_event(blackout, _listing(), _property(), 3)
+        assert event.source == "airbnb"
+        assert event.source_event_id == "uid-123"
+        assert event.host_notes == "left key under mat"
+        assert event.attachment_count == 3
+        # iCal gives no guest name — the detail dialog keys its hint off this.
+        assert event.summary is None
+
+
+class TestEventSortKey:
+    def test_orders_by_property_then_listing_then_start(self) -> None:
+        prop_a, prop_b = _property("A prop"), _property("B prop")
+        listing_x, listing_y = _listing("X room"), _listing("Y room")
+        applicant = SimpleNamespace(legal_name="T")
+
+        events = [
+            lease_to_event(_lease(date(2026, 8, 5), date(2026, 8, 9)), listing_y, prop_b, applicant),
+            lease_to_event(_lease(date(2026, 8, 3), date(2026, 8, 9)), listing_x, prop_a, applicant),
+            lease_to_event(_lease(date(2026, 8, 1), date(2026, 8, 9)), listing_y, prop_a, applicant),
+            blackout_to_event(_blackout(date(2026, 8, 2), date(2026, 8, 4)), listing_x, prop_a, 0),
+        ]
+        ordered = sorted(events, key=event_sort_key)
+
+        assert [(e.property_name, e.listing_name, e.starts_on) for e in ordered] == [
+            ("A prop", "X room", date(2026, 8, 2)),
+            ("A prop", "X room", date(2026, 8, 3)),
+            ("A prop", "Y room", date(2026, 8, 1)),
+            ("B prop", "Y room", date(2026, 8, 5)),
+        ]
+
+    def test_interleaves_leases_and_blackouts_on_the_same_listing(self) -> None:
+        """The union must not arrive as two separate blocks."""
+        prop, listing = _property(), _listing()
+        applicant = SimpleNamespace(legal_name="T")
+        events = [
+            blackout_to_event(_blackout(date(2026, 8, 10), date(2026, 8, 12)), listing, prop, 0),
+            lease_to_event(_lease(date(2026, 8, 1), date(2026, 8, 5)), listing, prop, applicant),
+            blackout_to_event(_blackout(date(2026, 8, 6), date(2026, 8, 8)), listing, prop, 0),
+        ]
+        ordered = sorted(events, key=event_sort_key)
+        assert [e.source for e in ordered] == [LEASE_SOURCE, "airbnb", "airbnb"]

--- a/apps/mybookkeeper/backend/tests/test_calendar_service.py
+++ b/apps/mybookkeeper/backend/tests/test_calendar_service.py
@@ -1,20 +1,35 @@
-"""Service tests for calendar window resolution.
+"""Service tests for calendar window resolution and source union.
 
-Pure unit tests on ``_resolve_window`` — no DB. Verifies:
+``_resolve_window`` and ``_blackout_sources`` are pure. ``list_events`` is
+exercised with the repositories patched — no DB. Verifies:
 - both omitted → today → today + DEFAULT_WINDOW_DAYS
 - partial supply (only from / only to) → fills the missing side
 - inverted ranges raise CalendarWindowError
 - window > MAX_WINDOW_DAYS raises CalendarWindowError
+- blackouts and leases union into one ordered list
+- ``sources`` selects between the two, and skips the query it doesn't need
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+import uuid
+from contextlib import asynccontextmanager
+from datetime import date, datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.core.calendar_constants import DEFAULT_WINDOW_DAYS, MAX_WINDOW_DAYS
+from app.core.calendar_constants import (
+    DEFAULT_WINDOW_DAYS,
+    LEASE_SOURCE,
+    MAX_WINDOW_DAYS,
+)
 from app.services.calendar import calendar_service
-from app.services.calendar.calendar_service import CalendarWindowError, _resolve_window
+from app.services.calendar.calendar_service import (
+    CalendarWindowError,
+    _blackout_sources,
+    _resolve_window,
+)
 
 
 class TestCalendarServiceWindow:
@@ -65,3 +80,131 @@ class TestCalendarServiceWindow:
 # Smoke check: re-export sanity (the service is the public interface).
 def test_service_exports_window_error() -> None:
     assert calendar_service.CalendarWindowError is CalendarWindowError
+
+
+class TestBlackoutSourceSplit:
+    def test_no_filter_runs_the_blackout_query_unfiltered(self) -> None:
+        assert _blackout_sources(None) == (None, True)
+        assert _blackout_sources([]) == (None, True)
+
+    def test_lease_is_stripped_from_the_channel_slugs(self) -> None:
+        slugs, run = _blackout_sources(["airbnb", LEASE_SOURCE])
+        assert slugs == ["airbnb"]
+        assert run is True
+
+    def test_leases_only_skips_the_blackout_query(self) -> None:
+        slugs, run = _blackout_sources([LEASE_SOURCE])
+        assert slugs == []
+        assert run is False
+
+
+_ORG = uuid.uuid4()
+_USER = uuid.uuid4()
+_NOW = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+
+
+def _blackout_row(listing_title: str, starts_on: date, ends_on: date):
+    prop = SimpleNamespace(id=uuid.uuid4(), name="6734 Peerless")
+    listing = SimpleNamespace(id=uuid.uuid4(), title=listing_title)
+    blackout = SimpleNamespace(
+        id=uuid.uuid4(),
+        listing_id=listing.id,
+        starts_on=starts_on,
+        ends_on=ends_on,
+        source="airbnb",
+        source_event_id="uid-1",
+        host_notes=None,
+        updated_at=_NOW,
+    )
+    return blackout, listing, prop
+
+
+def _lease_row(listing_title: str, starts_on: date, ends_on: date, name: str):
+    prop = SimpleNamespace(id=uuid.uuid4(), name="6734 Peerless")
+    listing = SimpleNamespace(id=uuid.uuid4(), title=listing_title)
+    lease = SimpleNamespace(
+        id=uuid.uuid4(), starts_on=starts_on, ends_on=ends_on, updated_at=_NOW,
+    )
+    return lease, listing, prop, SimpleNamespace(legal_name=name)
+
+
+@asynccontextmanager
+async def _fake_session():
+    yield AsyncMock()
+
+
+async def _list_events(*, blackouts, leases, sources=None):
+    """Run ``list_events`` with both repositories patched.
+
+    Returns ``(events, query_events_mock, query_lease_events_mock)`` so tests
+    can assert on which queries ran, not just on the merged output.
+    """
+    with (
+        patch.object(calendar_service, "AsyncSessionLocal", _fake_session),
+        patch.object(calendar_service, "calendar_repository") as repo,
+        patch.object(
+            calendar_service, "listing_blackout_attachment_repo",
+        ) as attach_repo,
+    ):
+        repo.query_events = AsyncMock(return_value=blackouts)
+        repo.query_lease_events = AsyncMock(return_value=leases)
+        attach_repo.count_by_blackout_ids = AsyncMock(return_value={})
+        events = await calendar_service.list_events(
+            _ORG,
+            _USER,
+            from_=date(2026, 8, 1),
+            to=date(2026, 9, 1),
+            sources=sources,
+        )
+    return events, repo.query_events, repo.query_lease_events
+
+
+class TestListEventsUnion:
+    @pytest.mark.asyncio
+    async def test_returns_both_sources_in_one_ordered_list(self) -> None:
+        events, _, _ = await _list_events(
+            blackouts=[_blackout_row("B room", date(2026, 8, 20), date(2026, 8, 25))],
+            leases=[_lease_row("A room", date(2026, 8, 1), date(2026, 8, 9), "Sonu King")],
+        )
+        assert [e.source for e in events] == [LEASE_SOURCE, "airbnb"]
+        assert [e.listing_name for e in events] == ["A room", "B room"]
+
+    @pytest.mark.asyncio
+    async def test_lease_end_is_exclusive_in_the_response(self) -> None:
+        events, _, _ = await _list_events(
+            blackouts=[],
+            leases=[_lease_row("A room", date(2026, 8, 1), date(2026, 8, 9), "Sonu King")],
+        )
+        assert events[0].ends_on == date(2026, 8, 10)
+        assert events[0].summary == "Sonu King"
+
+    @pytest.mark.asyncio
+    async def test_lease_only_filter_skips_the_blackout_query(self) -> None:
+        events, query_events, query_leases = await _list_events(
+            blackouts=[_blackout_row("B room", date(2026, 8, 20), date(2026, 8, 25))],
+            leases=[_lease_row("A room", date(2026, 8, 1), date(2026, 8, 9), "Sonu King")],
+            sources=[LEASE_SOURCE],
+        )
+        query_events.assert_not_awaited()
+        query_leases.assert_awaited_once()
+        assert [e.source for e in events] == [LEASE_SOURCE]
+
+    @pytest.mark.asyncio
+    async def test_channel_only_filter_skips_the_lease_query(self) -> None:
+        events, query_events, query_leases = await _list_events(
+            blackouts=[_blackout_row("B room", date(2026, 8, 20), date(2026, 8, 25))],
+            leases=[_lease_row("A room", date(2026, 8, 1), date(2026, 8, 9), "Sonu King")],
+            sources=["airbnb"],
+        )
+        query_events.assert_awaited_once()
+        query_leases.assert_not_awaited()
+        assert [e.source for e in events] == ["airbnb"]
+
+    @pytest.mark.asyncio
+    async def test_lease_slug_is_not_forwarded_to_the_blackout_query(self) -> None:
+        _events, query_events, _ = await _list_events(
+            blackouts=[],
+            leases=[],
+            sources=["airbnb", LEASE_SOURCE],
+        )
+        assert query_events.await_args.kwargs["sources"] == ["airbnb"]

--- a/apps/mybookkeeper/frontend/e2e/calendar-lease-events.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/calendar-lease-events.spec.ts
@@ -1,0 +1,208 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * E2E for tenant occupancy on the unified calendar.
+ *
+ * The calendar used to read `listing_blackouts` alone, so an occupied house
+ * rendered as an empty grid. Leases are now a second source. This spec seeds a
+ * real tenancy alongside a channel booking on the same listing and verifies the
+ * full flow end to end:
+ *
+ * 1. Seed property + listing + applicant + a lease on that listing, plus an
+ *    Airbnb blackout on the same row
+ * 2. Both bars render, and the tenancy names the tenant
+ * 3. The lease band covers its final day — `SignedLease.ends_on` is INCLUSIVE
+ *    while the API's `ends_on` is EXCLUSIVE, so a regression here silently
+ *    renders every tenancy a day short
+ * 4. Opening the tenancy shows read-only detail and links to the lease, with no
+ *    notes editor or attachment uploader (those endpoints are blackout-keyed
+ *    and would 404 on a lease id)
+ * 5. Filtering to Tenant hides the channel booking, and vice versa
+ * 6. Cleanup
+ */
+
+const FROM_ISO = "2026-06-01";
+const TO_ISO = "2026-07-01";
+const LEASE_STARTS_ON = "2026-06-03";
+// Inclusive — the tenant's last day. The grid must still colour the 20th.
+const LEASE_ENDS_ON = "2026-06-20";
+
+interface SeedListingPayload {
+  property_id: string;
+  title?: string;
+  status?: "active" | "paused" | "draft" | "archived";
+}
+
+async function seedListing(api: APIRequestContext, payload: SeedListingPayload): Promise<string> {
+  const res = await api.post("/test/seed-listing", { data: payload });
+  if (!res.ok()) throw new Error(`seedListing failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function seedApplicant(api: APIRequestContext, legalName: string): Promise<string> {
+  const res = await api.post("/test/seed-applicant", {
+    data: { legal_name: legalName, stage: "lead" },
+  });
+  if (!res.ok()) throw new Error(`seedApplicant failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function seedLease(
+  api: APIRequestContext,
+  applicantId: string,
+  listingId: string,
+): Promise<string> {
+  const res = await api.post("/test/seed-signed-lease", {
+    data: {
+      applicant_id: applicantId,
+      listing_id: listingId,
+      kind: "imported",
+      status: "signed",
+      starts_on: LEASE_STARTS_ON,
+      ends_on: LEASE_ENDS_ON,
+    },
+  });
+  if (!res.ok()) throw new Error(`seedLease failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function seedBlackout(api: APIRequestContext, listingId: string, runId: number): Promise<string | null> {
+  const res = await api.post("/test/seed-blackout", {
+    data: {
+      listing_id: listingId,
+      starts_on: "2026-06-24",
+      ends_on: "2026-06-27",
+      source: "airbnb",
+      source_event_id: `e2e-lease-cal-${runId}`,
+    },
+  });
+  if (!res.ok()) return null;
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+test.describe("Tenant leases on the calendar", () => {
+  test("a seeded tenancy renders beside a channel booking, reads as read-only, and filters", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const tenantName = `E2E Tenant ${runId}`;
+    const property = await createProperty(api, { name: `E2E Lease Calendar ${runId}` });
+    const listingId = await seedListing(api, {
+      property_id: property.id,
+      title: `E2E Lease Calendar Listing ${runId}`,
+      status: "active",
+    });
+    const applicantId = await seedApplicant(api, tenantName);
+    const leaseId = await seedLease(api, applicantId, listingId);
+    const blackoutId = await seedBlackout(api, listingId, runId);
+
+    test.skip(
+      blackoutId === null,
+      "Blackout seed endpoint not wired up — see app/test_helpers/seed.py",
+    );
+
+    try {
+      await page.goto(`/calendar?from=${FROM_ISO}&to=${TO_ISO}`);
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByRole("heading", { name: "Calendar" })).toBeVisible();
+
+      // Both sources land on the same listing row.
+      const bars = page.getByTestId("calendar-event-bar");
+      await expect(bars).toHaveCount(2);
+
+      const leaseBar = page.locator(
+        '[data-testid="calendar-event-bar"][data-source="lease"]',
+      );
+      await expect(leaseBar).toHaveCount(1);
+      // The band names the tenant — "Tenant" alone would say nothing the
+      // colour didn't already.
+      await expect(leaseBar).toContainText(tenantName);
+
+      // Inclusive lease end → exclusive event end. If the mapper drops the
+      // +1 day, this bar stops on the 19th and the aria-label says so.
+      await expect(leaseBar).toHaveAttribute(
+        "aria-label",
+        new RegExp(`${tenantName} tenancy from ${LEASE_STARTS_ON} to 2026-06-21`),
+      );
+
+      // Detail dialog: read-only, links to the lease, offers no blackout-keyed
+      // editing affordances.
+      await leaseBar.click();
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByText(tenantName)).toBeVisible();
+      await expect(dialog.getByTestId("calendar-lease-footer")).toBeVisible();
+      await expect(dialog.getByRole("link", { name: /open the lease/i })).toHaveAttribute(
+        "href",
+        `/leases/${leaseId}`,
+      );
+      await expect(dialog.getByRole("textbox")).toHaveCount(0);
+      await expect(dialog.getByText("Days")).toBeVisible();
+      await page.keyboard.press("Escape");
+      await expect(dialog).toBeHidden();
+
+      // Filter to Tenant only — the channel booking drops out.
+      await page.getByTestId("source-filter-trigger").click();
+      await page.getByRole("menuitemcheckbox", { name: /Tenant/ }).click();
+      await page.keyboard.press("Escape");
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByTestId("calendar-event-bar")).toHaveCount(1);
+      await expect(page.getByTestId("calendar-event-bar")).toHaveAttribute("data-source", "lease");
+
+      // Swap the filter to Airbnb only — the tenancy drops out. This is the
+      // half that catches a service that ignores the source filter for one of
+      // the two queries.
+      await page.getByTestId("source-filter-trigger").click();
+      await page.getByRole("menuitemcheckbox", { name: /Tenant/ }).click();
+      await page.getByRole("menuitemcheckbox", { name: /Airbnb/ }).click();
+      await page.keyboard.press("Escape");
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByTestId("calendar-event-bar")).toHaveCount(1);
+      await expect(page.getByTestId("calendar-event-bar")).toHaveAttribute("data-source", "airbnb");
+    } finally {
+      if (blackoutId !== null) await api.delete(`/test/blackouts/${blackoutId}`).catch(() => {});
+      await api.delete(`/test/signed-leases/${leaseId}`).catch(() => {});
+      await api.delete(`/test/applicants/${applicantId}`).catch(() => {});
+      await api.delete(`/test/listings/${listingId}`).catch(() => {});
+      await deleteProperty(api, property.id);
+    }
+  });
+
+  test("a lease with no listing assigned stays off the grid", async ({ authedPage: page, api }) => {
+    // `signed_leases.listing_id` is nullable and is the only property linkage
+    // a lease carries, so an unassigned lease has no row to sit on. Pinning
+    // this stops a future "just LEFT JOIN it" change from inventing a
+    // placement the data cannot support.
+    const runId = Date.now();
+    const tenantName = `E2E Unassigned Tenant ${runId}`;
+    const applicantId = await seedApplicant(api, tenantName);
+    const res = await api.post("/test/seed-signed-lease", {
+      data: {
+        applicant_id: applicantId,
+        kind: "imported",
+        status: "signed",
+        starts_on: LEASE_STARTS_ON,
+        ends_on: LEASE_ENDS_ON,
+      },
+    });
+    const { id: leaseId } = (await res.json()) as { id: string };
+
+    try {
+      await page.goto(`/calendar?from=${FROM_ISO}&to=${TO_ISO}`);
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByRole("heading", { name: "Calendar" })).toBeVisible();
+      await expect(
+        page.getByTestId("calendar-event-bar").filter({ hasText: tenantName }),
+      ).toHaveCount(0);
+    } finally {
+      await api.delete(`/test/signed-leases/${leaseId}`).catch(() => {});
+      await api.delete(`/test/applicants/${applicantId}`).catch(() => {});
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/CalendarLeaseEvent.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/CalendarLeaseEvent.test.tsx
@@ -14,6 +14,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { baseApi } from "@/shared/store/baseApi";
 import * as calendarApi from "@/shared/store/calendarApi";
 import CalendarEventDetail from "@/app/features/calendar/CalendarEventDetail";
+import CalendarEventBar from "@/app/features/calendar/CalendarEventBar";
 import {
   CALENDAR_FILTER_SOURCES,
   getSourceColor,
@@ -143,6 +144,46 @@ describe("channel events keep their editing affordances", () => {
   it("still shows the iCal guest-details hint when no summary is present", () => {
     renderDetail(makeEvent());
     expect(screen.getByText(/doesn't expose guest details/i)).toBeInTheDocument();
+  });
+});
+
+describe("the bar on the grid", () => {
+  function renderBar(event: CalendarEvent) {
+    return render(
+      <CalendarEventBar event={event} startCol={0} span={5} onClick={vi.fn()} />,
+    );
+  }
+
+  it("names the tenant rather than repeating the source label", () => {
+    renderBar(makeLeaseEvent());
+    // "Tenant" on every band would tell the host nothing they didn't
+    // already know from the colour — the name is the reason they looked.
+    expect(screen.getByRole("button")).toHaveTextContent("Sonu King");
+  });
+
+  it("falls back to the source label when the tenancy has no name", () => {
+    renderBar(makeLeaseEvent({ summary: null }));
+    expect(screen.getByRole("button")).toHaveTextContent("Tenant");
+  });
+
+  it("still shows the channel name on a channel bar", () => {
+    // iCal sends no guest name, so the channel is all there is to show.
+    renderBar(makeEvent());
+    expect(screen.getByRole("button")).toHaveTextContent("Airbnb");
+  });
+
+  it("calls a tenancy a tenancy, not a blackout, for screen readers", () => {
+    renderBar(makeLeaseEvent());
+    expect(
+      screen.getByRole("button", { name: /Sonu King tenancy from 2026-05-03/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("still calls a channel booking a blackout", () => {
+    renderBar(makeEvent());
+    expect(
+      screen.getByRole("button", { name: /Airbnb blackout from 2026-06-05/i }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/mybookkeeper/frontend/src/__tests__/CalendarLeaseEvent.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/CalendarLeaseEvent.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for tenant-occupancy events in the calendar detail dialog.
+ *
+ * A `lease` event's `id` is a lease id, not a blackout id. The notes and
+ * attachment endpoints are keyed by blackout, so offering either would fire a
+ * request that 404s. These tests pin that the dialog hides both and links to
+ * the lease instead — and that channel events are unaffected.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { configureStore } from "@reduxjs/toolkit";
+import { baseApi } from "@/shared/store/baseApi";
+import * as calendarApi from "@/shared/store/calendarApi";
+import CalendarEventDetail from "@/app/features/calendar/CalendarEventDetail";
+import {
+  CALENDAR_FILTER_SOURCES,
+  getSourceColor,
+  getSourceLabel,
+  isReadOnlySource,
+} from "@/shared/lib/calendar-constants";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+
+function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "blackout-1",
+    listing_id: "listing-1",
+    listing_name: "Master Bedroom",
+    property_id: "prop-1",
+    property_name: "Med Center House",
+    starts_on: "2026-06-05",
+    ends_on: "2026-06-10",
+    source: "airbnb",
+    source_event_id: "uid-1",
+    summary: null,
+    host_notes: null,
+    attachment_count: 0,
+    updated_at: "2026-05-01T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeLeaseEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return makeEvent({
+    id: "lease-abc",
+    source: "lease",
+    source_event_id: null,
+    summary: "Sonu King",
+    starts_on: "2026-05-03",
+    ends_on: "2026-08-10", // exclusive — term runs through Aug 9
+    ...overrides,
+  });
+}
+
+function renderDetail(event: CalendarEvent) {
+  const store = configureStore({
+    reducer: { [baseApi.reducerPath]: baseApi.reducer },
+    middleware: (getDefault) => getDefault().concat(baseApi.middleware),
+  });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CalendarEventDetail event={event} onClose={vi.fn()} />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(calendarApi, "useGetBlackoutAttachmentsQuery").mockReturnValue({
+    data: [],
+    isLoading: false,
+  } as unknown as ReturnType<typeof calendarApi.useGetBlackoutAttachmentsQuery>);
+  vi.spyOn(calendarApi, "useUpdateBlackoutMutation").mockReturnValue([
+    vi.fn().mockReturnValue({ unwrap: vi.fn().mockResolvedValue({}) }),
+    { isLoading: false },
+  ] as unknown as ReturnType<typeof calendarApi.useUpdateBlackoutMutation>);
+  vi.spyOn(calendarApi, "useUploadBlackoutAttachmentMutation").mockReturnValue([
+    vi.fn().mockReturnValue({ unwrap: vi.fn().mockResolvedValue({}) }),
+    { isLoading: false },
+  ] as unknown as ReturnType<typeof calendarApi.useUploadBlackoutAttachmentMutation>);
+  vi.spyOn(calendarApi, "useDeleteBlackoutAttachmentMutation").mockReturnValue([
+    vi.fn().mockReturnValue({ unwrap: vi.fn().mockResolvedValue(undefined) }),
+    { isLoading: false },
+  ] as unknown as ReturnType<typeof calendarApi.useDeleteBlackoutAttachmentMutation>);
+});
+
+describe("lease events in the calendar detail dialog", () => {
+  it("shows the tenant name as the title, exactly once", () => {
+    renderDetail(makeLeaseEvent());
+    // The title already names the tenant — a duplicate summary row would be
+    // noise, so the dialog must not also render one.
+    expect(screen.getAllByText("Sonu King")).toHaveLength(1);
+  });
+
+  it("hides the notes editor — the id is a lease, not a blackout", () => {
+    renderDetail(makeLeaseEvent());
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("never queries blackout attachments for a lease event", () => {
+    renderDetail(makeLeaseEvent());
+    // The attachments section is not rendered, so its hook never fires.
+    expect(calendarApi.useGetBlackoutAttachmentsQuery).not.toHaveBeenCalled();
+  });
+
+  it("links to the lease so the host has somewhere to edit", () => {
+    renderDetail(makeLeaseEvent());
+    const link = screen.getByRole("link", { name: /open the lease/i });
+    expect(link).toHaveAttribute("href", "/leases/lease-abc");
+  });
+
+  it("reads as a Tenant source, with no channel row", () => {
+    renderDetail(makeLeaseEvent());
+    expect(screen.getAllByText("Tenant")).toHaveLength(1);
+    expect(screen.queryByText("From channel")).not.toBeInTheDocument();
+  });
+
+  it("omits the iCal guest-details hint, which does not apply to leases", () => {
+    renderDetail(makeLeaseEvent());
+    expect(screen.queryByText(/doesn't expose guest details/i)).not.toBeInTheDocument();
+  });
+
+  it("counts a months-long tenancy in days, not nights", () => {
+    renderDetail(makeLeaseEvent());
+    expect(screen.getByText("Days")).toBeInTheDocument();
+    expect(screen.queryByText("Nights")).not.toBeInTheDocument();
+  });
+});
+
+describe("channel events keep their editing affordances", () => {
+  it("still renders the notes editor for an airbnb blackout", () => {
+    renderDetail(makeEvent());
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("still queries blackout attachments for an airbnb blackout", () => {
+    renderDetail(makeEvent());
+    expect(calendarApi.useGetBlackoutAttachmentsQuery).toHaveBeenCalled();
+  });
+
+  it("still shows the iCal guest-details hint when no summary is present", () => {
+    renderDetail(makeEvent());
+    expect(screen.getByText(/doesn't expose guest details/i)).toBeInTheDocument();
+  });
+});
+
+describe("lease source registration", () => {
+  it("appears in the legend and filter list", () => {
+    expect(CALENDAR_FILTER_SOURCES).toContain("lease");
+  });
+
+  it("has its own color rather than the unknown-source fallback", () => {
+    expect(getSourceColor("lease")).not.toBe(getSourceColor("some-new-channel"));
+  });
+
+  it("reads as 'Tenant' in the legend", () => {
+    expect(getSourceLabel("lease")).toBe("Tenant");
+  });
+
+  it("is the only read-only source today", () => {
+    expect(isReadOnlySource("lease")).toBe(true);
+    expect(isReadOnlySource("airbnb")).toBe(false);
+    expect(isReadOnlySource("manual")).toBe(false);
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventBar.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventBar.tsx
@@ -1,4 +1,4 @@
-import { getSourceColor, getSourceLabel } from "@/shared/lib/calendar-constants";
+import { getSourceColor, getSourceLabel, isReadOnlySource } from "@/shared/lib/calendar-constants";
 import { CALENDAR_DAY_CELL_PX } from "@/shared/lib/calendar-constants";
 import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
 
@@ -25,6 +25,12 @@ export default function CalendarEventBar({ event, startCol, span, onClick }: Cal
   const isManual = event.source === "manual";
   const color = getSourceColor(event.source);
   const label = getSourceLabel(event.source);
+  // A channel bar can only say which channel it came from — iCal sends no
+  // guest name. A tenancy knows exactly who lives there, and that name is
+  // the reason the host is looking at the row at all.
+  const isTenancy = isReadOnlySource(event.source);
+  const barLabel = isTenancy ? (event.summary ?? label) : label;
+  const kindWord = isTenancy ? "tenancy" : "blackout";
 
   const hasNotes = event.host_notes != null;
   const hasAttachments = event.attachment_count > 0;
@@ -53,11 +59,11 @@ export default function CalendarEventBar({ event, startCol, span, onClick }: Cal
           : undefined,
       }}
       title={tooltip}
-      aria-label={`${label} blackout from ${event.starts_on} to ${event.ends_on}. Click for details.`}
+      aria-label={`${barLabel} ${kindWord} from ${event.starts_on} to ${event.ends_on}. Click for details.`}
       data-testid="calendar-event-bar"
       data-source={event.source}
     >
-      <span className="truncate flex-1">{label}</span>
+      <span className="truncate flex-1">{barLabel}</span>
 
       {/* Notes / attachment indicators — top-right of the bar */}
       {(hasNotes || hasAttachments) ? (

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventDetailBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventDetailBody.tsx
@@ -7,10 +7,12 @@ import {
 import {
   getSourceColor,
   getSourceLabel,
+  isReadOnlySource,
 } from "@/shared/lib/calendar-constants";
 import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
 import AttachmentsSection from "@/app/features/calendar/CalendarEventAttachmentsSection";
 import NotesSection from "@/app/features/calendar/CalendarEventNotesSection";
+import LeaseEventFooter from "@/app/features/calendar/CalendarLeaseEventFooter";
 
 export interface CalendarEventDetailBodyProps {
   event: CalendarEvent;
@@ -22,6 +24,19 @@ export default function CalendarEventDetailBody({ event }: CalendarEventDetailBo
   const nights = Math.max(1, daysBetween(event.starts_on, event.ends_on));
   const range = formatWindowLabel(event.starts_on, event.ends_on);
   const synced = relativeTime(event.updated_at);
+  // A read-only event's id belongs to another table (a lease, not a
+  // blackout), so the notes and attachment endpoints don't address it.
+  const readOnly = isReadOnlySource(event.source);
+  // A months-long tenancy isn't measured in nights, and nothing polls a
+  // lease — the channel wording would be wrong on both counts.
+  const nightsLabel = readOnly ? "Days" : "Nights";
+  const updatedLabel = readOnly ? "Last updated" : "Last synced";
+  // A lease's summary IS the tenant name, already the title. Repeating it as
+  // a row adds nothing; for a channel the raw iCal text is worth showing.
+  const showSummaryRow = !!event.summary && !readOnly;
+  // Channels that send no guest name get a nudge to record it in the notes.
+  // Leases always carry a tenant name and have no notes field here.
+  const showChannelHint = !event.summary && !readOnly;
 
   return (
     <div className="space-y-5">
@@ -50,10 +65,10 @@ export default function CalendarEventDetailBody({ event }: CalendarEventDetailBo
         <dt className="text-muted-foreground">Dates</dt>
         <dd className="font-medium">{range}</dd>
 
-        <dt className="text-muted-foreground">Nights</dt>
+        <dt className="text-muted-foreground">{nightsLabel}</dt>
         <dd className="font-medium">{nights}</dd>
 
-        {event.summary ? (
+        {showSummaryRow ? (
           <>
             <dt className="text-muted-foreground">From channel</dt>
             <dd className="font-medium break-words">{event.summary}</dd>
@@ -67,22 +82,28 @@ export default function CalendarEventDetailBody({ event }: CalendarEventDetailBo
           </>
         ) : null}
 
-        <dt className="text-muted-foreground">Last synced</dt>
+        <dt className="text-muted-foreground">{updatedLabel}</dt>
         <dd className="font-medium">{synced}</dd>
       </dl>
 
-      {!event.summary ? (
+      {showChannelHint ? (
         <p className="text-xs text-muted-foreground italic border-t pt-3">
           {sourceLabel} doesn't expose guest details over iCal — only the dates
           and source channel. Paste guest info in the notes below.
         </p>
       ) : null}
 
-      {/* Editable notes — key resets local state when a different blackout is opened */}
-      <NotesSection key={event.id} blackoutId={event.id} initialNotes={event.host_notes} />
+      {readOnly ? (
+        <LeaseEventFooter leaseId={event.id} />
+      ) : (
+        <>
+          {/* Editable notes — key resets local state when a different blackout is opened */}
+          <NotesSection key={event.id} blackoutId={event.id} initialNotes={event.host_notes} />
 
-      {/* Attachments */}
-      <AttachmentsSection blackoutId={event.id} />
+          {/* Attachments */}
+          <AttachmentsSection blackoutId={event.id} />
+        </>
+      )}
     </div>
   );
 }

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarLeaseEventFooter.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarLeaseEventFooter.tsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router-dom";
+
+export interface CalendarLeaseEventFooterProps {
+  leaseId: string;
+}
+
+/**
+ * Footer for a tenant-occupancy event in the calendar detail dialog.
+ *
+ * Lease events are read-only here: the notes and attachment endpoints are
+ * keyed by blackout id, and this event's id is a lease id. Rather than
+ * offering an edit that would 404, send the host to the lease — where notes,
+ * documents, and the term itself actually live.
+ */
+export default function CalendarLeaseEventFooter({
+  leaseId,
+}: CalendarLeaseEventFooterProps) {
+  return (
+    <div className="border-t pt-3 space-y-2" data-testid="calendar-lease-footer">
+      <p className="text-xs text-muted-foreground italic">
+        These dates come from a signed lease, so they aren't editable here.
+      </p>
+      <Link
+        to={`/leases/${leaseId}`}
+        className="inline-flex items-center min-h-[44px] text-sm font-medium text-primary hover:underline"
+      >
+        Open the lease
+      </Link>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/calendar-constants.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/calendar-constants.ts
@@ -57,6 +57,7 @@ export const CALENDAR_SOURCE_COLORS: Record<string, string> = {
   rotating_room: "#7c3aed",   // purple
   direct: "#6b7280",          // slate gray
   manual: "#475569",          // darker slate; hatched overlay added in CSS
+  lease: "#b45309",           // amber-700; warm, and unlike every channel hue
 };
 
 /**
@@ -69,7 +70,21 @@ export const CALENDAR_SOURCE_LABELS: Record<string, string> = {
   rotating_room: "Rotating Room",
   direct: "Direct",
   manual: "Manual",
+  lease: "Tenant",
 };
+
+/**
+ * Sources whose events cannot be edited in the detail dialog.
+ *
+ * A `lease` event's `id` is a lease id, not a blackout id — the notes and
+ * attachment endpoints are keyed by blackout and would 404. The dialog hides
+ * both sections for these sources and points the host at the lease instead.
+ */
+export const CALENDAR_READ_ONLY_SOURCES: readonly string[] = ["lease"];
+
+export function isReadOnlySource(source: string): boolean {
+  return CALENDAR_READ_ONLY_SOURCES.includes(source);
+}
 
 /**
  * Fallback color for unknown source slugs (e.g., a channel added on
@@ -98,4 +113,5 @@ export const CALENDAR_FILTER_SOURCES: readonly CalendarSource[] = [
   "rotating_room",
   "direct",
   "manual",
+  "lease",
 ];

--- a/apps/mybookkeeper/frontend/src/shared/types/calendar/calendar-source.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/calendar/calendar-source.ts
@@ -1,11 +1,16 @@
 /**
  * Known event source slugs.
  *
- * `manual` is operator-entered; the others come from iCal-poll imports
+ * `manual` is operator-entered; most others come from iCal-poll imports
  * (channel slugs). Furnished Finder doesn't expose iCal — its blackouts
  * never appear in this list, by design. The frontend treats unknown
  * sources gracefully (gray fallback color) so the calendar never
  * crashes if a new channel is added before the frontend is updated.
+ *
+ * `lease` is the odd one out: not a channel, but tenant occupancy unioned
+ * in from `signed_leases`. Events carrying it are read-only — their `id` is
+ * a lease id, so the blackout notes/attachment endpoints don't apply. See
+ * `CALENDAR_READ_ONLY_SOURCES` in `shared/lib/calendar-constants`.
  */
 export const CALENDAR_SOURCES = [
   "airbnb",
@@ -14,6 +19,7 @@ export const CALENDAR_SOURCES = [
   "rotating_room",
   "direct",
   "manual",
+  "lease",
 ] as const;
 
 export type CalendarSource = (typeof CALENDAR_SOURCES)[number];

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -408,6 +408,7 @@
         "backend/app/schemas/listings/listing_blackout_attachment_response.py",
         "backend/app/models/listings/listing_blackout.py",
         "backend/app/models/listings/listing_blackout_attachment.py",
+        "backend/app/models/leases/signed_lease.py",
         "backend/app/core/calendar_constants.py",
         "frontend/src/app/pages/Calendar.tsx",
         "frontend/src/app/features/calendar/",
@@ -438,6 +439,7 @@
       ],
       "e2e_specs": [
         "calendar.spec.ts",
+        "calendar-lease-events.spec.ts",
         "calendar-booking-notes.spec.ts",
         "calendar-review-queue-resolve.spec.ts"
       ]

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -399,6 +399,7 @@
         "backend/app/services/listings/blackout_service.py",
         "backend/app/services/listings/attachment_response_builder.py",
         "backend/app/repositories/calendar/",
+        "backend/app/mappers/calendar_event_mapper.py",
         "backend/app/repositories/listings/listing_blackout_repo.py",
         "backend/app/repositories/listings/listing_blackout_attachment_repo.py",
         "backend/app/schemas/calendar/",
@@ -419,6 +420,7 @@
       "backend_tests": [
         "test_calendar_repository.py",
         "test_calendar_service.py",
+        "test_calendar_event_mapper.py",
         "test_calendar_events_route.py",
         "test_calendar_route.py",
         "test_blackout_notes_attachments.py",
@@ -430,6 +432,7 @@
         "Calendar.test.tsx",
         "calendar-utils.test.ts",
         "CalendarEventDetail.test.tsx",
+        "CalendarLeaseEvent.test.tsx",
         "ReviewQueueItem.test.tsx",
         "ReviewQueueDrawer.test.tsx"
       ],


### PR DESCRIPTION
## Why

The calendar read `listing_blackouts` and nothing else, so it showed channel
bookings and manual holds but never the people actually living in the rooms —
an occupied house rendered as an empty August.

## What

Leases become a second source, unioned into the same event list.

- **`calendar_repository.query_lease_events`** — joins `signed_leases` →
  `listings` → `properties` → `applicants`, restricted to occupancy statuses
  (`signed` / `active` / `ended`) and to leases overlapping the window.
- **`mappers/calendar_event_mapper.py`** (new) — converts both row shapes to
  `CalendarEventResponse` and owns the one genuinely subtle bit:
  `ListingBlackout.ends_on` is **exclusive** (iCal RFC 5545) while
  `SignedLease.ends_on` is **inclusive**, so a lease end gets `+1 day`. Without
  that every tenancy renders a day short. Both conversions now live in one
  module instead of being inlined in the service.
- **`calendar_service.list_events`** — runs whichever queries the `sources`
  filter asks for (a `lease`-only filter skips the blackout query entirely, and
  vice-versa) and merges by `(property, listing, start)` so leases and channel
  bookings interleave on a listing row rather than arriving as two blocks.

Front end registers `lease` as a source with its own colour and the label
**Tenant**. The grid bar shows the tenant's **name** — a channel bar can only
name its channel because iCal sends no guest, but a tenancy knows who lives
there, and "Tenant" on every band would say nothing the colour didn't.

A lease event's `id` is a lease id, not a blackout id, so the detail dialog
hides the notes editor and the attachments section — both endpoints are
blackout-keyed and would 404 — and links to `/leases/:id` instead. Tenancies are
counted in **Days**, not Nights, and there is no "last synced" wording because
nothing polls a lease.

## Verification

- 46 backend calendar tests, 42 frontend calendar tests, `tsc --noEmit`, eslint,
  `check-file-size.py` — all green.
- **New E2E** `calendar-lease-events.spec.ts` seeds a property, listing,
  applicant, a lease on that listing and an Airbnb blackout on the same row,
  then walks the whole flow: both bars render, the tenancy names the tenant, the
  band covers its final day, the detail dialog is read-only and links to the
  lease with no notes editor, and each source filter hides the other. A second
  test pins that a lease with no listing stays off the grid. `/test/seed-signed-lease`
  gains `listing_id` (it hardcoded `None`, so no E2E could build this scenario).
- Exercised the **real SQL against local Postgres**, since the service tests
  mock the repository: seeded one lease `2026-08-01 → 2026-08-09` on a listing,
  confirmed `query_lease_events` returns it and the mapper emits
  `ends_on = 2026-08-10`, plus four window-boundary cases (window ending on the
  lease start → 0; starting on the inclusive end → 1; starting the day after →
  0; fully before → 0). Seed rows deleted afterwards and the count verified back
  to zero.

## Note for the operator

A lease only appears if it has a **listing assigned**. `signed_leases.listing_id`
is nullable and is the *only* property linkage a lease carries, so a lease
without one has no calendar row to sit on — there is no data to place it with.
Assigning a listing to an existing lease is not possible in the UI today
(`PATCH /signed-leases/{id}` accepts `notes` / `status` / `values` /
`auto_email_tenant` only, and neither the Leases list nor Lease detail even
displays the listing). If your existing leases were imported without picking a
room, that gap is the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ML9WSmCrU3dyjH9BWZRQmG