### PR TITLE
fix(mybookkeeper): seed the 2026 electricity terms so renewal alerts stop lying

### DIFF
--- a/apps/mybookkeeper/backend/app/cli/peerless_utility_plan_seed.py
+++ b/apps/mybookkeeper/backend/app/cli/peerless_utility_plan_seed.py
@@ -1,32 +1,42 @@
 """Seed rows for the Peerless St portfolio's utility plans.
 
-Every figure here was transcribed from the provider's own email, not inferred:
+Two generations of electricity contract are seeded per property: the 2025 terms
+that have since lapsed, and the 2026 terms currently in force. The lapsed rows
+are kept deliberately — a superseded plan is the baseline a new offer gets
+measured against, and deleting it destroys the comparison the feature exists to
+make. The seeder's idempotency key includes ``service_start_date``, so the two
+generations coexist rather than one overwriting the other.
 
-* Constellation enrollment confirmations, 2025-01-23 — 6732 PEERLESS ST and
-  6734 PEERLESS ST (two separate messages, same plan and same rates).
-* Constellation "Residential Plan Change Notice", 2025-01-27 — 6738 PEERLESS
-  ST, account 204430810.
-* CenterPoint payment alerts — the only messages that print an account number
-  and its service address together: 6403771807-5 is 6734, 6403771834-9 is 6732.
+Sources, in order of authority:
 
-Two things are deliberately left NULL rather than guessed:
+* **The Constellation account portal, read 2026-08-10** — plan detail and billed
+  usage for all three accounts. This is the only source for the 2026 plans and
+  it supersedes the email-derived guesses below wherever they disagree.
+* Constellation enrollment confirmations, 2025-01-23 — 6732 and 6734.
+* Constellation "Residential Plan Change Notice", 2025-01-27 — 6738.
+* CenterPoint payment alerts — the only messages printing an account number and
+  its service address together: 6403771807-5 is 6734, 6403771834-9 is 6732.
 
-1. **The electric account numbers for 6732 and 6734.** Two Constellation
-   accounts (204865879, 204865622) appear on invoices, but no message binds
-   either to a street address, and the enrollment confirmations pre-date
-   account creation. Which is which is recorded in ``notes`` for the operator
-   to resolve from a bill; inventing the mapping would silently attach the
-   wrong account to a property.
-2. **6738's average price and early-termination fee.** The plan-change notice
-   states the term, the component rates, and the start date, but not those two
-   figures. They are almost certainly identical to the other two properties —
-   "almost certainly" is not a source.
+**The portal resolved the account mapping that email could not.** 204865879 is
+6732 and 204865622 is 6734, read off the Accounts page where each customer
+number sits beside its service address. Both 2025 rows previously carried NULL
+account numbers with the ambiguity recorded in ``notes``; they now carry the
+confirmed values.
 
-``term_end_date`` is start + ``term_months`` in every case. The enrollment
-emails say the exact contract end date arrives in the welcome package, which is
-not in the mailbox; the derived date is accurate to the day the term was sold
-and is what the renewal alert needs. All three electric terms have already
-lapsed, which is the point of seeding them.
+Still deliberately NULL rather than guessed:
+
+1. **Every 2026 component rate** (energy charge, TDU, monthly base). The portal
+   states a single blended "Average Rate" per plan and does not break it out.
+   The per-plan EFL does, and is linked from each plan-detail page.
+2. **Every early-termination fee.** Not shown in the portal's plan detail. The
+   2025 rows' $150 came from the enrollment emails; carrying that figure
+   forward onto a differently-named 2026 plan would be invention.
+3. **6738's 2025 average price.** Its plan-change notice never stated one, and
+   copying a sibling property's is not a source.
+
+``term_end_date`` on the 2025 rows is start + ``term_months``; the exact end
+date lived in a welcome package that is not in the mailbox. The 2026 rows use
+the portal's stated renewal date, which is authoritative.
 """
 from __future__ import annotations
 
