### PR TITLE
fix(mybookkeeper): show leases that aren't linked to a listing on the calendar

### DIFF
--- a/apps/mybookkeeper/backend/app/mappers/calendar_event_mapper.py
+++ b/apps/mybookkeeper/backend/app/mappers/calendar_event_mapper.py
@@ -55,14 +55,19 @@ def blackout_to_event(
 
 def lease_to_event(
     lease: SignedLease,
-    listing: Listing,
-    prop: Property,
+    listing: Listing | None,
+    prop: Property | None,
     applicant: Applicant,
 ) -> CalendarEventResponse:
     """Map tenant occupancy from a signed lease.
 
     ``summary`` carries the tenant's name — the whole point of surfacing
     leases here is seeing *who* is in a room, not just that it is taken.
+
+    ``listing`` and ``prop`` are optional because ``signed_leases.listing_id``
+    is nullable: a host can record a tenancy without linking it to a listing.
+    Those leases map to an event with null listing/property rather than being
+    dropped, and the viewer groups them under an "unassigned" heading.
 
     Notes and attachments stay empty: those endpoints are keyed by blackout
     id, and this event's id is a lease id. The frontend hides both sections
@@ -74,10 +79,10 @@ def lease_to_event(
     assert lease.starts_on is not None and lease.ends_on is not None
     return CalendarEventResponse(
         id=lease.id,
-        listing_id=listing.id,
-        listing_name=listing.title,
-        property_id=prop.id,
-        property_name=prop.name,
+        listing_id=listing.id if listing else None,
+        listing_name=listing.title if listing else None,
+        property_id=prop.id if prop else None,
+        property_name=prop.name if prop else None,
         starts_on=lease.starts_on,
         ends_on=lease.ends_on + timedelta(days=1),
         source=LEASE_SOURCE,
@@ -91,11 +96,22 @@ def lease_to_event(
 
 def event_sort_key(
     event: CalendarEventResponse,
-) -> tuple[str, str, object, uuid.UUID]:
+) -> tuple[bool, str, str, object, uuid.UUID]:
     """Ordering for the merged list.
 
     Mirrors what each repository query orders by, applied after the union so
     blackouts and leases interleave correctly instead of arriving in two
     separate blocks.
+
+    The leading flag is the Python equivalent of the queries' ``NULLS LAST``:
+    ``False`` sorts before ``True``, so events with a listing come first and
+    unassigned leases collect at the end. It also keeps the comparison
+    total — ``None`` and ``str`` are not orderable against each other.
     """
-    return (event.property_name, event.listing_name, event.starts_on, event.id)
+    return (
+        event.property_name is None,
+        event.property_name or "",
+        event.listing_name or "",
+        event.starts_on,
+        event.id,
+    )

--- a/apps/mybookkeeper/backend/app/repositories/calendar/calendar_repository.py
+++ b/apps/mybookkeeper/backend/app/repositories/calendar/calendar_repository.py
@@ -3,11 +3,19 @@
 Two queries feed the viewer, one per event source:
 
 ``query_events`` joins ``listing_blackouts`` → ``listings`` → ``properties``
-— channel bookings and manual blocks. ``query_lease_events`` joins
-``signed_leases`` → ``listings`` → ``properties`` → ``applicants`` — tenant
-occupancy. Both return the per-event listing name + property name the viewer
-needs in a single round trip, and both are tenant-scoped via
-``listings.organization_id``.
+— channel bookings and manual blocks; tenant-scoped via
+``listings.organization_id`` because a blackout carries no organization of its
+own. ``query_lease_events`` OUTER-joins ``signed_leases`` → ``listings`` →
+``properties`` and inner-joins ``applicants`` — tenant occupancy, scoped on
+``signed_leases.organization_id``. Both return the per-event listing name +
+property name the viewer needs in a single round trip.
+
+The lease join is outer, and the scope column differs, for the same reason:
+``signed_leases.listing_id`` is nullable, so a lease the host never linked to
+a listing has no listing to scope on or read a name from. Inner-joining would
+drop it from the calendar without a trace — the host sees a tenancy missing
+and no explanation. Such a lease is returned with ``None`` for its listing and
+property; the viewer groups those under an "unassigned" heading.
 
 Date overlap semantics differ between the two, and the difference matters:
 
@@ -25,7 +33,7 @@ import uuid
 from collections.abc import Sequence
 from datetime import date
 
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.calendar_constants import LEASE_OCCUPANCY_STATUSES
@@ -95,7 +103,7 @@ async def query_lease_events(
     to: date,
     listing_ids: Sequence[uuid.UUID] | None = None,
     property_ids: Sequence[uuid.UUID] | None = None,
-) -> list[tuple[SignedLease, Listing, Property, Applicant]]:
+) -> list[tuple[SignedLease, Listing | None, Property | None, Applicant]]:
     """Return occupying leases + listing + property + tenant within the window.
 
     ``listing_ids`` / ``property_ids`` narrow the result the same way they do
@@ -104,22 +112,39 @@ async def query_lease_events(
     this query at all rather than filtering inside it.
 
     Excluded, all for the same reason (they do not describe someone living in
-    the listing on those dates):
+    a listing on those dates):
 
     - statuses outside ``LEASE_OCCUPANCY_STATUSES``
-    - soft-deleted leases and soft-deleted listings
-    - leases with no ``listing_id`` — the grid is listing-rows, so a lease
-      with nothing to sit on cannot be drawn (the join drops these)
+    - soft-deleted leases
     - leases missing either date bound, which have no extent to draw
+
+    A lease with no ``listing_id`` — or one pointing at a soft-deleted listing
+    — is NOT excluded. It comes back with ``None`` in the listing and property
+    slots. The tenancy is real and the host needs to see it; which listing it
+    belongs to is a separate, fixable gap. The soft-delete test lives in the
+    join's ON clause rather than the WHERE so a deleted listing degrades the
+    lease to unassigned instead of erasing it.
+
+    Narrowing by ``listing_ids`` or ``property_ids`` does drop unassigned
+    leases, which is correct: the host asked for one listing's occupancy, and
+    a lease with no listing is not part of that answer.
     """
     stmt = (
         select(SignedLease, Listing, Property, Applicant)
-        .join(Listing, Listing.id == SignedLease.listing_id)
-        .join(Property, Property.id == Listing.property_id)
+        .outerjoin(
+            Listing,
+            and_(
+                Listing.id == SignedLease.listing_id,
+                Listing.deleted_at.is_(None),
+            ),
+        )
+        .outerjoin(Property, Property.id == Listing.property_id)
         .join(Applicant, Applicant.id == SignedLease.applicant_id)
         .where(
-            Listing.organization_id == organization_id,
-            Listing.deleted_at.is_(None),
+            # Scoped on the lease, not the listing — an unassigned lease has
+            # no listing to carry the organization. ``signed_leases`` owns an
+            # organization_id of its own precisely for this.
+            SignedLease.organization_id == organization_id,
             SignedLease.deleted_at.is_(None),
             SignedLease.status.in_(sorted(LEASE_OCCUPANCY_STATUSES)),
             SignedLease.starts_on.is_not(None),
@@ -129,8 +154,9 @@ async def query_lease_events(
             SignedLease.ends_on >= from_,
         )
         .order_by(
-            Property.name.asc(),
-            Listing.title.asc(),
+            # Unassigned sorts last, matching the viewer's grouping.
+            Property.name.asc().nulls_last(),
+            Listing.title.asc().nulls_last(),
             SignedLease.starts_on.asc(),
             SignedLease.id.asc(),
         )

--- a/apps/mybookkeeper/backend/app/schemas/calendar/calendar_event_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/calendar/calendar_event_response.py
@@ -1,5 +1,4 @@
-"""Calendar event payload — one row per listing_blackout joined to its
-listing + property.
+"""Calendar event payload — one channel/manual blackout or one tenancy.
 
 Returned as a flat list by ``GET /api/calendar/events`` (the unified
 calendar viewer). The viewer is read-only — no mutations exist on this
@@ -8,6 +7,12 @@ schema.
 Date semantics match ``ListingBlackout``: ``starts_on`` inclusive,
 ``ends_on`` exclusive (iCal RFC 5545 convention). The frontend grid is
 responsible for translating exclusive end → display end.
+
+The listing and property fields are nullable, and only a ``lease`` event can
+actually carry nulls: a blackout hangs off a listing by construction, whereas
+``signed_leases.listing_id`` is nullable and a host can record a tenancy
+before linking it to a listing. Consumers must render those events under an
+"unassigned" heading rather than assume a name is present.
 """
 from __future__ import annotations
 
@@ -19,10 +24,10 @@ from pydantic import BaseModel, ConfigDict
 
 class CalendarEventResponse(BaseModel):
     id: uuid.UUID
-    listing_id: uuid.UUID
-    listing_name: str
-    property_id: uuid.UUID
-    property_name: str
+    listing_id: uuid.UUID | None = None
+    listing_name: str | None = None
+    property_id: uuid.UUID | None = None
+    property_name: str | None = None
     starts_on: date
     ends_on: date
     source: str

--- a/apps/mybookkeeper/backend/app/test_helpers/seed.py
+++ b/apps/mybookkeeper/backend/app/test_helpers/seed.py
@@ -592,8 +592,9 @@ class _SeedSignedLeaseRequest(BaseModel):
     applicant_id: uuid.UUID | None = None
     kind: str = "imported"
     status: str = "signed"
-    # The only property linkage a lease has — a lease without it cannot
-    # appear on the (listing-keyed) calendar.
+    # The only property linkage a lease has. Leaving it unset is a real
+    # state, not an invalid one — the calendar collects such tenancies
+    # under an "unassigned" row rather than dropping them.
     listing_id: uuid.UUID | None = None
     starts_on: _dt.date | None = None
     ends_on: _dt.date | None = None

--- a/apps/mybookkeeper/backend/tests/test_calendar_event_mapper.py
+++ b/apps/mybookkeeper/backend/tests/test_calendar_event_mapper.py
@@ -115,6 +115,24 @@ class TestLeaseToEvent:
         assert event.property_id == prop.id
         assert event.property_name == "Elsewhere"
 
+    def test_maps_a_lease_with_no_listing_instead_of_refusing(self) -> None:
+        """``signed_leases.listing_id`` is nullable — the tenancy is still real."""
+        event = lease_to_event(
+            _lease(date(2026, 8, 26), date(2026, 10, 3)),
+            None,
+            None,
+            SimpleNamespace(legal_name="Mohammed Awamleh"),
+        )
+        assert event.listing_id is None
+        assert event.listing_name is None
+        assert event.property_id is None
+        assert event.property_name is None
+        # Everything that makes the event useful still survives.
+        assert event.summary == "Mohammed Awamleh"
+        assert event.starts_on == date(2026, 8, 26)
+        assert event.ends_on == date(2026, 10, 4)
+        assert event.source == LEASE_SOURCE
+
 
 class TestBlackoutToEvent:
     def test_passes_the_exclusive_end_through_untouched(self) -> None:
@@ -166,3 +184,18 @@ class TestEventSortKey:
         ]
         ordered = sorted(events, key=event_sort_key)
         assert [e.source for e in ordered] == [LEASE_SOURCE, "airbnb", "airbnb"]
+
+    def test_sorts_listing_less_leases_last_without_raising(self) -> None:
+        """``None`` and ``str`` are not orderable — the key must rank null-ness."""
+        applicant = SimpleNamespace(legal_name="T")
+        events = [
+            lease_to_event(_lease(date(2026, 8, 1), date(2026, 8, 9)), None, None, applicant),
+            lease_to_event(
+                _lease(date(2026, 8, 1), date(2026, 8, 9)),
+                _listing("Z room"),
+                _property("Z prop"),
+                applicant,
+            ),
+        ]
+        ordered = sorted(events, key=event_sort_key)
+        assert [e.property_name for e in ordered] == ["Z prop", None]

--- a/apps/mybookkeeper/backend/tests/test_calendar_repository.py
+++ b/apps/mybookkeeper/backend/tests/test_calendar_repository.py
@@ -1,10 +1,18 @@
 """Repository tests for the unified calendar viewer.
 
-Covers:
+Covers, for ``query_events`` (blackouts):
 - date-range overlap (events fully inside / overlapping start / overlapping end / outside)
 - soft-deleted listings excluded
 - tenant isolation: another organization's events never appear
 - filter composition: listing_ids, property_ids, sources
+
+and, for ``query_lease_events`` (tenancies):
+- leases with no ``listing_id`` are RETURNED, with null listing/property
+- tenant isolation on ``signed_leases.organization_id``, including for
+  leases that have no listing to scope on
+- status / soft-delete / date-bound exclusions
+- filter composition, including that narrowing by listing or property
+  intentionally drops unlinked leases
 
 Per CLAUDE.md: 'enumerate and test all composite key combinations
 before implementation' — applied here to the half-open interval
@@ -19,6 +27,8 @@ from decimal import Decimal
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.applicants.applicant import Applicant
+from app.models.leases.signed_lease import SignedLease
 from app.models.listings.listing import Listing
 from app.models.listings.listing_blackout import ListingBlackout
 from app.models.organization.organization import Organization
@@ -72,6 +82,48 @@ async def _seed_property(
     db.add(prop)
     await db.flush()
     return prop
+
+
+async def _seed_applicant(
+    db: AsyncSession, org: Organization, user: User, *, legal_name: str,
+) -> Applicant:
+    applicant = Applicant(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        user_id=user.id,
+        legal_name=legal_name,
+    )
+    db.add(applicant)
+    await db.flush()
+    return applicant
+
+
+def _make_lease(
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    applicant_id: uuid.UUID,
+    starts_on: date | None,
+    ends_on: date | None,
+    listing_id: uuid.UUID | None = None,
+    status: str = "signed",
+    deleted_at: datetime | None = None,
+) -> SignedLease:
+    """A signed lease. ``listing_id`` defaults to None — the case the
+    calendar used to drop on the floor."""
+    return SignedLease(
+        id=uuid.uuid4(),
+        organization_id=organization_id,
+        user_id=user_id,
+        applicant_id=applicant_id,
+        listing_id=listing_id,
+        kind="generated",
+        values={},
+        status=status,
+        starts_on=starts_on,
+        ends_on=ends_on,
+        deleted_at=deleted_at,
+    )
 
 
 def _make_blackout(
@@ -766,3 +818,267 @@ class TestListingBlackoutRepoCreateAndDelete:
             db, blackout_id=uuid.uuid4(), organization_id=test_org.id,
         )
         assert deleted is False
+
+
+# ---------------------------------------------------------------------------
+# query_lease_events — tenant occupancy
+#
+# The regression these exist for: ``signed_leases.listing_id`` is nullable, and
+# an inner join to ``listings`` silently discarded every lease the host hadn't
+# linked yet. A tenancy that exists must reach the calendar; the missing link
+# is a gap to surface, not a reason to hide the tenant.
+# ---------------------------------------------------------------------------
+
+_WINDOW = {"from_": date(2026, 8, 1), "to": date(2026, 9, 1)}
+
+
+class TestCalendarRepoLeaseEvents:
+    @pytest.mark.asyncio
+    async def test_lease_with_no_listing_is_returned_with_null_listing(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        applicant = await _seed_applicant(
+            db, test_org, test_user, legal_name="Mohammed Awamleh",
+        )
+        db.add(_make_lease(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            applicant_id=applicant.id,
+            starts_on=date(2026, 8, 26),
+            ends_on=date(2026, 10, 3),
+        ))
+        await db.commit()
+
+        rows = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id, **_WINDOW,
+        )
+        assert len(rows) == 1
+        lease, listing, prop, tenant = rows[0]
+        assert listing is None
+        assert prop is None
+        assert lease.starts_on == date(2026, 8, 26)
+        assert tenant.legal_name == "Mohammed Awamleh"
+
+    @pytest.mark.asyncio
+    async def test_linked_and_unlinked_leases_both_come_back(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        prop = await _seed_property(db, test_org, test_user, name="6734 Peerless")
+        listing = _make_listing(
+            organization_id=test_org.id, user_id=test_user.id, property_id=prop.id,
+            title="Private suite",
+        )
+        db.add(listing)
+        await db.flush()
+        linked = await _seed_applicant(db, test_org, test_user, legal_name="Sonu King")
+        unlinked = await _seed_applicant(db, test_org, test_user, legal_name="Andrew Le")
+        db.add_all([
+            _make_lease(
+                organization_id=test_org.id, user_id=test_user.id,
+                applicant_id=linked.id, listing_id=listing.id,
+                starts_on=date(2026, 5, 3), ends_on=date(2026, 11, 10),
+            ),
+            _make_lease(
+                organization_id=test_org.id, user_id=test_user.id,
+                applicant_id=unlinked.id,
+                starts_on=date(2026, 5, 30), ends_on=date(2026, 8, 9),
+            ),
+        ])
+        await db.commit()
+
+        rows = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id, **_WINDOW,
+        )
+        assert len(rows) == 2
+        assert {r[3].legal_name for r in rows} == {"Sonu King", "Andrew Le"}
+        # Linked first, unlinked last — NULLS LAST on the property name.
+        assert rows[0][1] is not None
+        assert rows[1][1] is None
+
+    @pytest.mark.asyncio
+    async def test_soft_deleted_listing_degrades_the_lease_to_unlinked(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The tenancy survives; only the (now-deleted) listing name drops."""
+        prop = await _seed_property(db, test_org, test_user)
+        gone = _make_listing(
+            organization_id=test_org.id, user_id=test_user.id, property_id=prop.id,
+            title="Gone", deleted_at=datetime.now(timezone.utc),
+        )
+        db.add(gone)
+        await db.flush()
+        applicant = await _seed_applicant(db, test_org, test_user, legal_name="Sonu King")
+        db.add(_make_lease(
+            organization_id=test_org.id, user_id=test_user.id,
+            applicant_id=applicant.id, listing_id=gone.id,
+            starts_on=date(2026, 8, 1), ends_on=date(2026, 8, 20),
+        ))
+        await db.commit()
+
+        rows = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id, **_WINDOW,
+        )
+        assert len(rows) == 1
+        assert rows[0][1] is None
+        assert rows[0][3].legal_name == "Sonu King"
+
+    @pytest.mark.asyncio
+    async def test_another_orgs_unlinked_lease_never_appears(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Scoping moved from the listing to the lease — prove it still holds
+        for exactly the rows that have no listing to scope on."""
+        mine = await _seed_applicant(db, test_org, test_user, legal_name="Mine")
+        db.add(_make_lease(
+            organization_id=test_org.id, user_id=test_user.id,
+            applicant_id=mine.id,
+            starts_on=date(2026, 8, 1), ends_on=date(2026, 8, 20),
+        ))
+
+        user_b = User(
+            id=uuid.uuid4(), email="leaseb@example.com", hashed_password="hash",
+            is_active=True, is_superuser=False, is_verified=True,
+        )
+        org_b = Organization(id=uuid.uuid4(), name="Org B", created_by=user_b.id)
+        db.add_all([user_b, org_b])
+        await db.flush()
+        db.add(OrganizationMember(
+            organization_id=org_b.id, user_id=user_b.id, org_role="owner",
+        ))
+        theirs = await _seed_applicant(db, org_b, user_b, legal_name="Theirs")
+        db.add(_make_lease(
+            organization_id=org_b.id, user_id=user_b.id,
+            applicant_id=theirs.id,
+            starts_on=date(2026, 8, 1), ends_on=date(2026, 8, 20),
+        ))
+        await db.commit()
+
+        mine_rows = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id, **_WINDOW,
+        )
+        assert [r[3].legal_name for r in mine_rows] == ["Mine"]
+
+        their_rows = await calendar_repository.query_lease_events(
+            db, organization_id=org_b.id, **_WINDOW,
+        )
+        assert [r[3].legal_name for r in their_rows] == ["Theirs"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", ["draft", "generated", "sent", "terminated"])
+    async def test_non_occupying_statuses_are_excluded(
+        self, db: AsyncSession, test_user: User, test_org: Organization, status: str,
+    ) -> None:
+        applicant = await _seed_applicant(db, test_org, test_user, legal_name="T")
+        db.add(_make_lease(
+            organization_id=test_org.id, user_id=test_user.id,
+            applicant_id=applicant.id, status=status,
+            starts_on=date(2026, 8, 1), ends_on=date(2026, 8, 20),
+        ))
+        await db.commit()
+
+        rows = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id, **_WINDOW,
+        )
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_soft_deleted_lease_is_excluded(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        applicant = await _seed_applicant(db, test_org, test_user, legal_name="T")
+        db.add(_make_lease(
+            organization_id=test_org.id, user_id=test_user.id,
+            applicant_id=applicant.id,
+            starts_on=date(2026, 8, 1), ends_on=date(2026, 8, 20),
+            deleted_at=datetime.now(timezone.utc),
+        ))
+        await db.commit()
+
+        rows = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id, **_WINDOW,
+        )
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_lease_missing_a_date_bound_is_excluded(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """No extent, nothing to draw — even though the lease is otherwise valid."""
+        applicant = await _seed_applicant(db, test_org, test_user, legal_name="T")
+        db.add(_make_lease(
+            organization_id=test_org.id, user_id=test_user.id,
+            applicant_id=applicant.id,
+            starts_on=date(2026, 8, 1), ends_on=None,
+        ))
+        await db.commit()
+
+        rows = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id, **_WINDOW,
+        )
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_lease_ending_the_day_before_the_window_is_excluded(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """``ends_on`` is INCLUSIVE for a lease: Aug 9 is in an Aug-9 window
+        but not in an Aug-10 one."""
+        applicant = await _seed_applicant(
+            db, test_org, test_user, legal_name="Prince Kapoor",
+        )
+        db.add(_make_lease(
+            organization_id=test_org.id, user_id=test_user.id,
+            applicant_id=applicant.id,
+            starts_on=date(2026, 5, 30), ends_on=date(2026, 8, 9),
+        ))
+        await db.commit()
+
+        covered = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id,
+            from_=date(2026, 8, 9), to=date(2026, 9, 1),
+        )
+        assert len(covered) == 1
+
+        after = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id,
+            from_=date(2026, 8, 10), to=date(2026, 9, 1),
+        )
+        assert after == []
+
+    @pytest.mark.asyncio
+    async def test_narrowing_by_property_drops_unlinked_leases(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Asking for one property's occupancy must not answer with a lease
+        that belongs to no property."""
+        prop = await _seed_property(db, test_org, test_user, name="6734 Peerless")
+        listing = _make_listing(
+            organization_id=test_org.id, user_id=test_user.id, property_id=prop.id,
+        )
+        db.add(listing)
+        await db.flush()
+        linked = await _seed_applicant(db, test_org, test_user, legal_name="Sonu King")
+        unlinked = await _seed_applicant(db, test_org, test_user, legal_name="Andrew Le")
+        db.add_all([
+            _make_lease(
+                organization_id=test_org.id, user_id=test_user.id,
+                applicant_id=linked.id, listing_id=listing.id,
+                starts_on=date(2026, 8, 1), ends_on=date(2026, 8, 20),
+            ),
+            _make_lease(
+                organization_id=test_org.id, user_id=test_user.id,
+                applicant_id=unlinked.id,
+                starts_on=date(2026, 8, 1), ends_on=date(2026, 8, 20),
+            ),
+        ])
+        await db.commit()
+
+        by_property = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id, property_ids=[prop.id], **_WINDOW,
+        )
+        assert [r[3].legal_name for r in by_property] == ["Sonu King"]
+
+        by_listing = await calendar_repository.query_lease_events(
+            db, organization_id=test_org.id, listing_ids=[listing.id], **_WINDOW,
+        )
+        assert [r[3].legal_name for r in by_listing] == ["Sonu King"]