@@ -57,11 +67,37 @@ _ETF_CENTS = 15_000
 _MIN_USAGE_FEE_CENTS = 0
 _MIN_USAGE_THRESHOLD_KWH = 999
 
-_UNKNOWN_ELECTRIC_ACCOUNT_NOTE = (
-    "Electric account number unresolved: Constellation accounts 204865879 and "
-    "204865622 both bill to this portfolio, but no email binds either to a "
-    "street address. Set it from a bill. Term end derived as start + 12 months "
-    "(the welcome package holds the exact contract end date)."
+_SUPERSEDED_2025_NOTE = (
+    "Superseded by the 2026-02-17 term; kept as the rate baseline a new offer "
+    "is measured against. Account number confirmed from the Constellation "
+    "portal 2026-08-10 (it was unresolved while only email was available). "
+    "Term end derived as start + 12 months."
+)
+
+# The 2026 terms, read from the Constellation account portal on 2026-08-10.
+# Every account renewed on the same day and every term ends on the same day.
+_TERM_2026_START = _dt.date(2026, 2, 17)
+_TERM_2026_END = _dt.date(2027, 2, 17)
+
+# The portal labels this "Average Rate ... per kWh" without stating the usage
+# tier it is averaged at. Texas EFLs quote average price at 500 / 1,000 / 2,000
+# kWh, so this is recorded in the at-1000 column as the closest true field —
+# but the tier is the portal's, not verified against the EFL. If the EFL shows
+# a different figure at 1,000 kWh, the EFL wins and these should be corrected.
+_AVG_RATE_2026_6732 = Decimal("15.0600")
+_AVG_RATE_2026_6734 = Decimal("15.6600")
+_AVG_RATE_2026_6738 = Decimal("16.2700")
+
+_PLAN_2026_NO_MIN_FEE = "12 Month (No Min Usage Fee)"
+_PLAN_2026_AC_PROTECT = "12 Month A/C Protect Plus for 2 Units"
+
+_TERM_2026_NOTE = (
+    "Current term. Read from the Constellation portal plan detail 2026-08-10: "
+    "plan name, fixed rate type, 12-month term, average rate, start and renewal "
+    "dates, status Enrolled. Component rates (energy / TDU / monthly base) and "
+    "the early-termination fee are NOT shown there — they are in the per-plan "
+    "EFL linked from the same page, and are left NULL rather than carried "
+    "forward from the 2025 contract."
 )
 
 PEERLESS_UTILITY_PLANS: tuple[UtilityPlanSeedRow, ...] = (
@@ -70,6 +106,7 @@ PEERLESS_UTILITY_PLANS: tuple[UtilityPlanSeedRow, ...] = (
         service_type=SERVICE_TYPE_ELECTRICITY,
         provider_name=_CONSTELLATION,
         rate_type=RATE_TYPE_FIXED,
+        account_number="204865879",
         plan_name=_CONSTELLATION_PLAN,
         energy_charge_cents_per_kwh=_ENERGY_CHARGE,
         tdu_charge_cents_per_kwh=_TDU_CHARGE,
@@ -81,13 +118,14 @@ PEERLESS_UTILITY_PLANS: tuple[UtilityPlanSeedRow, ...] = (
         early_termination_fee_cents=_ETF_CENTS,
         min_usage_fee_cents=_MIN_USAGE_FEE_CENTS,
         min_usage_threshold_kwh=_MIN_USAGE_THRESHOLD_KWH,
-        notes=_UNKNOWN_ELECTRIC_ACCOUNT_NOTE,
+        notes=_SUPERSEDED_2025_NOTE,
     ),
     UtilityPlanSeedRow(
         property_match="6734 Peerless",
         service_type=SERVICE_TYPE_ELECTRICITY,
         provider_name=_CONSTELLATION,
         rate_type=RATE_TYPE_FIXED,
+        account_number="204865622",
         plan_name=_CONSTELLATION_PLAN,
         energy_charge_cents_per_kwh=_ENERGY_CHARGE,
         tdu_charge_cents_per_kwh=_TDU_CHARGE,
@@ -99,7 +137,7 @@ PEERLESS_UTILITY_PLANS: tuple[UtilityPlanSeedRow, ...] = (
         early_termination_fee_cents=_ETF_CENTS,
         min_usage_fee_cents=_MIN_USAGE_FEE_CENTS,
         min_usage_threshold_kwh=_MIN_USAGE_THRESHOLD_KWH,
-        notes=_UNKNOWN_ELECTRIC_ACCOUNT_NOTE,
+        notes=_SUPERSEDED_2025_NOTE,
     ),
     UtilityPlanSeedRow(
         property_match="6738 Peerless",
@@ -115,10 +153,64 @@ PEERLESS_UTILITY_PLANS: tuple[UtilityPlanSeedRow, ...] = (
         service_start_date=_dt.date(2025, 1, 27),
         term_end_date=_dt.date(2026, 1, 27),
         notes=(
-            "From the 2025-01-27 plan-change notice, which does not state the "
-            "average price at 1,000 kWh or the early-termination fee — both "
-            "left blank rather than copied from the sibling properties. Term "
-            "end derived as start + 12 months."
+            "Superseded by the 2026-02-17 term; kept as the rate baseline a new "
+            "offer is measured against. From the 2025-01-27 plan-change notice, "
+            "which does not state the average price at 1,000 kWh or the "
+            "early-termination fee — both left blank rather than copied from "
+            "the sibling properties. Term end derived as start + 12 months."
+        ),
+    ),
+    # --- Current terms, all three enrolled 2026-02-17, renewing 2027-02-17. ---
+    # These are what the renewal alert should be measuring. Seeding only the
+    # 2025 rows left the app asserting every plan had lapsed in January 2026,
+    # which fired a false alert for six months.
+    UtilityPlanSeedRow(
+        property_match="6732 Peerless",
+        service_type=SERVICE_TYPE_ELECTRICITY,
+        provider_name=_CONSTELLATION,
+        rate_type=RATE_TYPE_FIXED,
+        account_number="204865879",
+        plan_name=_PLAN_2026_NO_MIN_FEE,
+        avg_price_cents_per_kwh_at_1000=_AVG_RATE_2026_6732,
+        term_months=12,
+        service_start_date=_TERM_2026_START,
+        term_end_date=_TERM_2026_END,
+        # The plan name itself is the source: this plan carries no minimum-usage
+        # fee, so there is no threshold for one to apply below.
+        min_usage_fee_cents=0,
+        notes=_TERM_2026_NOTE,
+    ),
+    UtilityPlanSeedRow(
+        property_match="6734 Peerless",
+        service_type=SERVICE_TYPE_ELECTRICITY,
+        provider_name=_CONSTELLATION,
+        rate_type=RATE_TYPE_FIXED,
+        account_number="204865622",
+        plan_name=_PLAN_2026_NO_MIN_FEE,
+        avg_price_cents_per_kwh_at_1000=_AVG_RATE_2026_6734,
+        term_months=12,
+        service_start_date=_TERM_2026_START,
+        term_end_date=_TERM_2026_END,
+        min_usage_fee_cents=0,
+        notes=_TERM_2026_NOTE,
+    ),
+    UtilityPlanSeedRow(
+        property_match="6738 Peerless",
+        service_type=SERVICE_TYPE_ELECTRICITY,
+        provider_name=_CONSTELLATION,
+        rate_type=RATE_TYPE_FIXED,
+        account_number="204430810",
+        plan_name=_PLAN_2026_AC_PROTECT,
+        avg_price_cents_per_kwh_at_1000=_AVG_RATE_2026_6738,
+        term_months=12,
+        service_start_date=_TERM_2026_START,
+        term_end_date=_TERM_2026_END,
+        # Unlike its siblings this plan's name makes no minimum-usage-fee claim,
+        # so the field stays NULL rather than assuming parity with them.
+        notes=(
+            _TERM_2026_NOTE + " This plan bundles an A/C protection service for "
+            "two units, which is why its average rate runs above the other two "
+            "properties for the same commodity."
         ),
     ),
     # Houston natural gas is a regulated monopoly: there is no competing

--- a/apps/mybookkeeper/backend/tests/test_utility_plan_seed.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_plan_seed.py
@@ -8,6 +8,7 @@ deliberately leaves unknown so a future edit cannot quietly invent them.
 """
 from __future__ import annotations
 
+import datetime as _dt
 import uuid
 from decimal import Decimal
 from types import SimpleNamespace
@@ -27,11 +28,47 @@ from app.core.utility_plan_constants import (
 )
 
 
-def _row(match: str, service_type: str) -> UtilityPlanSeedRow:
-    for row in PEERLESS_UTILITY_PLANS:
-        if row.property_match == match and row.service_type == service_type:
-            return row
-    raise AssertionError(f"no seed row for {match} / {service_type}")
+_TERM_2026_START = _dt.date(2026, 2, 17)
+_TERM_2026_END = _dt.date(2027, 2, 17)
+_TERM_2025_START = {
+    "6732 Peerless": _dt.date(2025, 1, 23),
+    "6734 Peerless": _dt.date(2025, 1, 23),
+    "6738 Peerless": _dt.date(2025, 1, 27),
+}
+
+
+def _row(
+    match: str,
+    service_type: str,
+    *,
+    start: _dt.date | None = None,
+) -> UtilityPlanSeedRow:
+    """The single seed row for a property + service, disambiguated by term.
+
+    Electricity now carries two generations per property, so a lookup that
+    ignores the start date would silently return whichever happens to be
+    declared first — exactly the kind of ambiguity these tests exist to catch.
+    """
+    candidates = [
+        row for row in PEERLESS_UTILITY_PLANS
+        if row.property_match == match
+        and row.service_type == service_type
+        and (start is None or row.service_start_date == start)
+    ]
+    if len(candidates) != 1:
+        raise AssertionError(
+            f"expected exactly one seed row for {match} / {service_type}"
+            f"{f' starting {start}' if start else ''}; got {len(candidates)}"
+        )
+    return candidates[0]
+
+
+def _row_2025(match: str) -> UtilityPlanSeedRow:
+    return _row(match, SERVICE_TYPE_ELECTRICITY, start=_TERM_2025_START[match])
+
+
+def _row_2026(match: str) -> UtilityPlanSeedRow:
+    return _row(match, SERVICE_TYPE_ELECTRICITY, start=_TERM_2026_START)
 
 
 class TestSeedRowsSatisfyTheSchema:
@@ -62,25 +99,35 @@ class TestSeedRowsSatisfyTheSchema:
 
 
 class TestElectricPlans:
-    def test_all_three_properties_have_a_lapsed_fixed_term(self) -> None:
+    _PROPERTIES = ("6732 Peerless", "6734 Peerless", "6738 Peerless")
+
+    def test_every_property_carries_both_a_lapsed_and_a_current_term(self) -> None:
+        """The superseded row is the baseline a new offer is measured against.
+
+        Seeding only the 2025 generation is what made the app assert every plan
+        had lapsed in January 2026 and fire a renewal alert for six months while
+        all three accounts were in fact under contract.
+        """
         electric = [r for r in PEERLESS_UTILITY_PLANS if r.service_type == SERVICE_TYPE_ELECTRICITY]
 
-        assert {r.property_match for r in electric} == {
-            "6732 Peerless", "6734 Peerless", "6738 Peerless",
-        }
-        for row in electric:
+        assert len(electric) == 6
+        for match in self._PROPERTIES:
+            assert _row_2025(match).term_end_date < _TERM_2026_START
+            assert _row_2026(match).term_end_date == _TERM_2026_END
+
+    @pytest.mark.parametrize("match", _PROPERTIES)
+    def test_every_electric_term_is_a_12_month_fixed_deal(self, match: str) -> None:
+        for row in (_row_2025(match), _row_2026(match)):
             assert row.rate_type == RATE_TYPE_FIXED
             assert row.term_months == 12
-            # Term end is start + 12 months; both dates are in the past, which
-            # is what makes the renewal alert fire the moment the seed lands.
             assert row.term_end_date is not None
             assert row.term_end_date.year == row.service_start_date.year + 1
             assert (row.term_end_date.month, row.term_end_date.day) == (
                 row.service_start_date.month, row.service_start_date.day,
             )
 
-    def test_rates_match_the_enrollment_emails(self) -> None:
-        row = _row("6734 Peerless", SERVICE_TYPE_ELECTRICITY)
+    def test_2025_rates_match_the_enrollment_emails(self) -> None:
+        row = _row_2025("6734 Peerless")
 
         assert row.energy_charge_cents_per_kwh == Decimal("11.6000")
         # Four decimal places — the reason the column is Numeric, not cents.
@@ -93,21 +140,50 @@ class TestElectricPlans:
         assert row.min_usage_fee_cents == 0
         assert row.min_usage_threshold_kwh == 999
 
-    def test_6738_leaves_unstated_figures_blank(self) -> None:
+    def test_6738_2025_leaves_unstated_figures_blank(self) -> None:
         """Its plan-change notice omits these; copying the siblings' would be invention."""
-        row = _row("6738 Peerless", SERVICE_TYPE_ELECTRICITY)
+        row = _row_2025("6738 Peerless")
 
         assert row.avg_price_cents_per_kwh_at_1000 is None
         assert row.early_termination_fee_cents is None
-        assert row.account_number == "204430810"
 
-    def test_the_two_unbound_accounts_are_left_null_and_documented(self) -> None:
-        """No email binds 204865879 / 204865622 to an address — don't guess."""
-        for match in ("6732 Peerless", "6734 Peerless"):
-            row = _row(match, SERVICE_TYPE_ELECTRICITY)
-            assert row.account_number is None
-            assert "204865879" in row.notes
-            assert "204865622" in row.notes
+    def test_every_account_number_is_the_one_the_portal_printed(self) -> None:
+        """Email never bound 204865879 / 204865622 to an address; the portal did.
+
+        Both generations carry the same number per property — they are the same
+        meter, so a mismatch between them would be a transcription error.
+        """
+        expected = {
+            "6732 Peerless": "204865879",
+            "6734 Peerless": "204865622",
+            "6738 Peerless": "204430810",
+        }
+        for match, account in expected.items():
+            assert _row_2025(match).account_number == account
+            assert _row_2026(match).account_number == account
+
+    def test_current_terms_record_the_portal_rate_and_nothing_it_did_not_state(self) -> None:
+        """Plan detail shows a blended average only — no components, no ETF."""
+        rates = {
+            "6732 Peerless": Decimal("15.0600"),
+            "6734 Peerless": Decimal("15.6600"),
+            "6738 Peerless": Decimal("16.2700"),
+        }
+        for match, rate in rates.items():
+            row = _row_2026(match)
+            assert row.avg_price_cents_per_kwh_at_1000 == rate
+            # Carrying 2025's components or ETF forward onto a differently
+            # named plan would be invention, not a transcription.
+            assert row.energy_charge_cents_per_kwh is None
+            assert row.tdu_charge_cents_per_kwh is None
+            assert row.monthly_base_charge_cents is None
+            assert row.early_termination_fee_cents is None
+
+    def test_only_the_plans_that_say_so_claim_no_minimum_usage_fee(self) -> None:
+        """The claim comes from the plan name; 6738's name makes no such claim."""
+        assert _row_2026("6732 Peerless").min_usage_fee_cents == 0
+        assert _row_2026("6734 Peerless").min_usage_fee_cents == 0
+        assert _row_2026("6738 Peerless").min_usage_fee_cents is None
 
 
 class TestGasPlans:
@@ -149,7 +225,7 @@ class TestPlanParams:
     def test_tenant_columns_come_from_the_matched_property(self) -> None:
         prop = self._prop()
 
-        params = _plan_params(_row("6734 Peerless", SERVICE_TYPE_ELECTRICITY), prop)
+        params = _plan_params(_row_2026("6734 Peerless"), prop)
 
         assert params["property_id"] == str(prop.id)
         assert params["user_id"] == str(prop.user_id)
@@ -163,11 +239,24 @@ class TestPlanParams:
         assert params["account_number"] == "64037718075"
 
     def test_a_missing_account_number_stays_null(self) -> None:
-        params = _plan_params(_row("6732 Peerless", SERVICE_TYPE_ELECTRICITY), self._prop())
+        """Every seeded row now has one, so this holds the behaviour directly.
+
+        Previously this leaned on 6732's electricity row being unbound; the
+        portal resolved it, and a test that silently stops exercising its own
+        subject is worse than no test.
+        """
+        row = UtilityPlanSeedRow(
+            property_match="6732 Peerless",
+            service_type=SERVICE_TYPE_ELECTRICITY,
+            provider_name="Constellation",
+            rate_type=RATE_TYPE_FIXED,
+        )
+
+        params = _plan_params(row, self._prop())
 
         assert params["account_number"] is None
 
     def test_rate_precision_is_passed_through_undamaged(self) -> None:
-        params = _plan_params(_row("6732 Peerless", SERVICE_TYPE_ELECTRICITY), self._prop())
+        params = _plan_params(_row_2025("6732 Peerless"), self._prop())
 
         assert params["tdu_charge_cents_per_kwh"] == Decimal("5.3509")


### PR DESCRIPTION
## What

The Peerless seed carried only the **2025** Constellation contracts, whose terms ended in January 2026. Since then MBK has asserted every electricity plan had lapsed and fired a renewal alert at a growing negative day count — while all three accounts were in fact re-enrolled on **2026-02-17** under 12-month fixed terms running to **2027-02-17**.

Read from the Constellation account portal on 2026-08-10:

| Property | Account | Plan | Avg rate |
|---|---|---|---|
| 6732 | 204865879 | 12 Month (No Min Usage Fee) | 15.06¢/kWh |
| 6734 | 204865622 | 12 Month (No Min Usage Fee) | 15.66¢/kWh |
| 6738 | 204430810 | 12 Month A/C Protect Plus for 2 Units | 16.27¢/kWh |

## Why keep the 2025 rows

A superseded plan is the baseline a new offer gets measured against — deleting it destroys the comparison the optimizer exists to make. The seeder's idempotency key already includes `service_start_date`, so both generations coexist without one clobbering the other.

## Also resolved

The portal bound two account numbers to addresses that email never could. 6732's and 6734's 2025 rows lose their NULL `account_number` and the note recording that ambiguity.

## Deliberately left NULL on the 2026 rows

Component rates (energy / TDU / monthly base) and the early-termination fee. Plan detail states one blended average and no ETF; those figures live in the per-plan EFL. Carrying 2025's $150 forward onto a differently-named plan would be invention, not transcription.

## Tests

`pytest tests -k utilit` — 190 passed.

Two assertions encoded the now-false facts (every term lapsed; two accounts unbound). Both are **replaced, not deleted**: each property is now asserted to carry both generations, and a lookup helper disambiguates by term so an ambiguous match fails loudly instead of silently returning whichever row was declared first.

## Operational follow-up

Not a breaking change — no env or config migration. To pick the new rows up locally:

```
python -m app.cli.migrate_data --dry-run seed-utility-plans
python -m app.cli.migrate_data seed-utility-plans
```

Existing rows are skipped; only the three 2026 rows insert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgX4F6Unf2PbXHwHAX2fVb