--- a/apps/mybookkeeper/backend/tests/test_calendar_service.py
+++ b/apps/mybookkeeper/backend/tests/test_calendar_service.py
@@ -128,6 +128,18 @@ def _lease_row(listing_title: str, starts_on: date, ends_on: date, name: str):
     return lease, listing, prop, SimpleNamespace(legal_name=name)
 
 
+def _unlinked_lease_row(starts_on: date, ends_on: date, name: str):
+    """A lease the host never attached to a listing.
+
+    ``signed_leases.listing_id`` is nullable, so the repository's outer join
+    hands the service ``None`` in both the listing and property slots.
+    """
+    lease = SimpleNamespace(
+        id=uuid.uuid4(), starts_on=starts_on, ends_on=ends_on, updated_at=_NOW,
+    )
+    return lease, None, None, SimpleNamespace(legal_name=name)
+
+
 @asynccontextmanager
 async def _fake_session():
     yield AsyncMock()
@@ -208,3 +220,58 @@ class TestListEventsUnion:
             sources=["airbnb", LEASE_SOURCE],
         )
         assert query_events.await_args.kwargs["sources"] == ["airbnb"]
+
+
+class TestListEventsWithUnlinkedLeases:
+    """A tenancy with no listing must reach the response, not vanish."""
+
+    @pytest.mark.asyncio
+    async def test_a_lease_with_no_listing_is_returned(self) -> None:
+        events, _, _ = await _list_events(
+            blackouts=[],
+            leases=[
+                _unlinked_lease_row(
+                    date(2026, 8, 26), date(2026, 10, 3), "Mohammed Awamleh",
+                ),
+            ],
+        )
+        assert len(events) == 1
+        assert events[0].summary == "Mohammed Awamleh"
+        assert events[0].listing_id is None
+        assert events[0].listing_name is None
+        assert events[0].property_id is None
+        assert events[0].property_name is None
+        # The end-date convention still applies to an unlinked lease.
+        assert events[0].ends_on == date(2026, 10, 4)
+
+    @pytest.mark.asyncio
+    async def test_unlinked_leases_sort_after_everything_with_a_listing(self) -> None:
+        events, _, _ = await _list_events(
+            blackouts=[_blackout_row("Z room", date(2026, 8, 20), date(2026, 8, 25))],
+            leases=[
+                _unlinked_lease_row(date(2026, 8, 1), date(2026, 8, 9), "Andrew Le"),
+                _lease_row("A room", date(2026, 8, 3), date(2026, 8, 9), "Sonu King"),
+            ],
+        )
+        assert [e.summary for e in events] == ["Sonu King", None, "Andrew Le"]
+        assert events[-1].listing_name is None
+
+    @pytest.mark.asyncio
+    async def test_mixed_linked_and_unlinked_leases_all_survive(self) -> None:
+        """The regression this class exists for: 4 leases in, 4 leases out."""
+        events, _, _ = await _list_events(
+            blackouts=[],
+            leases=[
+                _lease_row("A room", date(2026, 5, 3), date(2026, 11, 10), "Sonu King"),
+                _lease_row("A room", date(2026, 5, 30), date(2026, 8, 9), "Prince Kapoor"),
+                _unlinked_lease_row(date(2026, 8, 26), date(2026, 10, 3), "Mohammed Awamleh"),
+                _unlinked_lease_row(date(2026, 5, 30), date(2026, 8, 9), "Andrew Le"),
+            ],
+        )
+        assert len(events) == 4
+        assert sorted(e.summary for e in events) == [
+            "Andrew Le",
+            "Mohammed Awamleh",
+            "Prince Kapoor",
+            "Sonu King",
+        ]

--- a/apps/mybookkeeper/frontend/e2e/calendar-lease-events.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/calendar-lease-events.spec.ts
@@ -173,36 +173,8 @@ test.describe("Tenant leases on the calendar", () => {
       await deleteProperty(api, property.id);
     }
   });
-
-  test("a lease with no listing assigned stays off the grid", async ({ authedPage: page, api }) => {
-    // `signed_leases.listing_id` is nullable and is the only property linkage
-    // a lease carries, so an unassigned lease has no row to sit on. Pinning
-    // this stops a future "just LEFT JOIN it" change from inventing a
-    // placement the data cannot support.
-    const runId = Date.now();
-    const tenantName = `E2E Unassigned Tenant ${runId}`;
-    const applicantId = await seedApplicant(api, tenantName);
-    const res = await api.post("/test/seed-signed-lease", {
-      data: {
-        applicant_id: applicantId,
-        kind: "imported",
-        status: "signed",
-        starts_on: LEASE_STARTS_ON,
-        ends_on: LEASE_ENDS_ON,
-      },
-    });
-    const { id: leaseId } = (await res.json()) as { id: string };
-
-    try {
-      await page.goto(`/calendar?from=${FROM_ISO}&to=${TO_ISO}`);
-      await page.waitForLoadState("networkidle");
-      await expect(page.getByRole("heading", { name: "Calendar" })).toBeVisible();
-      await expect(
-        page.getByTestId("calendar-event-bar").filter({ hasText: tenantName }),
-      ).toHaveCount(0);
-    } finally {
-      await api.delete(`/test/signed-leases/${leaseId}`).catch(() => {});
-      await api.delete(`/test/applicants/${applicantId}`).catch(() => {});
-    }
-  });
 });
+
+// A lease with no `listing_id` used to be dropped from the calendar entirely.
+// That behaviour is now a bug, not a contract — see
+// `calendar-unlinked-lease.spec.ts` for the replacement coverage.

--- a/apps/mybookkeeper/frontend/e2e/calendar-unlinked-lease.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/calendar-unlinked-lease.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * E2E for tenancies the host never linked to a listing.
+ *
+ * `signed_leases.listing_id` is nullable (`ondelete="SET NULL"`), and the
+ * calendar's lease query used to INNER JOIN `listings`. Every unlinked lease
+ * was therefore dropped from the response with no error and no empty state —
+ * the host saw a calendar missing tenants they knew they had. Two of the
+ * operator's four real leases were invisible for exactly this reason.
+ *
+ * The query is now an outer join scoped on `signed_leases.organization_id`,
+ * and unlinked tenancies collect into their own row at the end of the grid.
+ * This spec walks the whole flow:
+ *
+ * 1. Seed a linked lease and an unlinked lease in the same window
+ * 2. Both bars render — the unlinked one is not silently swallowed
+ * 3. The unlinked tenancy sits on its own row, labelled as a gap to fill,
+ *    below every row that does have a listing
+ * 4. Its detail dialog opens and names the missing link instead of printing
+ *    "null · null"
+ * 5. Narrowing to a specific property still excludes it — the host asked for
+ *    one property's occupancy and an unlinked lease is not part of that
+ * 6. Cleanup
+ */
+
+const FROM_ISO = "2026-09-01";
+const TO_ISO = "2026-10-01";
+const LEASE_STARTS_ON = "2026-09-03";
+// Inclusive — the tenant's last day.
+const LEASE_ENDS_ON = "2026-09-20";
+
+const UNASSIGNED_LISTING_LABEL = "No listing linked";
+const UNASSIGNED_PROPERTY_LABEL = "Not linked to a property";
+
+async function seedListing(
+  api: APIRequestContext,
+  propertyId: string,
+  title: string,
+): Promise<string> {
+  const res = await api.post("/test/seed-listing", {
+    data: { property_id: propertyId, title, status: "active" },
+  });
+  if (!res.ok()) throw new Error(`seedListing failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function seedApplicant(api: APIRequestContext, legalName: string): Promise<string> {
+  const res = await api.post("/test/seed-applicant", {
+    data: { legal_name: legalName, stage: "lead" },
+  });
+  if (!res.ok()) throw new Error(`seedApplicant failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+/** `listingId === null` seeds the case this spec exists for. */
+async function seedLease(
+  api: APIRequestContext,
+  applicantId: string,
+  listingId: string | null,
+): Promise<string> {
+  const res = await api.post("/test/seed-signed-lease", {
+    data: {
+      applicant_id: applicantId,
+      listing_id: listingId,
+      kind: "generated",
+      status: "signed",
+      starts_on: LEASE_STARTS_ON,
+      ends_on: LEASE_ENDS_ON,
+    },
+  });
+  if (!res.ok()) throw new Error(`seedLease failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+test.describe("Tenancies with no listing linked", () => {
+  test("an unlinked lease reaches the calendar on its own row and opens", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const linkedTenant = `E2E Linked Tenant ${runId}`;
+    const unlinkedTenant = `E2E Unlinked Tenant ${runId}`;
+
+    const property = await createProperty(api, { name: `E2E Unlinked Lease ${runId}` });
+    const listingId = await seedListing(api, property.id, `E2E Unlinked Listing ${runId}`);
+    const linkedApplicantId = await seedApplicant(api, linkedTenant);
+    const unlinkedApplicantId = await seedApplicant(api, unlinkedTenant);
+    const linkedLeaseId = await seedLease(api, linkedApplicantId, listingId);
+    const unlinkedLeaseId = await seedLease(api, unlinkedApplicantId, null);
+
+    try {
+      // The API is the layer the bug lived in — assert it before the DOM so a
+      // failure points at the repository rather than at rendering.
+      const res = await api.get(
+        `/calendar/events?from=${FROM_ISO}&to=${TO_ISO}&sources=lease`,
+      );
+      expect(res.ok()).toBe(true);
+      const events = (await res.json()) as {
+        id: string;
+        summary: string | null;
+        listing_id: string | null;
+      }[];
+      const unlinkedEvent = events.find((e) => e.summary === unlinkedTenant);
+      expect(unlinkedEvent, "the unlinked tenancy must survive the query").toBeDefined();
+      expect(unlinkedEvent?.listing_id).toBeNull();
+
+      await page.goto(`/calendar?from=${FROM_ISO}&to=${TO_ISO}`);
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByRole("heading", { name: "Calendar" })).toBeVisible();
+
+      // Both tenancies draw. The unlinked one is the regression.
+      const linkedBar = page
+        .getByTestId("calendar-event-bar")
+        .filter({ hasText: linkedTenant });
+      const unlinkedBar = page
+        .getByTestId("calendar-event-bar")
+        .filter({ hasText: unlinkedTenant });
+      await expect(linkedBar).toHaveCount(1);
+      await expect(unlinkedBar).toHaveCount(1);
+      // Inclusive lease end → exclusive event end, same as a linked lease.
+      await expect(unlinkedBar).toHaveAttribute(
+        "aria-label",
+        new RegExp(`${unlinkedTenant} tenancy from ${LEASE_STARTS_ON} to 2026-09-21`),
+      );
+
+      // It sits on the unassigned row, labelled as a gap rather than a room.
+      const unassignedRow = page.locator(
+        '[data-testid="calendar-listing-row"][data-unassigned="true"]',
+      );
+      await expect(unassignedRow).toHaveCount(1);
+      await expect(unassignedRow).toContainText(UNASSIGNED_LISTING_LABEL);
+      await expect(unassignedRow).toContainText(UNASSIGNED_PROPERTY_LABEL);
+      await expect(unassignedRow.getByText(unlinkedTenant)).toBeVisible();
+
+      // ...and below everything that does have a listing, so the grid still
+      // reads property-first.
+      const rowIds = await page
+        .getByTestId("calendar-listing-row")
+        .evaluateAll((rows) =>
+          rows.map((row) => (row as HTMLElement).dataset.listingId ?? ""),
+        );
+      expect(rowIds.indexOf("unassigned")).toBe(rowIds.length - 1);
+      expect(rowIds.indexOf(listingId)).toBeLessThan(rowIds.indexOf("unassigned"));
+
+      // Detail dialog names the missing link instead of rendering "null · null".
+      await unlinkedBar.click();
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByText(unlinkedTenant)).toBeVisible();
+      await expect(dialog.getByText(UNASSIGNED_LISTING_LABEL)).toBeVisible();
+      await expect(dialog.getByRole("link", { name: /open the lease/i })).toHaveAttribute(
+        "href",
+        `/leases/${unlinkedLeaseId}`,
+      );
+      await page.keyboard.press("Escape");
+      await expect(dialog).toBeHidden();
+
+      // Narrowing to the property answers "this property's occupancy", which
+      // an unlinked lease is not part of. The linked tenancy survives.
+      await page.goto(
+        `/calendar?from=${FROM_ISO}&to=${TO_ISO}&properties=${property.id}`,
+      );
+      await page.waitForLoadState("networkidle");
+      await expect(
+        page.getByTestId("calendar-event-bar").filter({ hasText: linkedTenant }),
+      ).toHaveCount(1);
+      await expect(
+        page.getByTestId("calendar-event-bar").filter({ hasText: unlinkedTenant }),
+      ).toHaveCount(0);
+      await expect(
+        page.locator('[data-testid="calendar-listing-row"][data-unassigned="true"]'),
+      ).toHaveCount(0);
+    } finally {
+      await api.delete(`/test/signed-leases/${unlinkedLeaseId}`).catch(() => {});
+      await api.delete(`/test/signed-leases/${linkedLeaseId}`).catch(() => {});
+      await api.delete(`/test/applicants/${unlinkedApplicantId}`).catch(() => {});
+      await api.delete(`/test/applicants/${linkedApplicantId}`).catch(() => {});
+      await api.delete(`/test/listings/${listingId}`).catch(() => {});
+      await deleteProperty(api, property.id);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/Calendar.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/Calendar.test.tsx
@@ -224,6 +224,20 @@ describe("Calendar page", () => {
     expect(screen.getByRole("link", { name: /add a listing/i })).toHaveAttribute("href", "/listings");
   });
 
+  it("shows the events, not the no-listings prompt, when a lease has no listing behind it", () => {
+    // A signed lease can exist before it's linked to a listing, so an org with
+    // zero listings can still have real tenancies. Showing "add a listing"
+    // here would hide them.
+    vi.mocked(useGetListingsQuery).mockReturnValue(
+      { data: { items: [], total: 0, has_more: false }, isLoading: false } as unknown as ReturnType<
+        typeof useGetListingsQuery
+      >,
+    );
+    renderCalendar();
+    expect(screen.queryByTestId("calendar-no-listings")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("calendar-event-bar").length).toBeGreaterThan(0);
+  });
+
   it("displays last-synced relative time when events exist", () => {
     renderCalendar();
     const lastSynced = screen.getByTestId("calendar-last-synced");

--- a/apps/mybookkeeper/frontend/src/__tests__/CalendarUnlinkedLease.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/CalendarUnlinkedLease.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for tenancies the host hasn't linked to a listing.
+ *
+ * `signed_leases.listing_id` is nullable, so a real tenancy can arrive with no
+ * listing and no property. The calendar used to inner-join those away, which
+ * meant a lease simply never appeared and nothing said why. These tests pin
+ * that every surface renders it — timeline row, mobile agenda, detail dialog —
+ * and names the missing link instead of showing a blank.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { configureStore } from "@reduxjs/toolkit";
+import { baseApi } from "@/shared/store/baseApi";
+import CalendarGrid from "@/app/features/calendar/CalendarGrid";
+import CalendarAgendaList from "@/app/features/calendar/CalendarAgendaList";
+import CalendarEventDetail from "@/app/features/calendar/CalendarEventDetail";
+import {
+  CALENDAR_UNASSIGNED_LISTING_LABEL,
+  CALENDAR_UNASSIGNED_PROPERTY_LABEL,
+} from "@/shared/lib/calendar-constants";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+
+function makeLinkedLease(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "lease-linked",
+    listing_id: "listing-1",
+    listing_name: "Private suite",
+    property_id: "prop-1",
+    property_name: "6734 Peerless St",
+    starts_on: "2026-08-03",
+    ends_on: "2026-08-20",
+    source: "lease",
+    source_event_id: null,
+    summary: "Sonu King",
+    host_notes: null,
+    attachment_count: 0,
+    updated_at: "2026-08-01T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeUnlinkedLease(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return makeLinkedLease({
+    id: "lease-unlinked",
+    listing_id: null,
+    listing_name: null,
+    property_id: null,
+    property_name: null,
+    summary: "Mohammed Awamleh",
+    ...overrides,
+  });
+}
+
+function renderWithProviders(ui: React.ReactElement) {
+  const store = configureStore({
+    reducer: { [baseApi.reducerPath]: baseApi.reducer },
+    middleware: (getDefault) => getDefault().concat(baseApi.middleware),
+  });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("timeline grid", () => {
+  it("renders a row for a lease with no listing", () => {
+    renderWithProviders(
+      <CalendarGrid
+        events={[makeUnlinkedLease()]}
+        fromIso="2026-08-01"
+        toIso="2026-09-01"
+      />,
+    );
+
+    const rows = screen.getAllByTestId("calendar-listing-row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute("data-unassigned", "true");
+    expect(screen.getAllByText(CALENDAR_UNASSIGNED_LISTING_LABEL).length).toBeGreaterThan(0);
+  });
+
+  it("keeps the unlinked row separate from a linked one, and last", () => {
+    renderWithProviders(
+      <CalendarGrid
+        events={[makeUnlinkedLease(), makeLinkedLease()]}
+        fromIso="2026-08-01"
+        toIso="2026-09-01"
+      />,
+    );
+
+    const rows = screen.getAllByTestId("calendar-listing-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).not.toHaveAttribute("data-unassigned");
+    expect(rows[1]).toHaveAttribute("data-unassigned", "true");
+
+    const headers = screen.getAllByTestId("calendar-property-header");
+    expect(headers.map((h) => h.textContent)).toEqual([
+      "6734 Peerless St",
+      CALENDAR_UNASSIGNED_PROPERTY_LABEL,
+    ]);
+  });
+
+  it("still draws the event bar for an unlinked lease", () => {
+    renderWithProviders(
+      <CalendarGrid
+        events={[makeUnlinkedLease()]}
+        fromIso="2026-08-01"
+        toIso="2026-09-01"
+      />,
+    );
+
+    const bars = screen.getAllByTestId("calendar-event-bar");
+    expect(bars).toHaveLength(1);
+    expect(bars[0]).toHaveTextContent("Mohammed Awamleh");
+  });
+});
+
+describe("mobile agenda", () => {
+  it("leads with the tenant name and names the missing link", () => {
+    renderWithProviders(<CalendarAgendaList events={[makeUnlinkedLease()]} />);
+
+    const row = screen.getByTestId("calendar-agenda-event");
+    expect(row).toHaveTextContent("Mohammed Awamleh");
+    expect(row).toHaveTextContent(CALENDAR_UNASSIGNED_LISTING_LABEL);
+  });
+
+  it("still shows a channel booking by its listing", () => {
+    const channel = makeLinkedLease({
+      id: "blackout-1",
+      source: "airbnb",
+      summary: null,
+      source_event_id: "uid-1",
+    });
+    renderWithProviders(<CalendarAgendaList events={[channel]} />);
+
+    const row = screen.getByTestId("calendar-agenda-event");
+    expect(row).toHaveTextContent("Private suite");
+    expect(row).toHaveTextContent("6734 Peerless St");
+    expect(row).toHaveTextContent("Airbnb");
+  });
+});
+
+describe("detail dialog", () => {
+  it("names the missing link instead of rendering a bare separator", () => {
+    renderWithProviders(
+      <CalendarEventDetail event={makeUnlinkedLease()} onClose={() => {}} />,
+    );
+
+    expect(screen.getByText(CALENDAR_UNASSIGNED_LISTING_LABEL)).toBeInTheDocument();
+    expect(screen.getByText("Mohammed Awamleh")).toBeInTheDocument();
+  });
+
+  it("keeps listing · property for a linked lease", () => {
+    renderWithProviders(
+      <CalendarEventDetail event={makeLinkedLease()} onClose={() => {}} />,
+    );
+
+    expect(screen.getByText("Private suite · 6734 Peerless St")).toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/calendar-utils.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/calendar-utils.test.ts
@@ -35,6 +35,21 @@ function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
   };
 }
 
+/** A signed lease the host never linked to a listing — the calendar's only
+ * source of null listing/property fields. */
+function unlinkedLease(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return makeEvent({
+    source: "lease",
+    listing_id: null,
+    listing_name: null,
+    property_id: null,
+    property_name: null,
+    source_event_id: null,
+    summary: "Mohammed Awamleh",
+    ...overrides,
+  });
+}
+
 describe("parseIsoDate / formatIsoDate", () => {
   it("parses ISO date as UTC midnight", () => {
     const d = parseIsoDate("2026-06-05");
@@ -127,6 +142,31 @@ describe("groupByListing", () => {
   it("handles empty input", () => {
     expect(groupByListing([])).toEqual([]);
   });
+
+  it("collects every listing-less lease into one row", () => {
+    const events: CalendarEvent[] = [
+      unlinkedLease({ id: "1", summary: "Mohammed Awamleh" }),
+      unlinkedLease({ id: "2", summary: "Andrew Le" }),
+    ];
+    const rows = groupByListing(events);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].listing_id).toBeNull();
+    expect(rows[0].events.map((e) => e.summary)).toEqual([
+      "Mohammed Awamleh",
+      "Andrew Le",
+    ]);
+  });
+
+  it("keeps a listing-less row separate from a listed one and sorts it last", () => {
+    const events: CalendarEvent[] = [
+      unlinkedLease({ id: "1" }),
+      makeEvent({ id: "2", listing_id: "L1", listing_name: "A Room", property_name: "House A" }),
+    ];
+    const rows = groupByListing(events);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].listing_name).toBe("A Room");
+    expect(rows[1].listing_id).toBeNull();
+  });
 });
 
 describe("groupByProperty", () => {
@@ -140,6 +180,18 @@ describe("groupByProperty", () => {
     const groups = groupByProperty(rows);
     expect(groups).toHaveLength(2);
     expect(groups[0].rows).toHaveLength(2);
+    expect(groups[1].rows).toHaveLength(1);
+  });
+
+  it("puts listing-less rows in their own trailing group", () => {
+    const events: CalendarEvent[] = [
+      makeEvent({ id: "1", listing_id: "L1", property_id: "P1", property_name: "A" }),
+      unlinkedLease({ id: "2" }),
+    ];
+    const groups = groupByProperty(groupByListing(events));
+    expect(groups).toHaveLength(2);
+    expect(groups[0].property_name).toBe("A");
+    expect(groups[1].property_id).toBeNull();
     expect(groups[1].rows).toHaveLength(1);
   });
 });

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarAgendaEvent.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarAgendaEvent.tsx
@@ -1,0 +1,66 @@
+import {
+  CALENDAR_UNASSIGNED_LISTING_LABEL,
+  getSourceColor,
+  getSourceLabel,
+  isReadOnlySource,
+} from "@/shared/lib/calendar-constants";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+
+export interface CalendarAgendaEventProps {
+  event: CalendarEvent;
+  onSelect: (event: CalendarEvent) => void;
+}
+
+/**
+ * One tappable row in the mobile agenda.
+ *
+ * The headline answers "who or what is this", the sub-line answers "where and
+ * from which source". Those differ by kind: a channel booking carries no
+ * guest name over iCal, so its listing is the most identifying thing about
+ * it; a tenancy knows exactly who lives there, and the tenant's name is what
+ * the host is scanning for.
+ *
+ * A lease with no listing linked still renders — the tenancy is real whether
+ * or not the foreign key has been set — with the missing link named in the
+ * sub-line instead of silently blank.
+ */
+export default function CalendarAgendaEvent({ event, onSelect }: CalendarAgendaEventProps) {
+  const sourceLabel = getSourceLabel(event.source);
+  const isTenancy = isReadOnlySource(event.source);
+  const listingLabel = event.listing_name ?? CALENDAR_UNASSIGNED_LISTING_LABEL;
+
+  const headline = isTenancy ? (event.summary ?? sourceLabel) : listingLabel;
+  // A channel's headline is already its listing, so repeating it below would
+  // waste the line; a tenancy's headline is the tenant, so the listing goes
+  // here. `property_name` is null exactly when `listing_name` is.
+  const subLine = [
+    isTenancy ? listingLabel : null,
+    event.property_name,
+    sourceLabel,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(event)}
+      className="flex items-start gap-2 w-full text-left p-2 -m-2 rounded-md hover:bg-muted transition-colors min-h-[44px]"
+      data-testid="calendar-agenda-event"
+      aria-label={`${headline}, ${sourceLabel} booking. Click for details.`}
+    >
+      <span
+        className="inline-block h-3 w-3 rounded-sm mt-1 shrink-0"
+        style={{ backgroundColor: getSourceColor(event.source) }}
+        aria-hidden="true"
+      />
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium truncate">{headline}</div>
+        <div className="text-xs text-muted-foreground truncate">{subLine}</div>
+        <div className="text-xs text-muted-foreground">
+          {event.starts_on} → {event.ends_on}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarAgendaList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarAgendaList.tsx
@@ -1,10 +1,7 @@
 import { useState } from "react";
-import {
-  getSourceColor,
-  getSourceLabel,
-} from "@/shared/lib/calendar-constants";
 import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
 import CalendarEventDetail from "@/app/features/calendar/CalendarEventDetail";
+import CalendarAgendaEvent from "@/app/features/calendar/CalendarAgendaEvent";
 
 export interface CalendarAgendaListProps {
   events: readonly CalendarEvent[];
@@ -53,30 +50,7 @@ export default function CalendarAgendaList({ events }: CalendarAgendaListProps) 
             <ul className="space-y-2">
               {dayEvents.map((event) => (
                 <li key={event.id} data-source={event.source}>
-                  <button
-                    type="button"
-                    onClick={() => setSelectedEvent(event)}
-                    className="flex items-start gap-2 w-full text-left p-2 -m-2 rounded-md hover:bg-muted transition-colors min-h-[44px]"
-                    data-testid="calendar-agenda-event"
-                    aria-label={`${event.listing_name}, ${getSourceLabel(event.source)} booking. Click for details.`}
-                  >
-                    <span
-                      className="inline-block h-3 w-3 rounded-sm mt-1 shrink-0"
-                      style={{ backgroundColor: getSourceColor(event.source) }}
-                      aria-hidden="true"
-                    />
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium truncate">
-                        {event.listing_name}
-                      </div>
-                      <div className="text-xs text-muted-foreground truncate">
-                        {event.property_name} · {getSourceLabel(event.source)}
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        {event.starts_on} → {event.ends_on}
-                      </div>
-                    </div>
-                  </button>
+                  <CalendarAgendaEvent event={event} onSelect={setSelectedEvent} />
                 </li>
               ))}
             </ul>

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventDetailBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventDetailBody.tsx
@@ -5,6 +5,7 @@ import {
   relativeTime,
 } from "@/app/features/calendar/calendar-utils";
 import {
+  CALENDAR_UNASSIGNED_LISTING_LABEL,
   getSourceColor,
   getSourceLabel,
   isReadOnlySource,
@@ -37,6 +38,12 @@ export default function CalendarEventDetailBody({ event }: CalendarEventDetailBo
   // Channels that send no guest name get a nudge to record it in the notes.
   // Leases always carry a tenant name and have no notes field here.
   const showChannelHint = !event.summary && !readOnly;
+  // An unlinked lease has neither name to show. Say so plainly rather than
+  // rendering a bare separator between two blanks.
+  const locationLabel =
+    event.listing_name === null
+      ? CALENDAR_UNASSIGNED_LISTING_LABEL
+      : `${event.listing_name} · ${event.property_name}`;
 
   return (
     <div className="space-y-5">
@@ -52,7 +59,7 @@ export default function CalendarEventDetailBody({ event }: CalendarEventDetailBo
             {event.summary ?? `${sourceLabel} booking`}
           </Dialog.Title>
           <Dialog.Description className="text-sm text-muted-foreground">
-            {event.listing_name} · {event.property_name}
+            {locationLabel}
           </Dialog.Description>
         </div>
       </div>

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarGrid.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarGrid.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import {
   CALENDAR_DAY_CELL_PX,
   CALENDAR_LABEL_COLUMN_PX,
+  CALENDAR_UNASSIGNED_KEY,
+  CALENDAR_UNASSIGNED_PROPERTY_LABEL,
 } from "@/shared/lib/calendar-constants";
 import {
   daysBetween,
@@ -48,18 +50,18 @@ export default function CalendarGrid({ events, fromIso, toIso }: CalendarGridPro
         <div style={{ minWidth: totalGridWidth }}>
           <CalendarGridHeader fromIso={fromIso} totalDays={totalDays} />
           {groups.map((group) => (
-            <div key={group.property_id}>
+            <div key={group.property_id ?? CALENDAR_UNASSIGNED_KEY}>
               {/* Property header row — visually distinct so multiple properties
                   are obvious without a tree-collapse interaction (kept simple). */}
               <div
                 className="flex bg-muted/30 border-t text-xs font-semibold text-muted-foreground uppercase tracking-wide px-3 py-1.5"
                 data-testid="calendar-property-header"
               >
-                {group.property_name}
+                {group.property_name ?? CALENDAR_UNASSIGNED_PROPERTY_LABEL}
               </div>
               {group.rows.map((row) => (
                 <CalendarListingRow
-                  key={row.listing_id}
+                  key={row.listing_id ?? CALENDAR_UNASSIGNED_KEY}
                   row={row}
                   fromIso={fromIso}
                   toIso={toIso}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarListingRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarListingRow.tsx
@@ -2,6 +2,9 @@ import {
   CALENDAR_DAY_CELL_PX,
   CALENDAR_LABEL_COLUMN_PX,
   CALENDAR_ROW_HEIGHT_PX,
+  CALENDAR_UNASSIGNED_KEY,
+  CALENDAR_UNASSIGNED_LISTING_LABEL,
+  CALENDAR_UNASSIGNED_PROPERTY_LABEL,
 } from "@/shared/lib/calendar-constants";
 import {
   eventStartIndex,
@@ -26,6 +29,10 @@ export interface CalendarListingRowProps {
  * Property name is rendered as a small subtitle under the listing name
  * so the operator can disambiguate two rooms named the same way under
  * different properties without an explicit column.
+ *
+ * A row with no listing collects the leases the host hasn't linked yet. Its
+ * label is muted and italic so it reads as a gap to fill rather than as
+ * another room.
  */
 export default function CalendarListingRow({
   row,
@@ -34,25 +41,37 @@ export default function CalendarListingRow({
   totalDays,
   onEventClick,
 }: CalendarListingRowProps) {
+  const isUnassigned = row.listing_id === null;
+  const listingLabel = row.listing_name ?? CALENDAR_UNASSIGNED_LISTING_LABEL;
+  const propertyLabel = row.property_name ?? CALENDAR_UNASSIGNED_PROPERTY_LABEL;
+
   return (
     <div
       className="flex border-t"
       style={{ height: CALENDAR_ROW_HEIGHT_PX }}
       data-testid="calendar-listing-row"
-      data-listing-id={row.listing_id}
+      data-listing-id={row.listing_id ?? CALENDAR_UNASSIGNED_KEY}
+      data-unassigned={isUnassigned ? "true" : undefined}
     >
       <div
         className="px-3 py-2 border-r flex flex-col justify-center bg-card"
         style={{ width: CALENDAR_LABEL_COLUMN_PX }}
       >
-        <div className="text-sm font-medium truncate" title={row.listing_name}>
-          {row.listing_name}
+        <div
+          className={
+            isUnassigned
+              ? "text-sm font-medium italic text-muted-foreground truncate"
+              : "text-sm font-medium truncate"
+          }
+          title={listingLabel}
+        >
+          {listingLabel}
         </div>
         <div
           className="text-xs text-muted-foreground truncate"
-          title={row.property_name}
+          title={propertyLabel}
         >
-          {row.property_name}
+          {propertyLabel}
         </div>
       </div>
       <div

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/calendar-utils.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/calendar-utils.ts
@@ -1,3 +1,4 @@
+import { CALENDAR_UNASSIGNED_KEY } from "@/shared/lib/calendar-constants";
 import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
 
 /**
@@ -51,12 +52,18 @@ export function eventSpan(event: CalendarEvent, windowFromIso: string, windowToI
   return Math.max(1, daysBetween(startsClipped, endsClipped));
 }
 
-/** Listing → events map, indexed for grid rendering. */
+/**
+ * Listing → events map, indexed for grid rendering.
+ *
+ * `listing_id` / `property_id` are null for leases the host hasn't linked to
+ * a listing. Those collapse into a single trailing row so the tenancy is
+ * still visible; see `CALENDAR_UNASSIGNED_*` in `shared/lib/calendar-constants`.
+ */
 export interface ListingRow {
-  listing_id: string;
-  listing_name: string;
-  property_id: string;
-  property_name: string;
+  listing_id: string | null;
+  listing_name: string | null;
+  property_id: string | null;
+  property_name: string | null;
   events: CalendarEvent[];
 }
 
@@ -64,19 +71,20 @@ export interface ListingRow {
  * Group events into one row per listing, then group rows by property.
  *
  * Order matches the backend repository: by property name, then listing
- * name. The backend already orders this way; we re-derive in case the
- * frontend ever fans out to additional sources.
+ * name, with unassigned events last. The backend already orders this way;
+ * we re-derive in case the frontend ever fans out to additional sources.
  */
 export function groupByListing(events: readonly CalendarEvent[]): ListingRow[] {
   const byListingId = new Map<string, ListingRow>();
 
   for (const event of events) {
-    const existing = byListingId.get(event.listing_id);
+    const key = event.listing_id ?? CALENDAR_UNASSIGNED_KEY;
+    const existing = byListingId.get(key);
     if (existing) {
       existing.events.push(event);
       continue;
     }
-    byListingId.set(event.listing_id, {
+    byListingId.set(key, {
       listing_id: event.listing_id,
       listing_name: event.listing_name,
       property_id: event.property_id,
@@ -85,30 +93,44 @@ export function groupByListing(events: readonly CalendarEvent[]): ListingRow[] {
     });
   }
 
-  return Array.from(byListingId.values()).sort((a, b) => {
-    if (a.property_name !== b.property_name) {
-      return a.property_name.localeCompare(b.property_name);
-    }
-    return a.listing_name.localeCompare(b.listing_name);
-  });
+  return Array.from(byListingId.values()).sort(compareByPropertyThenListing);
+}
+
+/**
+ * Sort rows by property name, then listing name, with unassigned last.
+ *
+ * Null names can't go through `localeCompare`, and "sorts wherever the empty
+ * string lands" would put unassigned first — the opposite of what the
+ * backend's `NULLS LAST` promises. Rank the null-ness explicitly instead.
+ */
+function compareByPropertyThenListing(a: ListingRow, b: ListingRow): number {
+  const aUnassigned = a.property_name === null;
+  const bUnassigned = b.property_name === null;
+  if (aUnassigned !== bUnassigned) return aUnassigned ? 1 : -1;
+
+  const propertyOrder = (a.property_name ?? "").localeCompare(b.property_name ?? "");
+  if (propertyOrder !== 0) return propertyOrder;
+
+  return (a.listing_name ?? "").localeCompare(b.listing_name ?? "");
 }
 
 /** Group listing-rows by property for the collapsible header rendering. */
 export interface PropertyGroup {
-  property_id: string;
-  property_name: string;
+  property_id: string | null;
+  property_name: string | null;
   rows: ListingRow[];
 }
 
 export function groupByProperty(rows: readonly ListingRow[]): PropertyGroup[] {
   const groups = new Map<string, PropertyGroup>();
   for (const row of rows) {
-    const g = groups.get(row.property_id);
+    const key = row.property_id ?? CALENDAR_UNASSIGNED_KEY;
+    const g = groups.get(key);
     if (g) {
       g.rows.push(row);
       continue;
     }
-    groups.set(row.property_id, {
+    groups.set(key, {
       property_id: row.property_id,
       property_name: row.property_name,
       rows: [row],

--- a/apps/mybookkeeper/frontend/src/app/pages/Calendar.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Calendar.tsx
@@ -201,7 +201,10 @@ export default function Calendar() {
 
       {isLoading ? (
         <CalendarSkeleton />
-      ) : hasNoListings ? (
+      ) : hasNoListings && isEmpty ? (
+        // A tenancy can exist with no listing behind it, so "no listings" is
+        // only the right story when there's also nothing to show. Otherwise
+        // this prompt would hide the very events it claims don't exist.
         <div
           className="text-center text-muted-foreground text-sm py-8"
           data-testid="calendar-no-listings"

--- a/apps/mybookkeeper/frontend/src/shared/lib/calendar-constants.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/calendar-constants.ts
@@ -87,6 +87,23 @@ export function isReadOnlySource(source: string): boolean {
 }
 
 /**
+ * Labels for a lease the host hasn't linked to a listing yet.
+ *
+ * `signed_leases.listing_id` is nullable, so a tenancy can exist before it is
+ * attached to a listing. The calendar shows it regardless — a real tenant in
+ * a real room is not less real for a missing foreign key — under this
+ * heading, which doubles as a nudge to go set the link.
+ */
+export const CALENDAR_UNASSIGNED_LISTING_LABEL = "No listing linked";
+export const CALENDAR_UNASSIGNED_PROPERTY_LABEL = "Not linked to a property";
+
+/**
+ * Map key standing in for a null listing/property id when grouping. Real ids
+ * are UUIDs, so this can never collide with one.
+ */
+export const CALENDAR_UNASSIGNED_KEY = "unassigned";
+
+/**
  * Fallback color for unknown source slugs (e.g., a channel added on
  * the backend before the frontend is updated). Slightly lighter than
  * `direct` so it stands out as "I don't know what this is."

--- a/apps/mybookkeeper/frontend/src/shared/types/calendar/calendar-event.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/calendar/calendar-event.ts
@@ -9,13 +9,19 @@
  *
  * `ends_on` is EXCLUSIVE per iCal RFC 5545 — a single blocked day has
  * `ends_on = starts_on + 1`.
+ *
+ * The listing and property fields are nullable, and only a `lease` event can
+ * carry nulls: a blackout hangs off a listing by construction, whereas a
+ * signed lease may not have been linked to one yet. Render those under an
+ * "unassigned" heading — see `CALENDAR_UNASSIGNED_*` in
+ * `shared/lib/calendar-constants`.
  */
 export interface CalendarEvent {
   id: string;
-  listing_id: string;
-  listing_name: string;
-  property_id: string;
-  property_name: string;
+  listing_id: string | null;
+  listing_name: string | null;
+  property_id: string | null;
+  property_name: string | null;
   starts_on: string;
   ends_on: string;
   source: string;

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -434,12 +434,14 @@
         "calendar-utils.test.ts",
         "CalendarEventDetail.test.tsx",
         "CalendarLeaseEvent.test.tsx",
+        "CalendarUnlinkedLease.test.tsx",
         "ReviewQueueItem.test.tsx",
         "ReviewQueueDrawer.test.tsx"
       ],
       "e2e_specs": [
         "calendar.spec.ts",
         "calendar-lease-events.spec.ts",
+        "calendar-unlinked-lease.spec.ts",
         "calendar-booking-notes.spec.ts",
         "calendar-review-queue-resolve.spec.ts"
       ]


### PR DESCRIPTION
## The bug

The operator has four signed leases. The calendar showed two.

| Tenant | Dates | `listing_id` | On the calendar? |
|---|---|---|---|
| Sonu King | 2026-05-03 → 2026-11-10 | set | yes |
| Prince Kapoor | 2026-05-30 → 2026-08-09 | set | yes (outside the visible window) |
| Mohammed Awamleh | 2026-08-26 → 2026-10-03 | **NULL** | **no** |
| Andrew Le | 2026-05-30 → 2026-08-09 | **NULL** | **no** |

`signed_leases.listing_id` is nullable (`ForeignKey(..., ondelete="SET NULL")`), but `query_lease_events` INNER JOINed `listings` and scoped the query on `listings.organization_id`. Any tenancy the host never linked to a listing — or whose listing was later deleted — was dropped from the response with no error and no empty state.

## The fix

- `query_lease_events` outer joins `listings` (and `properties` through it) and scopes on `signed_leases.organization_id`, which the table carries precisely so an unassigned lease still belongs to a tenant.
- The listing soft-delete test moves into the `ON` clause, so a deleted listing yields `NULL` instead of dropping the lease.
- `listing_id`, `listing_name`, `property_id`, `property_name` are nullable on `CalendarEventResponse` and the matching TS type.
- Unlinked tenancies collect into one row at the end of the grid, labelled **"No listing linked" / "Not linked to a property"** in muted italics so it reads as a gap to fill rather than another room. The detail dialog names the missing link instead of rendering `null · null`.
- Property filtering still excludes them — a request for one property's occupancy is not answered by a lease belonging to no property.

## Why it went uncaught

PR #1056 added lease support to the calendar with no repository test for `query_lease_events`. Coverage is added here at every layer.

## Tests

- **Backend** — `test_calendar_repository.py` (new `TestCalendarRepoLeaseEvents`, 9 cases), `test_calendar_service.py` (new `TestListEventsWithUnlinkedLeases`, incl. a 4-leases-in / 4-events-out regression), `test_calendar_event_mapper.py`. **63 passed.**
- **Frontend** — new `CalendarUnlinkedLease.test.tsx`, extended `calendar-utils.test.ts`. All six calendar suites: **88 passed.**
- **E2E** — new `calendar-unlinked-lease.spec.ts` seeds a linked and an unlinked lease in the same window and asserts the API response, both bars, row ordering, the detail dialog, and property filtering.
- Reverting the repository to the old inner join fails 5 of the new repository cases.

The E2E in `calendar-lease-events.spec.ts` that pinned the old behaviour ("a lease with no listing assigned stays off the grid") is removed — the requirement changed, so that contract was wrong, not the code.

## Not in this PR

The calendar's month-grid redesign (Google-Calendar-style month view with a `[Month | Timeline]` toggle) is a separate follow-up, per one-feature-per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGrPnfsGueqXN6dVzHQpiw