### PR TITLE
feat(mybookkeeper): Google-Calendar-style month view with a timeline toggle

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/calendar-booking-notes.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/calendar-booking-notes.spec.ts
@@ -74,7 +74,7 @@ test.describe("Calendar booking notes + attachments", () => {
 
     try {
       // Navigate to the calendar with the test window.
-      await page.goto("/calendar?from=2026-06-01&to=2026-07-01");
+      await page.goto("/calendar?from=2026-06-01&to=2026-07-01&view=timeline");
       await page.waitForLoadState("networkidle");
 
       // Open the detail dialog by clicking the event bar.
@@ -140,7 +140,7 @@ test.describe("Calendar booking notes + attachments", () => {
     test.skip(blackoutId === null, "Blackout seed endpoint not available");
 
     try {
-      await page.goto("/calendar?from=2026-06-01&to=2026-07-01");
+      await page.goto("/calendar?from=2026-06-01&to=2026-07-01&view=timeline");
       await page.waitForLoadState("networkidle");
 
       // Open detail dialog.

--- a/apps/mybookkeeper/frontend/e2e/calendar-lease-events.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/calendar-lease-events.spec.ts
@@ -108,7 +108,8 @@ test.describe("Tenant leases on the calendar", () => {
     );
 
     try {
-      await page.goto(`/calendar?from=${FROM_ISO}&to=${TO_ISO}`);
+      // The listing-per-row timeline — the month grid is the default view.
+      await page.goto(`/calendar?from=${FROM_ISO}&to=${TO_ISO}&view=timeline`);
       await page.waitForLoadState("networkidle");
       await expect(page.getByRole("heading", { name: "Calendar" })).toBeVisible();
 

--- a/apps/mybookkeeper/frontend/e2e/calendar-month-view.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/calendar-month-view.spec.ts
@@ -1,0 +1,264 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * E2E for the month view — the calendar's default shape.
+ *
+ * The calendar used to open on a listing-per-row timeline, which answers
+ * "which room is free" but reads nothing like a calendar. The month grid is
+ * now the default and the timeline lives behind a toggle. This spec walks the
+ * flow a host actually performs:
+ *
+ * 1. Seed a property + listing + a tenancy inside a known month
+ * 2. The month grid is what loads by default, with the stay drawn as a pill
+ *    spanning the days it covers
+ * 3. The pill opens the same detail dialog the timeline uses
+ * 4. Stepping to the next month moves the grid and the URL together
+ * 5. The toggle swaps to the timeline and back, and survives a reload —
+ *    the view lives in the URL so a shared link opens on what was sent
+ * 6. Cleanup
+ */
+
+const ANCHOR_ISO = "2026-09-01";
+const LEASE_STARTS_ON = "2026-09-07";
+// Inclusive — the tenant's last day. The API reports the 10th, exclusive.
+const LEASE_ENDS_ON = "2026-09-09";
+// The overflow case counts everything drawn on one day, so it gets a month of
+// its own — the suite's specs share one organization and run in parallel, and
+// a neighbour's booking landing on the same day would move the count.
+const CROWDED_ANCHOR_ISO = "2026-11-01";
+const CROWDED_DAY = "2026-11-10";
+const CROWDED_LEASE_ENDS_ON = "2026-11-12";
+const CROWDED_BLACKOUT_ENDS_ON = "2026-11-11";
+const CROWDING_SOURCES = ["airbnb", "vrbo", "furnished_finder", "rotating_room", "direct"];
+
+async function seedListing(
+  api: APIRequestContext,
+  propertyId: string,
+  title: string,
+): Promise<string> {
+  const res = await api.post("/test/seed-listing", {
+    data: { property_id: propertyId, title, status: "active" },
+  });
+  if (!res.ok()) throw new Error(`seedListing failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function seedApplicant(api: APIRequestContext, legalName: string): Promise<string> {
+  const res = await api.post("/test/seed-applicant", {
+    data: { legal_name: legalName, stage: "lead" },
+  });
+  if (!res.ok()) throw new Error(`seedApplicant failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function seedBlackout(
+  api: APIRequestContext,
+  listingId: string,
+  source: string,
+  uid: string,
+): Promise<string> {
+  const res = await api.post("/test/seed-blackout", {
+    data: {
+      listing_id: listingId,
+      starts_on: CROWDED_DAY,
+      // Exclusive per the iCal convention — one blocked day.
+      ends_on: CROWDED_BLACKOUT_ENDS_ON,
+      source,
+      source_event_id: uid,
+    },
+  });
+  if (!res.ok()) throw new Error(`seedBlackout failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function seedLease(
+  api: APIRequestContext,
+  applicantId: string,
+  listingId: string,
+  startsOn: string = LEASE_STARTS_ON,
+  endsOn: string = LEASE_ENDS_ON,
+): Promise<string> {
+  const res = await api.post("/test/seed-signed-lease", {
+    data: {
+      applicant_id: applicantId,
+      listing_id: listingId,
+      kind: "imported",
+      status: "signed",
+      starts_on: startsOn,
+      ends_on: endsOn,
+    },
+  });
+  if (!res.ok()) throw new Error(`seedLease failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+test.describe("Calendar month view", () => {
+  test("opens on the month grid, draws the stay, and toggles to the timeline", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const tenantName = `E2E Month Tenant ${runId}`;
+    const property = await createProperty(api, { name: `E2E Month View ${runId}` });
+    const listingId = await seedListing(api, property.id, `E2E Month Listing ${runId}`);
+    const applicantId = await seedApplicant(api, tenantName);
+    const leaseId = await seedLease(api, applicantId, listingId);
+
+    try {
+      // No `view` param — the month grid is the default.
+      await page.goto(`/calendar?from=${ANCHOR_ISO}`);
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByRole("heading", { name: "Calendar" })).toBeVisible();
+
+      const monthGrid = page.getByTestId("calendar-month-grid");
+      await expect(monthGrid).toBeVisible();
+      await expect(monthGrid).toHaveAttribute("data-month", "September 2026");
+      await expect(page.getByTestId("calendar-grid")).toHaveCount(0);
+
+      // Six week rows of seven days, and Sunday leads the header.
+      await expect(page.getByTestId("calendar-month-week")).toHaveCount(6);
+      await expect(page.getByTestId("calendar-month-day")).toHaveCount(42);
+      await expect(page.getByTestId("calendar-month-weekday-header")).toContainText("Sun");
+
+      // Columns are sevenths of the width, not fixed pixels — unlike the
+      // timeline, the month grid must never push the page sideways.
+      const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+      expect(
+        bodyWidth,
+        `Horizontal scroll on body in month view — bodyWidth=${bodyWidth}`,
+      ).toBeLessThanOrEqual(1281);
+
+      // The tenancy draws as one pill across the days it covers. Inclusive
+      // lease end → exclusive event end, same conversion the timeline makes.
+      const pill = page
+        .getByTestId("calendar-month-event-pill")
+        .filter({ hasText: tenantName });
+      await expect(pill).toHaveCount(1);
+      await expect(pill).toHaveAttribute(
+        "aria-label",
+        new RegExp(`${tenantName} tenancy from ${LEASE_STARTS_ON} to 2026-09-10`),
+      );
+
+      // Same detail dialog as the timeline, linking back to the lease.
+      await pill.click();
+      const dialog = page.getByTestId("calendar-event-detail");
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByText(tenantName)).toBeVisible();
+      await expect(dialog.getByRole("link", { name: /open the lease/i })).toHaveAttribute(
+        "href",
+        `/leases/${leaseId}`,
+      );
+      await page.keyboard.press("Escape");
+      await expect(dialog).toBeHidden();
+
+      // Next month moves the grid and the URL together; the stay is behind us.
+      await page.getByTestId("calendar-month-next").click();
+      await page.waitForLoadState("networkidle");
+      await expect(monthGrid).toHaveAttribute("data-month", "October 2026");
+      expect(page.url()).toContain("from=2026-10-01");
+      await expect(
+        page.getByTestId("calendar-month-event-pill").filter({ hasText: tenantName }),
+      ).toHaveCount(0);
+
+      await page.getByTestId("calendar-month-prev").click();
+      await page.waitForLoadState("networkidle");
+      await expect(monthGrid).toHaveAttribute("data-month", "September 2026");
+
+      // Toggle to the timeline — the listing-per-row shape comes back.
+      await page.getByTestId("calendar-view-timeline").click();
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByTestId("calendar-grid")).toBeVisible();
+      await expect(page.getByTestId("calendar-month-grid")).toHaveCount(0);
+      await expect(page.getByTestId("calendar-window-nav")).toBeVisible();
+      await expect(
+        page.getByTestId("calendar-event-bar").filter({ hasText: tenantName }),
+      ).toHaveCount(1);
+
+      // The view is URL state, so a reload keeps it — a link opens on the
+      // shape the sender was looking at.
+      expect(page.url()).toContain("view=timeline");
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByTestId("calendar-grid")).toBeVisible();
+
+      // ...and back to the month.
+      await page.getByTestId("calendar-view-month").click();
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByTestId("calendar-month-grid")).toBeVisible();
+      await expect(page.getByTestId("calendar-grid")).toHaveCount(0);
+    } finally {
+      await api.delete(`/test/signed-leases/${leaseId}`).catch(() => {});
+      await api.delete(`/test/applicants/${applicantId}`).catch(() => {});
+      await api.delete(`/test/listings/${listingId}`).catch(() => {});
+      await deleteProperty(api, property.id);
+    }
+  });
+
+  test("surfaces bookings past the lane budget behind a clickable +N more", async ({
+    authedPage: page,
+    api,
+  }) => {
+    /**
+     * A day can hold more bookings than the cell has lanes for. The ones that
+     * don't fit are counted into a "+N more" button, which must sit BELOW the
+     * pills and stay clickable — the pill layer is painted on top of the
+     * cells, so a button that lands in a lane's band is covered by a pill and
+     * the overflow becomes unreachable. That failure is invisible to jsdom
+     * (no layout), which is why it is asserted here by actually clicking.
+     */
+    const runId = Date.now();
+    const tenantName = `E2E Crowded Tenant ${runId}`;
+    const property = await createProperty(api, { name: `E2E Crowded Month ${runId}` });
+    const listingId = await seedListing(api, property.id, `E2E Crowded Listing ${runId}`);
+    const applicantId = await seedApplicant(api, tenantName);
+    const leaseId = await seedLease(
+      api,
+      applicantId,
+      listingId,
+      CROWDED_DAY,
+      CROWDED_LEASE_ENDS_ON,
+    );
+    const blackoutIds: string[] = [];
+
+    try {
+      for (const source of CROWDING_SOURCES) {
+        blackoutIds.push(await seedBlackout(api, listingId, source, `crowd-${source}-${runId}`));
+      }
+      // Lease + five blackouts on one day, against a four-lane budget.
+      const expectedOverflow = 1 + CROWDING_SOURCES.length - 4;
+
+      await page.goto(`/calendar?from=${CROWDED_ANCHOR_ISO}`);
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByTestId("calendar-month-grid")).toBeVisible();
+
+      const day = page.locator(`[data-day="${CROWDED_DAY}"]`);
+      const overflow = day.getByTestId("calendar-month-overflow");
+      await expect(overflow).toHaveText(`+${expectedOverflow} more`);
+
+      // The click is the assertion: a covered button times out here.
+      await overflow.click();
+
+      const dialog = page.getByTestId("calendar-month-day-dialog");
+      await expect(dialog).toBeVisible();
+      // Every booking on the day, including the ones no pill was drawn for.
+      await expect(dialog.getByTestId("calendar-month-day-dialog-event")).toHaveCount(
+        1 + CROWDING_SOURCES.length,
+      );
+      await expect(dialog.getByText(tenantName)).toBeVisible();
+
+      await page.keyboard.press("Escape");
+      await expect(dialog).toBeHidden();
+    } finally {
+      for (const id of blackoutIds) await api.delete(`/test/blackouts/${id}`).catch(() => {});
+      await api.delete(`/test/signed-leases/${leaseId}`).catch(() => {});
+      await api.delete(`/test/applicants/${applicantId}`).catch(() => {});
+      await api.delete(`/test/listings/${listingId}`).catch(() => {});
+      await deleteProperty(api, property.id);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/e2e/calendar-review-queue-resolve.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/calendar-review-queue-resolve.spec.ts
@@ -122,7 +122,8 @@ test.describe("Calendar review queue — Phase 2b resolve creates blackout", () 
     const blackoutIdsToClean: string[] = [];
 
     try {
-      await page.goto(`/calendar?from=${fromIso}&to=${toIso}`);
+      // Timeline view — the resolved booking is asserted as an event bar.
+      await page.goto(`/calendar?from=${fromIso}&to=${toIso}&view=timeline`);
       await page.waitForLoadState("networkidle");
 
       // Open the review queue drawer.

--- a/apps/mybookkeeper/frontend/e2e/calendar-unlinked-lease.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/calendar-unlinked-lease.spec.ts
@@ -109,7 +109,9 @@ test.describe("Tenancies with no listing linked", () => {
       expect(unlinkedEvent, "the unlinked tenancy must survive the query").toBeDefined();
       expect(unlinkedEvent?.listing_id).toBeNull();
 
-      await page.goto(`/calendar?from=${FROM_ISO}&to=${TO_ISO}`);
+      // The unassigned row is a timeline concept — the month grid stacks
+      // every listing into one cell, so it has no row to belong to.
+      await page.goto(`/calendar?from=${FROM_ISO}&to=${TO_ISO}&view=timeline`);
       await page.waitForLoadState("networkidle");
       await expect(page.getByRole("heading", { name: "Calendar" })).toBeVisible();
 
@@ -163,7 +165,7 @@ test.describe("Tenancies with no listing linked", () => {
       // Narrowing to the property answers "this property's occupancy", which
       // an unlinked lease is not part of. The linked tenancy survives.
       await page.goto(
-        `/calendar?from=${FROM_ISO}&to=${TO_ISO}&properties=${property.id}`,
+        `/calendar?from=${FROM_ISO}&to=${TO_ISO}&view=timeline&properties=${property.id}`,
       );
       await page.waitForLoadState("networkidle");
       await expect(

--- a/apps/mybookkeeper/frontend/e2e/calendar.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/calendar.spec.ts
@@ -102,7 +102,9 @@ test.describe("Unified calendar viewer", () => {
     if (vr !== null) blackoutIds.push(vr);
 
     try {
-      await page.goto(`/calendar?from=${fromIso}&to=${toIso}`);
+      // `view=timeline` throughout this spec: the month grid is the default
+      // now, and these assertions are about the listing-per-row shape.
+      await page.goto(`/calendar?from=${fromIso}&to=${toIso}&view=timeline`);
       await page.waitForLoadState("networkidle");
 
       // Heading visible.
@@ -164,7 +166,7 @@ test.describe("Unified calendar viewer", () => {
     try {
       // Desktop: grid view visible, mobile agenda hidden.
       await page.setViewportSize({ width: 1280, height: 900 });
-      await page.goto("/calendar?from=2026-06-01&to=2026-07-01");
+      await page.goto("/calendar?from=2026-06-01&to=2026-07-01&view=timeline");
       await page.waitForLoadState("networkidle");
       await expect(page.getByRole("heading", { name: "Calendar" })).toBeVisible();
       await expect(page.getByTestId("calendar-desktop")).toBeVisible();
@@ -178,7 +180,7 @@ test.describe("Unified calendar viewer", () => {
 
       // Mobile: agenda list visible, desktop grid hidden.
       await page.setViewportSize({ width: 375, height: 800 });
-      await page.goto("/calendar?from=2026-06-01&to=2026-07-01");
+      await page.goto("/calendar?from=2026-06-01&to=2026-07-01&view=timeline");
       await page.waitForLoadState("networkidle");
       await expect(page.getByTestId("calendar-mobile")).toBeVisible();
       await expect(page.getByTestId("calendar-desktop")).toBeHidden();

--- a/apps/mybookkeeper/frontend/src/__tests__/Calendar.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/Calendar.test.tsx
@@ -119,6 +119,12 @@ vi.mock("@/shared/store/listingsApi", () => ({
 import { useGetCalendarEventsQuery } from "@/shared/store/calendarApi";
 import { useGetListingsQuery } from "@/shared/store/listingsApi";
 
+/**
+ * The month grid is the default view, so any assertion about the
+ * listing-per-row timeline has to ask for it explicitly.
+ */
+const TIMELINE_URL = ["/calendar?from=2026-06-01&to=2026-07-01&view=timeline"];
+
 function renderCalendar(initialEntries: string[] = ["/calendar?from=2026-06-01&to=2026-07-01"]) {
   return render(
     <Provider store={store}>
@@ -144,16 +150,23 @@ describe("Calendar page", () => {
     expect(screen.getByRole("heading", { name: "Calendar" })).toBeInTheDocument();
   });
 
-  it("renders the legend, filters, and window nav", () => {
+  it("renders the legend, filters, and month nav", () => {
     renderCalendar();
     expect(screen.getByTestId("calendar-legend")).toBeInTheDocument();
     expect(screen.getByTestId("property-filter-trigger")).toBeInTheDocument();
     expect(screen.getByTestId("source-filter-trigger")).toBeInTheDocument();
-    expect(screen.getByTestId("calendar-window-nav")).toBeInTheDocument();
+    expect(screen.getByTestId("calendar-month-nav")).toBeInTheDocument();
+    expect(screen.getByTestId("calendar-view-toggle")).toBeInTheDocument();
   });
 
-  it("renders event bars colored by source on desktop view", () => {
-    renderCalendar();
+  it("swaps in the window nav when the timeline is selected", () => {
+    renderCalendar(TIMELINE_URL);
+    expect(screen.getByTestId("calendar-window-nav")).toBeInTheDocument();
+    expect(screen.queryByTestId("calendar-month-nav")).not.toBeInTheDocument();
+  });
+
+  it("renders event bars colored by source on the timeline", () => {
+    renderCalendar(TIMELINE_URL);
     const bars = screen.getAllByTestId("calendar-event-bar");
     expect(bars).toHaveLength(mockEvents.length);
     const sources = bars.map((b) => b.getAttribute("data-source"));
@@ -162,8 +175,8 @@ describe("Calendar page", () => {
     expect(sources).toContain("manual");
   });
 
-  it("groups listings by property in the desktop grid", () => {
-    renderCalendar();
+  it("groups listings by property in the timeline grid", () => {
+    renderCalendar(TIMELINE_URL);
     const desktop = screen.getByTestId("calendar-desktop");
     const propertyHeaders = within(desktop).getAllByTestId("calendar-property-header");
     expect(propertyHeaders).toHaveLength(1);
@@ -235,7 +248,7 @@ describe("Calendar page", () => {
     );
     renderCalendar();
     expect(screen.queryByTestId("calendar-no-listings")).not.toBeInTheDocument();
-    expect(screen.getAllByTestId("calendar-event-bar").length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId("calendar-month-event-pill").length).toBeGreaterThan(0);
   });
 
   it("displays last-synced relative time when events exist", () => {
@@ -262,7 +275,7 @@ describe("Calendar skeleton", () => {
     vi.mocked(useGetCalendarEventsQuery).mockReturnValue(
       defaultEventsState as unknown as ReturnType<typeof useGetCalendarEventsQuery>,
     );
-    const { unmount } = renderCalendar();
+    const { unmount } = renderCalendar(TIMELINE_URL);
     const loaded = screen.getByTestId("calendar-grid");
     const loadedRows = within(loaded).getAllByTestId("calendar-listing-row");
     const loadedRowCount = loadedRows.length;
@@ -274,7 +287,7 @@ describe("Calendar skeleton", () => {
         typeof useGetCalendarEventsQuery
       >,
     );
-    renderCalendar();
+    renderCalendar(TIMELINE_URL);
     const skeleton = screen.getByTestId("calendar-skeleton");
     // Skeleton's desktop-only block is hidden via CSS in tests (jsdom doesn't
     // evaluate media queries), but the structural sanity check is that the

--- a/apps/mybookkeeper/frontend/src/__tests__/CalendarMonthGrid.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/CalendarMonthGrid.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for the month view.
+ *
+ * The month grid is the calendar's default shape, so these cover the things a
+ * host reads off it at a glance: the right days in the right columns, a stay
+ * drawn as one bar across the days it covers, and — the part that's easy to
+ * get wrong — nothing silently hidden when a day is busier than the row has
+ * lanes for.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { configureStore } from "@reduxjs/toolkit";
+import { baseApi } from "@/shared/store/baseApi";
+import * as calendarApi from "@/shared/store/calendarApi";
+import CalendarMonthGrid from "@/app/features/calendar/CalendarMonthGrid";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+
+const TODAY = "2026-09-15";
+const ANCHOR = "2026-09-01";
+
+function makeEvent(overrides: Partial<CalendarEvent> & Pick<CalendarEvent, "id">): CalendarEvent {
+  return {
+    listing_id: "listing-1",
+    listing_name: "Master Bedroom",
+    property_id: "prop-1",
+    property_name: "Med Center House",
+    starts_on: "2026-09-07",
+    ends_on: "2026-09-10",
+    source: "airbnb",
+    source_event_id: "uid-1",
+    summary: null,
+    host_notes: null,
+    attachment_count: 0,
+    updated_at: "2026-09-01T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderMonth(events: CalendarEvent[], anchorIso = ANCHOR) {
+  const store = configureStore({
+    reducer: { [baseApi.reducerPath]: baseApi.reducer },
+    middleware: (getDefault) => getDefault().concat(baseApi.middleware),
+  });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CalendarMonthGrid events={events} anchorIso={anchorIso} todayIso={TODAY} />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  // The detail dialog reaches for attachments as soon as it opens.
+  vi.spyOn(calendarApi, "useGetBlackoutAttachmentsQuery").mockReturnValue({
+    data: [],
+    isLoading: false,
+  } as unknown as ReturnType<typeof calendarApi.useGetBlackoutAttachmentsQuery>);
+  vi.spyOn(calendarApi, "useUpdateBlackoutMutation").mockReturnValue([
+    vi.fn().mockReturnValue({ unwrap: vi.fn().mockResolvedValue({}) }),
+    { isLoading: false },
+  ] as unknown as ReturnType<typeof calendarApi.useUpdateBlackoutMutation>);
+  vi.spyOn(calendarApi, "useUploadBlackoutAttachmentMutation").mockReturnValue([
+    vi.fn().mockReturnValue({ unwrap: vi.fn().mockResolvedValue({}) }),
+    { isLoading: false },
+  ] as unknown as ReturnType<typeof calendarApi.useUploadBlackoutAttachmentMutation>);
+  vi.spyOn(calendarApi, "useDeleteBlackoutAttachmentMutation").mockReturnValue([
+    vi.fn().mockReturnValue({ unwrap: vi.fn().mockResolvedValue(undefined) }),
+    { isLoading: false },
+  ] as unknown as ReturnType<typeof calendarApi.useDeleteBlackoutAttachmentMutation>);
+});
+
+describe("CalendarMonthGrid layout", () => {
+  it("renders a Sunday-first weekday header", () => {
+    renderMonth([]);
+    const header = screen.getByTestId("calendar-month-weekday-header");
+    expect(header.textContent).toBe("SunMonTueWedThuFriSat");
+  });
+
+  it("renders six week rows of seven days", () => {
+    renderMonth([]);
+    expect(screen.getAllByTestId("calendar-month-week")).toHaveLength(6);
+    expect(screen.getAllByTestId("calendar-month-day")).toHaveLength(42);
+  });
+
+  it("dims the padding days borrowed from the neighbouring months", () => {
+    renderMonth([]);
+    // September 2026 starts on a Tuesday, so Aug 30 and 31 pad the front.
+    const days = screen.getAllByTestId("calendar-month-day");
+    expect(days[0]).toHaveAttribute("data-day", "2026-08-30");
+    expect(days[0]).toHaveAttribute("data-outside-month", "true");
+    expect(days[2]).toHaveAttribute("data-day", "2026-09-01");
+    expect(days[2]).not.toHaveAttribute("data-outside-month");
+  });
+
+  it("marks today", () => {
+    renderMonth([]);
+    const todayCells = screen
+      .getAllByTestId("calendar-month-day")
+      .filter((cell) => cell.getAttribute("data-today") === "true");
+    expect(todayCells).toHaveLength(1);
+    expect(todayCells[0]).toHaveAttribute("data-day", TODAY);
+  });
+});
+
+describe("CalendarMonthGrid events", () => {
+  it("draws a stay as a single pill labelled by source", () => {
+    renderMonth([makeEvent({ id: "e1" })]);
+    const pills = screen.getAllByTestId("calendar-month-event-pill");
+    expect(pills).toHaveLength(1);
+    expect(pills[0]).toHaveTextContent("Airbnb");
+    expect(pills[0]).toHaveAttribute("data-source", "airbnb");
+  });
+
+  it("names the tenant on a lease pill instead of the source", () => {
+    renderMonth([
+      makeEvent({ id: "e1", source: "lease", summary: "Mohammed Awamleh" }),
+    ]);
+    expect(screen.getByTestId("calendar-month-event-pill")).toHaveTextContent(
+      "Mohammed Awamleh",
+    );
+  });
+
+  it("splits a stay that crosses a week boundary into two joined pills", () => {
+    // Thursday the 3rd → Wednesday the 9th, crossing Saturday the 5th.
+    renderMonth([makeEvent({ id: "e1", starts_on: "2026-09-03", ends_on: "2026-09-09" })]);
+    const pills = screen.getAllByTestId("calendar-month-event-pill");
+    expect(pills).toHaveLength(2);
+    // Both halves still describe the whole stay to a screen reader.
+    for (const pill of pills) {
+      expect(pill).toHaveAttribute(
+        "aria-label",
+        expect.stringContaining("from 2026-09-03 to 2026-09-09"),
+      );
+    }
+  });
+
+  it("opens the detail dialog when a pill is clicked", () => {
+    renderMonth([makeEvent({ id: "e1" })]);
+    fireEvent.click(screen.getByTestId("calendar-month-event-pill"));
+    expect(screen.getByTestId("calendar-event-detail")).toBeInTheDocument();
+  });
+});
+
+describe("CalendarMonthGrid overflow", () => {
+  // Five stays over the same days — one more than the lane budget.
+  const crowded = Array.from({ length: 5 }, (_, i) =>
+    makeEvent({ id: `e${i}`, starts_on: "2026-09-07", ends_on: "2026-09-09" }),
+  );
+
+  it("offers a +N more affordance rather than dropping the extra stay", () => {
+    renderMonth(crowded);
+    expect(screen.getAllByTestId("calendar-month-event-pill")).toHaveLength(4);
+    const overflow = screen.getAllByTestId("calendar-month-overflow");
+    // The hidden stay covers the 7th and the 8th.
+    expect(overflow).toHaveLength(2);
+    expect(overflow[0]).toHaveTextContent("+1 more");
+  });
+
+  it("lists every stay on the day — not just the hidden ones — when opened", () => {
+    renderMonth(crowded);
+    fireEvent.click(screen.getAllByTestId("calendar-month-overflow")[0]);
+
+    const dialog = screen.getByTestId("calendar-month-day-dialog");
+    expect(within(dialog).getAllByTestId("calendar-month-day-dialog-event")).toHaveLength(5);
+    expect(dialog).toHaveTextContent("Monday, September 7, 2026");
+    expect(dialog).toHaveTextContent("5 bookings");
+  });
+
+  it("swaps the day list for the detail dialog when a listed stay is clicked", () => {
+    renderMonth(crowded);
+    fireEvent.click(screen.getAllByTestId("calendar-month-overflow")[0]);
+    fireEvent.click(screen.getAllByTestId("calendar-month-day-dialog-event")[0]);
+
+    expect(screen.queryByTestId("calendar-month-day-dialog")).not.toBeInTheDocument();
+    expect(screen.getByTestId("calendar-event-detail")).toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/month-grid-utils.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/month-grid-utils.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import {
+  addMonths,
+  assignLanes,
+  buildMonthGrid,
+  eventsOnDay,
+  monthGridWindow,
+  startOfMonth,
+  startOfWeek,
+} from "@/app/features/calendar/month-grid-utils";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+
+function makeEvent(overrides: Partial<CalendarEvent> & Pick<CalendarEvent, "id">): CalendarEvent {
+  return {
+    listing_id: "listing-1",
+    listing_name: "Room A",
+    property_id: "property-1",
+    property_name: "Peerless St",
+    starts_on: "2026-09-03",
+    ends_on: "2026-09-06",
+    source: "airbnb",
+    source_event_id: null,
+    summary: null,
+    host_notes: null,
+    attachment_count: 0,
+    updated_at: "2026-09-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("startOfMonth", () => {
+  it("snaps any day to the first of its month", () => {
+    expect(startOfMonth("2026-09-17")).toBe("2026-09-01");
+    expect(startOfMonth("2026-09-01")).toBe("2026-09-01");
+  });
+});
+
+describe("addMonths", () => {
+  it("steps forward and back", () => {
+    expect(addMonths("2026-09-01", 1)).toBe("2026-10-01");
+    expect(addMonths("2026-09-01", -1)).toBe("2026-08-01");
+  });
+
+  it("crosses year boundaries", () => {
+    expect(addMonths("2026-12-01", 1)).toBe("2027-01-01");
+    expect(addMonths("2026-01-01", -1)).toBe("2025-12-01");
+  });
+
+  it("clamps to the target month's length instead of overflowing", () => {
+    // Naive date math turns Jan 31 + 1 month into March 3 — which would make
+    // "next month" skip February entirely.
+    expect(addMonths("2026-01-31", 1)).toBe("2026-02-28");
+    expect(addMonths("2028-01-31", 1)).toBe("2028-02-29");
+  });
+});
+
+describe("startOfWeek", () => {
+  it("returns the Sunday on or before the date", () => {
+    // 2026-09-01 is a Tuesday.
+    expect(startOfWeek("2026-09-01")).toBe("2026-08-30");
+    // A Sunday is its own week start.
+    expect(startOfWeek("2026-08-30")).toBe("2026-08-30");
+    // 2026-09-05 is a Saturday.
+    expect(startOfWeek("2026-09-05")).toBe("2026-08-30");
+  });
+});
+
+describe("monthGridWindow", () => {
+  it("spans six whole weeks starting on the Sunday before the 1st", () => {
+    const { fromIso, toIso } = monthGridWindow("2026-09-17");
+    expect(fromIso).toBe("2026-08-30");
+    expect(toIso).toBe("2026-10-11"); // 42 days later, exclusive
+  });
+
+  it("is the same window for every day in the month", () => {
+    expect(monthGridWindow("2026-09-01")).toEqual(monthGridWindow("2026-09-30"));
+  });
+});
+
+describe("buildMonthGrid", () => {
+  it("lays out six rows of seven days", () => {
+    const grid = buildMonthGrid("2026-09-01", [], "2026-09-15");
+    expect(grid.weeks).toHaveLength(6);
+    for (const week of grid.weeks) {
+      expect(week.days).toHaveLength(7);
+    }
+    expect(grid.monthLabel).toBe("September 2026");
+  });
+
+  it("marks the padding days from adjacent months", () => {
+    const grid = buildMonthGrid("2026-09-01", [], "2026-09-15");
+    const firstWeek = grid.weeks[0];
+    // Aug 30, Aug 31 pad the front; Sep 1 onwards belong to the month.
+    expect(firstWeek.days[0]).toMatchObject({ iso: "2026-08-30", isInAnchorMonth: false });
+    expect(firstWeek.days[1]).toMatchObject({ iso: "2026-08-31", isInAnchorMonth: false });
+    expect(firstWeek.days[2]).toMatchObject({
+      iso: "2026-09-01",
+      isInAnchorMonth: true,
+      dayOfMonth: 1,
+    });
+  });
+
+  it("marks today, and only today", () => {
+    const grid = buildMonthGrid("2026-09-01", [], "2026-09-15");
+    const flagged = grid.weeks.flatMap((w) => w.days).filter((d) => d.isToday);
+    expect(flagged.map((d) => d.iso)).toEqual(["2026-09-15"]);
+  });
+
+  it("places an event on the week that contains it", () => {
+    const event = makeEvent({ id: "e1", starts_on: "2026-09-07", ends_on: "2026-09-10" });
+    const grid = buildMonthGrid("2026-09-01", [event], "2026-09-15");
+
+    const weekWithEvent = grid.weeks.filter((w) => w.segments.length > 0);
+    expect(weekWithEvent).toHaveLength(1);
+    expect(weekWithEvent[0].startIso).toBe("2026-09-06");
+    expect(weekWithEvent[0].segments[0]).toMatchObject({
+      startCol: 1, // Monday
+      span: 3, // ends_on is exclusive: the 7th, 8th, 9th
+      continuesBefore: false,
+      continuesAfter: false,
+      lane: 0,
+    });
+  });
+
+  it("splits a stay that crosses a week boundary into two joined segments", () => {
+    // Thursday the 3rd through Wednesday the 9th, crossing Saturday the 5th.
+    const event = makeEvent({ id: "e1", starts_on: "2026-09-03", ends_on: "2026-09-09" });
+    const grid = buildMonthGrid("2026-09-01", [event], "2026-09-15");
+    const segments = grid.weeks.flatMap((w) => w.segments);
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({
+      startCol: 4, // Thursday
+      span: 3, // Thu, Fri, Sat
+      continuesBefore: false,
+      continuesAfter: true,
+    });
+    expect(segments[1]).toMatchObject({
+      startCol: 0, // Sunday
+      span: 3, // Sun, Mon, Tue
+      continuesBefore: true,
+      continuesAfter: false,
+    });
+  });
+
+  it("clips a stay that started before the grid and runs past its end", () => {
+    const event = makeEvent({ id: "e1", starts_on: "2026-05-03", ends_on: "2026-11-10" });
+    const grid = buildMonthGrid("2026-09-01", [event], "2026-09-15");
+    const segments = grid.weeks.flatMap((w) => w.segments);
+
+    expect(segments).toHaveLength(6);
+    for (const segment of segments) {
+      expect(segment).toMatchObject({ startCol: 0, span: 7, continuesBefore: true, continuesAfter: true });
+    }
+  });
+
+  it("ignores events entirely outside the grid", () => {
+    const event = makeEvent({ id: "e1", starts_on: "2026-11-01", ends_on: "2026-11-05" });
+    const grid = buildMonthGrid("2026-09-01", [event], "2026-09-15");
+    expect(grid.weeks.flatMap((w) => w.segments)).toHaveLength(0);
+  });
+
+  it("stacks overlapping events into separate lanes and reuses a freed lane", () => {
+    const events = [
+      makeEvent({ id: "a", starts_on: "2026-09-06", ends_on: "2026-09-09" }),
+      makeEvent({ id: "b", starts_on: "2026-09-07", ends_on: "2026-09-10" }),
+      // Starts after "a" ends, so it can share lane 0.
+      makeEvent({ id: "c", starts_on: "2026-09-10", ends_on: "2026-09-12" }),
+    ];
+    const grid = buildMonthGrid("2026-09-01", events, "2026-09-15");
+    const lanes = Object.fromEntries(
+      grid.weeks
+        .flatMap((w) => w.segments)
+        .map((s) => [s.event.id, s.lane]),
+    );
+
+    expect(lanes).toEqual({ a: 0, b: 1, c: 0 });
+  });
+});
+
+describe("assignLanes overflow", () => {
+  const week = "2026-09-06";
+
+  function segment(startCol: number, span: number, id: string) {
+    return {
+      event: makeEvent({ id }),
+      startCol,
+      span,
+      continuesBefore: false,
+      continuesAfter: false,
+    };
+  }
+
+  it("keeps every segment when the budget allows", () => {
+    const { placed, overflowByDay, laneCount } = assignLanes(
+      [segment(0, 3, "a"), segment(0, 3, "b")],
+      week,
+      4,
+    );
+    expect(placed).toHaveLength(2);
+    expect(overflowByDay).toEqual({});
+    expect(laneCount).toBe(2);
+  });
+
+  it("counts the segments past the budget per day instead of dropping them", () => {
+    const overlapping = [
+      segment(1, 2, "a"),
+      segment(1, 2, "b"),
+      segment(1, 2, "c"), // the third overlaps both, so it lands in lane 2
+    ];
+    const { placed, overflowByDay, laneCount } = assignLanes(overlapping, week, 2);
+
+    expect(placed.map((s) => s.event.id)).toEqual(["a", "b"]);
+    expect(laneCount).toBe(2);
+    // "c" covers Monday the 7th and Tuesday the 8th.
+    expect(overflowByDay).toEqual({ "2026-09-07": 1, "2026-09-08": 1 });
+  });
+});
+
+describe("eventsOnDay", () => {
+  const events = [
+    makeEvent({ id: "a", starts_on: "2026-09-03", ends_on: "2026-09-06" }),
+    makeEvent({ id: "b", starts_on: "2026-09-05", ends_on: "2026-09-08" }),
+    makeEvent({ id: "c", starts_on: "2026-09-10", ends_on: "2026-09-12" }),
+  ];
+
+  it("returns the events covering the day", () => {
+    expect(eventsOnDay(events, "2026-09-05").map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("treats ends_on as exclusive", () => {
+    // "a" ends_on the 6th, so the 6th is already free.
+    expect(eventsOnDay(events, "2026-09-06").map((e) => e.id)).toEqual(["b"]);
+  });
+
+  it("returns nothing on an empty day", () => {
+    expect(eventsOnDay(events, "2026-09-09")).toEqual([]);
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarAgendaSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarAgendaSkeleton.tsx
@@ -1,0 +1,26 @@
+import Skeleton from "@/shared/components/ui/Skeleton";
+
+export interface CalendarAgendaSkeletonProps {
+  rows?: number;
+}
+
+/**
+ * Skeleton for the mobile agenda list — one card per event, mirroring
+ * `CalendarAgendaEvent`'s three lines so nothing shifts when data lands.
+ *
+ * Shared by both desktop shapes: mobile falls back to the agenda whichever
+ * view the URL asks for, so its placeholder shouldn't be duplicated per view.
+ */
+export default function CalendarAgendaSkeleton({ rows = 4 }: CalendarAgendaSkeletonProps) {
+  return (
+    <ul className="space-y-3" aria-label="Loading agenda">
+      {Array.from({ length: rows }, (_, i) => (
+        <li key={i} className="space-y-2 rounded-lg border p-3">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-48" />
+          <Skeleton className="h-3 w-24" />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarLoadingState.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarLoadingState.tsx
@@ -1,0 +1,31 @@
+import CalendarAgendaSkeleton from "@/app/features/calendar/CalendarAgendaSkeleton";
+import CalendarMonthSkeleton from "@/app/features/calendar/CalendarMonthSkeleton";
+import CalendarSkeleton from "@/app/features/calendar/CalendarSkeleton";
+import type { CalendarView } from "@/shared/types/calendar/calendar-view";
+
+export interface CalendarLoadingStateProps {
+  view: CalendarView;
+}
+
+/**
+ * The right placeholder for whichever shape is about to render.
+ *
+ * Picking the skeleton is a per-view decision, but the page's render is
+ * already a chain of states; keeping the branch here keeps that chain
+ * readable and guarantees the mobile agenda placeholder is identical in
+ * both views.
+ */
+export default function CalendarLoadingState({ view }: CalendarLoadingStateProps) {
+  if (view === "timeline") return <CalendarSkeleton />;
+
+  return (
+    <div data-testid="calendar-skeleton">
+      <div className="md:hidden">
+        <CalendarAgendaSkeleton />
+      </div>
+      <div className="hidden md:block">
+        <CalendarMonthSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthDayCell.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthDayCell.tsx
@@ -1,0 +1,62 @@
+import { CALENDAR_MONTH_DAY_HEADER_PX } from "@/shared/lib/calendar-constants";
+import type { MonthGridDay } from "@/shared/types/calendar/month-grid-day";
+
+export interface CalendarMonthDayCellProps {
+  day: MonthGridDay;
+  /** Events on this day that didn't fit the lane budget. */
+  overflowCount: number;
+  onOverflowClick: (dayIso: string) => void;
+}
+
+/**
+ * Background cell for one day: the day number, and a "+N more" button when
+ * the week ran out of lanes.
+ *
+ * The pills themselves are drawn in a layer above the cells so a stay can
+ * span columns — this component owns only what belongs to a single day.
+ */
+export default function CalendarMonthDayCell({
+  day,
+  overflowCount,
+  onOverflowClick,
+}: CalendarMonthDayCellProps) {
+  const numberClass = [
+    "inline-flex h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-xs",
+    day.isToday ? "bg-primary font-semibold text-primary-foreground" : "",
+    !day.isToday && day.isInAnchorMonth ? "text-foreground" : "",
+    !day.isToday && !day.isInAnchorMonth ? "text-muted-foreground/60" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={`relative flex flex-col border-r border-t last:border-r-0 ${
+        day.isInAnchorMonth ? "" : "bg-muted/20"
+      }`}
+      data-testid="calendar-month-day"
+      data-day={day.iso}
+      data-outside-month={day.isInAnchorMonth ? undefined : "true"}
+      data-today={day.isToday ? "true" : undefined}
+    >
+      <div
+        className="flex items-start justify-end px-1.5 pt-1"
+        style={{ height: CALENDAR_MONTH_DAY_HEADER_PX }}
+      >
+        <span className={numberClass}>{day.dayOfMonth}</span>
+      </div>
+
+      {overflowCount > 0 ? (
+        <button
+          type="button"
+          onClick={() => onOverflowClick(day.iso)}
+          className="mt-auto mb-1 mx-1 rounded px-1 py-0.5 text-left text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          aria-label={`Show all bookings on ${day.iso}`}
+          data-testid="calendar-month-overflow"
+        >
+          +{overflowCount} more
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthDayDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthDayDialog.tsx
@@ -1,0 +1,83 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { getSourceColor, getSourceLabel, isReadOnlySource } from "@/shared/lib/calendar-constants";
+import { formatDayLabel } from "@/app/features/calendar/calendar-utils";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+
+export interface CalendarMonthDayDialogProps {
+  /** ISO date whose events to list, or null when closed. */
+  dayIso: string | null;
+  events: readonly CalendarEvent[];
+  onClose: () => void;
+  onEventClick: (event: CalendarEvent) => void;
+}
+
+/**
+ * Every booking on one day.
+ *
+ * A month cell only has room for a few lanes, and a busy day overflows. The
+ * overflow must stay reachable — a booking the host can't see is a booking
+ * they'll double-book — so "+N more" opens this list, which shows all of the
+ * day's events, not just the hidden ones.
+ */
+export default function CalendarMonthDayDialog({
+  dayIso,
+  events,
+  onClose,
+  onEventClick,
+}: CalendarMonthDayDialogProps) {
+  return (
+    <Dialog.Root open={dayIso !== null} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[70] bg-black/50" />
+        <Dialog.Content
+          data-testid="calendar-month-day-dialog"
+          className="fixed left-1/2 top-1/2 z-[70] max-h-[90vh] w-full max-w-md -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border bg-card p-6 shadow-lg"
+        >
+          <Dialog.Title className="text-lg font-semibold">
+            {dayIso ? formatDayLabel(dayIso) : ""}
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-sm text-muted-foreground">
+            {events.length === 1 ? "1 booking" : `${events.length} bookings`}
+          </Dialog.Description>
+
+          <ul className="mt-4 space-y-1">
+            {events.map((event) => {
+              const label = isReadOnlySource(event.source)
+                ? (event.summary ?? getSourceLabel(event.source))
+                : getSourceLabel(event.source);
+              return (
+                <li key={event.id}>
+                  <button
+                    type="button"
+                    onClick={() => onEventClick(event)}
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary"
+                    data-testid="calendar-month-day-dialog-event"
+                    data-event-id={event.id}
+                  >
+                    <span
+                      className="h-3 w-3 shrink-0 rounded-full"
+                      style={{ backgroundColor: getSourceColor(event.source) }}
+                      aria-hidden="true"
+                    />
+                    <span className="truncate">{label}</span>
+                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                      {event.starts_on} → {event.ends_on}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          <Dialog.Close
+            className="absolute right-3 top-3 flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md p-1 transition-colors hover:bg-muted"
+            aria-label="Close"
+          >
+            <X size={18} aria-hidden="true" />
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthEventPill.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthEventPill.tsx
@@ -1,0 +1,71 @@
+import {
+  CALENDAR_MONTH_DAY_HEADER_PX,
+  CALENDAR_MONTH_LANE_GAP_PX,
+  CALENDAR_MONTH_LANE_HEIGHT_PX,
+  CALENDAR_WEEK_LENGTH,
+  getSourceColor,
+  getSourceLabel,
+  isReadOnlySource,
+} from "@/shared/lib/calendar-constants";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+import type { MonthEventSegment } from "@/shared/types/calendar/month-event-segment";
+
+export interface CalendarMonthEventPillProps {
+  segment: MonthEventSegment;
+  onClick: (event: CalendarEvent) => void;
+}
+
+/**
+ * One booking or tenancy drawn across a week row.
+ *
+ * Position is expressed in sevenths of the row so the grid stays fluid at any
+ * viewport width. A stay that crosses a Saturday is two segments, one per
+ * week; the ends that continue into an adjacent week are squared off, so a
+ * rounded end always means "this is where the stay actually starts/stops".
+ */
+export default function CalendarMonthEventPill({
+  segment,
+  onClick,
+}: CalendarMonthEventPillProps) {
+  const { event, startCol, span, continuesBefore, continuesAfter, lane } = segment;
+
+  const isManual = event.source === "manual";
+  const sourceLabel = getSourceLabel(event.source);
+  // A channel booking can only name its channel — iCal carries no guest.
+  // A tenancy knows exactly who lives there, which is the point of the row.
+  const isTenancy = isReadOnlySource(event.source);
+  const pillLabel = isTenancy ? (event.summary ?? sourceLabel) : sourceLabel;
+  const kindWord = isTenancy ? "tenancy" : "blackout";
+
+  const roundingClass = [
+    continuesBefore ? "rounded-l-none" : "rounded-l",
+    continuesAfter ? "rounded-r-none" : "rounded-r",
+  ].join(" ");
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(event)}
+      className={`absolute flex items-center overflow-hidden px-1.5 text-[11px] leading-none text-white shadow-sm transition-all hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-primary ${roundingClass}`}
+      style={{
+        left: `calc(${(startCol / CALENDAR_WEEK_LENGTH) * 100}% + 2px)`,
+        width: `calc(${(span / CALENDAR_WEEK_LENGTH) * 100}% - 4px)`,
+        top:
+          CALENDAR_MONTH_DAY_HEADER_PX +
+          lane * (CALENDAR_MONTH_LANE_HEIGHT_PX + CALENDAR_MONTH_LANE_GAP_PX),
+        height: CALENDAR_MONTH_LANE_HEIGHT_PX,
+        backgroundColor: getSourceColor(event.source),
+        backgroundImage: isManual
+          ? "repeating-linear-gradient(45deg, transparent, transparent 4px, rgba(255,255,255,0.18) 4px, rgba(255,255,255,0.18) 8px)"
+          : undefined,
+      }}
+      title={`${sourceLabel}\n${event.starts_on} → ${event.ends_on}${event.summary ? `\n${event.summary}` : ""}`}
+      aria-label={`${pillLabel} ${kindWord} from ${event.starts_on} to ${event.ends_on}. Click for details.`}
+      data-testid="calendar-month-event-pill"
+      data-source={event.source}
+      data-event-id={event.id}
+    >
+      <span className="truncate">{pillLabel}</span>
+    </button>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthGrid.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthGrid.tsx
@@ -1,0 +1,88 @@
+import { useMemo, useState } from "react";
+import { CALENDAR_WEEKDAY_LABELS } from "@/shared/lib/calendar-constants";
+import { buildMonthGrid, eventsOnDay } from "@/app/features/calendar/month-grid-utils";
+import CalendarEventDetail from "@/app/features/calendar/CalendarEventDetail";
+import CalendarMonthDayDialog from "@/app/features/calendar/CalendarMonthDayDialog";
+import CalendarMonthWeekRow from "@/app/features/calendar/CalendarMonthWeekRow";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+
+export interface CalendarMonthGridProps {
+  events: readonly CalendarEvent[];
+  /** Any date inside the month to display. */
+  anchorIso: string;
+  /** Today's date, injected so the component stays deterministic in tests. */
+  todayIso: string;
+}
+
+/**
+ * Month view — the calendar shape people already know.
+ *
+ * Seven columns, Sunday through Saturday, six week rows. Bookings and
+ * tenancies draw as pills that span the days they cover, so "the house is
+ * occupied from the 3rd to the 20th" is one bar rather than eighteen badges.
+ *
+ * This is the default view. The listing-per-row timeline still exists behind
+ * the view toggle for the question this shape can't answer — which *room* is
+ * free — since a month cell stacks every listing together.
+ */
+export default function CalendarMonthGrid({
+  events,
+  anchorIso,
+  todayIso,
+}: CalendarMonthGridProps) {
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
+  const [expandedDayIso, setExpandedDayIso] = useState<string | null>(null);
+
+  const grid = useMemo(
+    () => buildMonthGrid(anchorIso, events, todayIso),
+    [anchorIso, events, todayIso],
+  );
+  const expandedDayEvents = useMemo(
+    () => (expandedDayIso ? eventsOnDay(events, expandedDayIso) : []),
+    [events, expandedDayIso],
+  );
+
+  function handleDayDialogEventClick(event: CalendarEvent) {
+    // Swap one dialog for the other rather than stacking them.
+    setExpandedDayIso(null);
+    setSelectedEvent(event);
+  }
+
+  return (
+    <>
+      <div
+        className="overflow-hidden rounded-lg border bg-card"
+        data-testid="calendar-month-grid"
+        data-month={grid.monthLabel}
+      >
+        <div className="grid grid-cols-7 bg-muted/30" data-testid="calendar-month-weekday-header">
+          {CALENDAR_WEEKDAY_LABELS.map((label) => (
+            <div
+              key={label}
+              className="border-r px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground last:border-r-0"
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {grid.weeks.map((week) => (
+          <CalendarMonthWeekRow
+            key={week.startIso}
+            week={week}
+            onEventClick={setSelectedEvent}
+            onOverflowClick={setExpandedDayIso}
+          />
+        ))}
+      </div>
+
+      <CalendarMonthDayDialog
+        dayIso={expandedDayIso}
+        events={expandedDayEvents}
+        onClose={() => setExpandedDayIso(null)}
+        onEventClick={handleDayDialogEventClick}
+      />
+      <CalendarEventDetail event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+    </>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthNav.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthNav.tsx
@@ -1,0 +1,64 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { addMonths, startOfMonth } from "@/app/features/calendar/month-grid-utils";
+import MonthYearJumper from "@/app/features/calendar/MonthYearJumper";
+
+export interface CalendarMonthNavProps {
+  /** Any date inside the displayed month. */
+  anchorIso: string;
+  onChange: (anchorIso: string) => void;
+  onToday: () => void;
+}
+
+/**
+ * Period navigation for the month view: `[<] [Month YYYY ▾] [>] [Today]`.
+ *
+ * The timeline's nav steps by an arbitrary window length and offers window-
+ * size presets; neither idea applies here, where the unit is exactly one
+ * month. The month/year jumper is shared between the two.
+ */
+export default function CalendarMonthNav({
+  anchorIso,
+  onChange,
+  onToday,
+}: CalendarMonthNavProps) {
+  // Anchor on the 1st so stepping from the 31st can't skip a short month.
+  const monthStartIso = startOfMonth(anchorIso);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" data-testid="calendar-month-nav">
+      <button
+        type="button"
+        onClick={() => onChange(addMonths(monthStartIso, -1))}
+        title="Previous month"
+        className="flex h-9 w-9 items-center justify-center rounded-md border transition-colors hover:bg-muted"
+        aria-label="Previous month"
+        data-testid="calendar-month-prev"
+      >
+        <ChevronLeft size={16} aria-hidden="true" />
+      </button>
+
+      <MonthYearJumper fromIso={monthStartIso} onJump={onChange} />
+
+      <button
+        type="button"
+        onClick={() => onChange(addMonths(monthStartIso, 1))}
+        title="Next month"
+        className="flex h-9 w-9 items-center justify-center rounded-md border transition-colors hover:bg-muted"
+        aria-label="Next month"
+        data-testid="calendar-month-next"
+      >
+        <ChevronRight size={16} aria-hidden="true" />
+      </button>
+
+      <button
+        type="button"
+        onClick={onToday}
+        title="Jump back to this month"
+        className="ml-2 h-9 rounded-md border px-3 text-sm transition-colors hover:bg-muted"
+        data-testid="calendar-month-today"
+      >
+        Today
+      </button>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthSkeleton.tsx
@@ -1,0 +1,85 @@
+import Skeleton from "@/shared/components/ui/Skeleton";
+import {
+  CALENDAR_MONTH_DAY_HEADER_PX,
+  CALENDAR_MONTH_LANE_GAP_PX,
+  CALENDAR_MONTH_LANE_HEIGHT_PX,
+  CALENDAR_MONTH_MIN_ROW_PX,
+  CALENDAR_MONTH_WEEKS,
+  CALENDAR_WEEKDAY_LABELS,
+} from "@/shared/lib/calendar-constants";
+
+/** Which columns get a placeholder pill, per week row — enough to read as a
+ *  month without pretending to know the data. */
+const PLACEHOLDER_PILLS: ReadonlyArray<ReadonlyArray<{ startCol: number; span: number }>> = [
+  [{ startCol: 1, span: 3 }],
+  [{ startCol: 0, span: 5 }, { startCol: 5, span: 2 }],
+  [{ startCol: 2, span: 4 }],
+  [{ startCol: 0, span: 2 }, { startCol: 3, span: 3 }],
+  [{ startCol: 4, span: 3 }],
+  [{ startCol: 1, span: 2 }],
+];
+
+/**
+ * Skeleton for the month view.
+ *
+ * Mirrors the loaded layout exactly — same weekday header, same six rows of
+ * seven cells, same day-number and pill geometry — so nothing shifts when the
+ * data lands.
+ */
+export default function CalendarMonthSkeleton() {
+  return (
+    <div
+      className="overflow-hidden rounded-lg border bg-card"
+      data-testid="calendar-month-skeleton"
+      aria-label="Loading calendar"
+    >
+      <div className="grid grid-cols-7 bg-muted/30">
+        {CALENDAR_WEEKDAY_LABELS.map((label) => (
+          <div key={label} className="border-r px-2 py-1.5 last:border-r-0">
+            <Skeleton className="h-3 w-8" />
+          </div>
+        ))}
+      </div>
+
+      {Array.from({ length: CALENDAR_MONTH_WEEKS }, (_, week) => (
+        <div
+          key={`w-${week}`}
+          className="relative"
+          style={{ minHeight: CALENDAR_MONTH_MIN_ROW_PX }}
+        >
+          <div className="grid h-full grid-cols-7">
+            {CALENDAR_WEEKDAY_LABELS.map((label) => (
+              <div key={`w-${week}-${label}`} className="border-r border-t last:border-r-0">
+                <div
+                  className="flex items-start justify-end px-1.5 pt-1"
+                  style={{ height: CALENDAR_MONTH_DAY_HEADER_PX }}
+                >
+                  <Skeleton className="h-5 w-5 rounded-full" />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="pointer-events-none absolute inset-0">
+            {PLACEHOLDER_PILLS[week].map(({ startCol, span }, lane) => (
+              <div
+                key={`w-${week}-p-${startCol}`}
+                className="absolute"
+                style={{
+                  left: `calc(${(startCol / 7) * 100}% + 2px)`,
+                  width: `calc(${(span / 7) * 100}% - 4px)`,
+                  top:
+                    CALENDAR_MONTH_DAY_HEADER_PX +
+                    lane * (CALENDAR_MONTH_LANE_HEIGHT_PX + CALENDAR_MONTH_LANE_GAP_PX),
+                  height: CALENDAR_MONTH_LANE_HEIGHT_PX,
+                }}
+              >
+                <Skeleton className="h-full w-full rounded" />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthWeekRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarMonthWeekRow.tsx
@@ -1,0 +1,73 @@
+import {
+  CALENDAR_MONTH_DAY_HEADER_PX,
+  CALENDAR_MONTH_LANE_GAP_PX,
+  CALENDAR_MONTH_LANE_HEIGHT_PX,
+  CALENDAR_MONTH_MIN_ROW_PX,
+} from "@/shared/lib/calendar-constants";
+import CalendarMonthDayCell from "@/app/features/calendar/CalendarMonthDayCell";
+import CalendarMonthEventPill from "@/app/features/calendar/CalendarMonthEventPill";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+import type { MonthGridWeek } from "@/shared/types/calendar/month-grid-week";
+
+export interface CalendarMonthWeekRowProps {
+  week: MonthGridWeek;
+  onEventClick: (event: CalendarEvent) => void;
+  onOverflowClick: (dayIso: string) => void;
+}
+
+/**
+ * One Sunday-to-Saturday row.
+ *
+ * Two stacked layers: a 7-column grid of day cells for the chrome, and an
+ * absolutely-positioned layer of pills above it. Splitting them is what lets
+ * a single stay stretch across day boundaries instead of being chopped into
+ * one badge per cell.
+ *
+ * The row itself is the grid rather than wrapping one: a nested `h-full` grid
+ * resolves against an auto height and collapses to its content, which would
+ * strand each cell's "+N more" button up under the first lane of pills instead
+ * of at the bottom of the cell.
+ */
+export default function CalendarMonthWeekRow({
+  week,
+  onEventClick,
+  onOverflowClick,
+}: CalendarMonthWeekRowProps) {
+  const lanesHeight =
+    week.laneCount * (CALENDAR_MONTH_LANE_HEIGHT_PX + CALENDAR_MONTH_LANE_GAP_PX);
+
+  return (
+    <div
+      className="relative grid grid-cols-7"
+      style={{
+        minHeight: Math.max(
+          CALENDAR_MONTH_MIN_ROW_PX,
+          CALENDAR_MONTH_DAY_HEADER_PX + lanesHeight + CALENDAR_MONTH_LANE_HEIGHT_PX,
+        ),
+      }}
+      data-testid="calendar-month-week"
+      data-week-start={week.startIso}
+    >
+      {week.days.map((day) => (
+        <CalendarMonthDayCell
+          key={day.iso}
+          day={day}
+          overflowCount={week.overflowByDay[day.iso] ?? 0}
+          onOverflowClick={onOverflowClick}
+        />
+      ))}
+
+      {/* Pills float above the cells; the wrapper must not eat cell clicks. */}
+      <div className="pointer-events-none absolute inset-0">
+        {week.segments.map((segment) => (
+          <span
+            key={`${segment.event.id}-${week.startIso}`}
+            className="pointer-events-auto"
+          >
+            <CalendarMonthEventPill segment={segment} onClick={onEventClick} />
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarSkeleton.tsx
@@ -1,4 +1,5 @@
 import Skeleton from "@/shared/components/ui/Skeleton";
+import CalendarAgendaSkeleton from "@/app/features/calendar/CalendarAgendaSkeleton";
 import {
   CALENDAR_DAY_CELL_PX,
   CALENDAR_LABEL_COLUMN_PX,
@@ -21,15 +22,9 @@ export default function CalendarSkeleton({ rows = 4, days = 30 }: CalendarSkelet
   return (
     <div data-testid="calendar-skeleton">
       {/* Mobile: agenda list skeleton */}
-      <ul className="md:hidden space-y-3" aria-label="Loading agenda">
-        {Array.from({ length: rows }, (_, i) => (
-          <li key={`m-${i}`} className="border rounded-lg p-3 space-y-2">
-            <Skeleton className="h-4 w-32" />
-            <Skeleton className="h-3 w-48" />
-            <Skeleton className="h-3 w-24" />
-          </li>
-        ))}
-      </ul>
+      <div className="md:hidden">
+        <CalendarAgendaSkeleton rows={rows} />
+      </div>
 
       {/* Desktop: grid skeleton */}
       <div className="hidden md:block border rounded-lg overflow-hidden">

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarViewToggle.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarViewToggle.tsx
@@ -1,0 +1,51 @@
+import { CalendarDays, Rows3 } from "lucide-react";
+import { CALENDAR_VIEW_OPTIONS } from "@/shared/lib/calendar-constants";
+import type { CalendarView } from "@/shared/types/calendar/calendar-view";
+
+export interface CalendarViewToggleProps {
+  view: CalendarView;
+  onChange: (view: CalendarView) => void;
+}
+
+const ICONS = { month: CalendarDays, timeline: Rows3 } as const;
+
+/**
+ * `[Month | Timeline]` segmented control.
+ *
+ * The two views answer different questions — "what's happening this month"
+ * vs. "which room is free" — so this is a real mode switch, not a
+ * cosmetic preference. The choice lives in the URL so a shared link opens on
+ * the view the sender was looking at.
+ */
+export default function CalendarViewToggle({ view, onChange }: CalendarViewToggleProps) {
+  return (
+    <div
+      className="flex items-center rounded-md border p-0.5"
+      role="group"
+      aria-label="Calendar view"
+      data-testid="calendar-view-toggle"
+    >
+      {CALENDAR_VIEW_OPTIONS.map(({ value, label }) => {
+        const Icon = ICONS[value];
+        const active = view === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            onClick={() => onChange(value)}
+            className={
+              active
+                ? "flex h-8 items-center gap-1.5 rounded px-2.5 text-xs font-medium bg-primary text-primary-foreground"
+                : "flex h-8 items-center gap-1.5 rounded px-2.5 text-xs font-medium hover:bg-muted transition-colors"
+            }
+            aria-pressed={active}
+            data-testid={`calendar-view-${value}`}
+          >
+            <Icon size={14} aria-hidden="true" />
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarViewport.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarViewport.tsx
@@ -1,0 +1,31 @@
+import CalendarGrid from "@/app/features/calendar/CalendarGrid";
+import CalendarMonthGrid from "@/app/features/calendar/CalendarMonthGrid";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+import type { CalendarView } from "@/shared/types/calendar/calendar-view";
+
+export interface CalendarViewportProps {
+  view: CalendarView;
+  events: readonly CalendarEvent[];
+  /** Fetched window — the timeline draws exactly this range. */
+  fromIso: string;
+  toIso: string;
+  /** Any date inside the month the month view should show. */
+  anchorIso: string;
+  todayIso: string;
+}
+
+/** The desktop calendar body: whichever shape the current view asks for. */
+export default function CalendarViewport({
+  view,
+  events,
+  fromIso,
+  toIso,
+  anchorIso,
+  todayIso,
+}: CalendarViewportProps) {
+  if (view === "timeline") {
+    return <CalendarGrid events={events} fromIso={fromIso} toIso={toIso} />;
+  }
+
+  return <CalendarMonthGrid events={events} anchorIso={anchorIso} todayIso={todayIso} />;
+}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/calendar-utils.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/calendar-utils.ts
@@ -155,6 +155,17 @@ export function formatMonthYear(iso: string): string {
   return d.toLocaleString("en-US", { month: "long", year: "numeric", timeZone: "UTC" });
 }
 
+/** Format an ISO date as a full day label (e.g. "Thursday, September 3, 2026"). */
+export function formatDayLabel(iso: string): string {
+  return parseIsoDate(iso).toLocaleString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 /** Format a window as a compact range label (e.g. "May 2 – Aug 1, 2026"). */
 export function formatWindowLabel(fromIso: string, toExclusiveIso: string): string {
   const from = parseIsoDate(fromIso);

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/month-grid-utils.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/month-grid-utils.ts
@@ -1,0 +1,229 @@
+import {
+  CALENDAR_MONTH_MAX_LANES,
+  CALENDAR_MONTH_WEEKS,
+  CALENDAR_WEEK_LENGTH,
+} from "@/shared/lib/calendar-constants";
+import {
+  addDays,
+  daysBetween,
+  formatIsoDate,
+  formatMonthYear,
+  parseIsoDate,
+} from "@/app/features/calendar/calendar-utils";
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+import type { MonthEventSegment } from "@/shared/types/calendar/month-event-segment";
+import type { MonthGrid } from "@/shared/types/calendar/month-grid";
+import type { MonthGridDay } from "@/shared/types/calendar/month-grid-day";
+import type { MonthGridWeek } from "@/shared/types/calendar/month-grid-week";
+
+/**
+ * Pure helpers for the month view.
+ *
+ * Same string-first, UTC-anchored discipline as `calendar-utils`: dates are
+ * ISO `YYYY-MM-DD` and comparisons are lexicographic, which is exact for that
+ * format and immune to the timezone drift that bites date-only `Date` parsing.
+ *
+ * Event windows follow the API's half-open convention — `starts_on` is
+ * inclusive, `ends_on` is exclusive — so a day D is covered when
+ * `starts_on <= D < ends_on`.
+ */
+
+/** ISO date of the first day of the month containing `iso`. */
+export function startOfMonth(iso: string): string {
+  return `${iso.slice(0, 7)}-01`;
+}
+
+/** Shift an ISO date by whole months, clamping to the target month's length. */
+export function addMonths(iso: string, months: number): string {
+  const d = parseIsoDate(iso);
+  const target = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + months, 1),
+  );
+  // Day 0 of the following month is the last day of the target month.
+  const lastDay = new Date(
+    Date.UTC(target.getUTCFullYear(), target.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  target.setUTCDate(Math.min(d.getUTCDate(), lastDay));
+  return formatIsoDate(target);
+}
+
+/** The Sunday on or before `iso`. */
+export function startOfWeek(iso: string): string {
+  return addDays(iso, -parseIsoDate(iso).getUTCDay());
+}
+
+/**
+ * The fetch window backing the month view: the grid's first cell through one
+ * day past its last.
+ *
+ * The grid is always `CALENDAR_MONTH_WEEKS` rows tall. A variable row count
+ * would make the page jump by a whole row between months, and would leave the
+ * skeleton unable to mirror the loaded layout.
+ */
+export function monthGridWindow(anchorIso: string): { fromIso: string; toIso: string } {
+  const fromIso = startOfWeek(startOfMonth(anchorIso));
+  return {
+    fromIso,
+    toIso: addDays(fromIso, CALENDAR_MONTH_WEEKS * CALENDAR_WEEK_LENGTH),
+  };
+}
+
+/** Whether an event covers any day in the half-open range `[fromIso, toIso)`. */
+function overlapsWindow(event: CalendarEvent, fromIso: string, toIso: string): boolean {
+  return event.starts_on < toIso && event.ends_on > fromIso;
+}
+
+/**
+ * Order segments so the layout is stable and reads top-down by start date.
+ *
+ * Longer stays sort above shorter ones that start the same day: a bar that
+ * runs the width of the week makes a better anchor line than one that stops
+ * on Tuesday, and keeping it in a low lane avoids a ragged first row.
+ */
+function compareForLanes(a: CalendarEvent, b: CalendarEvent): number {
+  if (a.starts_on !== b.starts_on) return a.starts_on < b.starts_on ? -1 : 1;
+  const aDays = daysBetween(a.starts_on, a.ends_on);
+  const bDays = daysBetween(b.starts_on, b.ends_on);
+  if (aDays !== bDays) return bDays - aDays;
+  return a.id < b.id ? -1 : 1;
+}
+
+function clipToWeek(
+  event: CalendarEvent,
+  weekStartIso: string,
+  weekEndIso: string,
+): Omit<MonthEventSegment, "lane"> | null {
+  const startIso = event.starts_on < weekStartIso ? weekStartIso : event.starts_on;
+  const endIso = event.ends_on > weekEndIso ? weekEndIso : event.ends_on;
+  const span = daysBetween(startIso, endIso);
+  if (span <= 0) return null;
+  return {
+    event,
+    startCol: daysBetween(weekStartIso, startIso),
+    span,
+    continuesBefore: event.starts_on < weekStartIso,
+    continuesAfter: event.ends_on > weekEndIso,
+  };
+}
+
+/**
+ * Pack one week's segments into horizontal lanes.
+ *
+ * Classic interval partitioning: walk the segments in order and drop each into
+ * the first lane whose last segment has already ended. Segments beyond
+ * `maxLanes` are not drawn — they are counted per day instead, so the cell can
+ * offer a "+N more" affordance rather than silently losing a booking.
+ */
+export function assignLanes(
+  segments: readonly Omit<MonthEventSegment, "lane">[],
+  weekStartIso: string,
+  maxLanes: number = CALENDAR_MONTH_MAX_LANES,
+): { placed: MonthEventSegment[]; overflowByDay: Record<string, number>; laneCount: number } {
+  const laneNextFreeCol: number[] = [];
+  const placed: MonthEventSegment[] = [];
+  const overflowByDay: Record<string, number> = {};
+
+  for (const segment of segments) {
+    let lane = laneNextFreeCol.findIndex((nextFree) => nextFree <= segment.startCol);
+    if (lane === -1) {
+      lane = laneNextFreeCol.length;
+      laneNextFreeCol.push(0);
+    }
+    laneNextFreeCol[lane] = segment.startCol + segment.span;
+
+    if (lane < maxLanes) {
+      placed.push({ ...segment, lane });
+      continue;
+    }
+
+    // Past the budget: give the day cells a count to surface instead.
+    for (let i = 0; i < segment.span; i += 1) {
+      const iso = addDays(weekStartIso, segment.startCol + i);
+      overflowByDay[iso] = (overflowByDay[iso] ?? 0) + 1;
+    }
+  }
+
+  return {
+    placed,
+    overflowByDay,
+    laneCount: Math.min(laneNextFreeCol.length, maxLanes),
+  };
+}
+
+function buildDay(iso: string, anchorMonth: string, todayIso: string): MonthGridDay {
+  return {
+    iso,
+    dayOfMonth: parseIsoDate(iso).getUTCDate(),
+    isInAnchorMonth: iso.slice(0, 7) === anchorMonth,
+    isToday: iso === todayIso,
+  };
+}
+
+function buildWeek(
+  weekStartIso: string,
+  events: readonly CalendarEvent[],
+  anchorMonth: string,
+  todayIso: string,
+  maxLanes: number,
+): MonthGridWeek {
+  const weekEndIso = addDays(weekStartIso, CALENDAR_WEEK_LENGTH);
+
+  const clipped = events
+    .filter((event) => overlapsWindow(event, weekStartIso, weekEndIso))
+    .sort(compareForLanes)
+    .map((event) => clipToWeek(event, weekStartIso, weekEndIso))
+    .filter((segment): segment is Omit<MonthEventSegment, "lane"> => segment !== null);
+
+  const { placed, overflowByDay, laneCount } = assignLanes(clipped, weekStartIso, maxLanes);
+
+  return {
+    startIso: weekStartIso,
+    days: Array.from({ length: CALENDAR_WEEK_LENGTH }, (_, i) =>
+      buildDay(addDays(weekStartIso, i), anchorMonth, todayIso),
+    ),
+    segments: placed,
+    overflowByDay,
+    laneCount,
+  };
+}
+
+/**
+ * Lay out the month containing `anchorIso`.
+ *
+ * `events` may span more than the grid — anything outside is filtered per
+ * week, so passing the whole fetched window is fine.
+ */
+export function buildMonthGrid(
+  anchorIso: string,
+  events: readonly CalendarEvent[],
+  todayIso: string,
+  maxLanes: number = CALENDAR_MONTH_MAX_LANES,
+): MonthGrid {
+  const { fromIso, toIso } = monthGridWindow(anchorIso);
+  const anchorMonth = anchorIso.slice(0, 7);
+
+  return {
+    gridStartIso: fromIso,
+    gridEndIso: toIso,
+    monthLabel: formatMonthYear(startOfMonth(anchorIso)),
+    weeks: Array.from({ length: CALENDAR_MONTH_WEEKS }, (_, i) =>
+      buildWeek(
+        addDays(fromIso, i * CALENDAR_WEEK_LENGTH),
+        events,
+        anchorMonth,
+        todayIso,
+        maxLanes,
+      ),
+    ),
+  };
+}
+
+/** Events covering `dayIso`, ordered the same way the grid lays them out. */
+export function eventsOnDay(
+  events: readonly CalendarEvent[],
+  dayIso: string,
+): CalendarEvent[] {
+  return events
+    .filter((event) => event.starts_on <= dayIso && event.ends_on > dayIso)
+    .sort(compareForLanes);
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/Calendar.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Calendar.tsx
@@ -11,19 +11,27 @@ import { useGetPropertiesQuery } from "@/shared/store/propertiesApi";
 import { useGetListingsQuery } from "@/shared/store/listingsApi";
 import {
   CALENDAR_DEFAULT_WINDOW_DAYS,
+  parseCalendarView,
 } from "@/shared/lib/calendar-constants";
 import {
   addDays,
   formatIsoDate,
 } from "@/app/features/calendar/calendar-utils";
-import CalendarSkeleton from "@/app/features/calendar/CalendarSkeleton";
-import CalendarGrid from "@/app/features/calendar/CalendarGrid";
+import {
+  monthGridWindow,
+  startOfMonth,
+} from "@/app/features/calendar/month-grid-utils";
+import CalendarLoadingState from "@/app/features/calendar/CalendarLoadingState";
+import CalendarViewport from "@/app/features/calendar/CalendarViewport";
 import CalendarAgendaList from "@/app/features/calendar/CalendarAgendaList";
 import CalendarLegend from "@/app/features/calendar/CalendarLegend";
 import CalendarSourceFilter from "@/app/features/calendar/CalendarSourceFilter";
+import CalendarMonthNav from "@/app/features/calendar/CalendarMonthNav";
 import CalendarWindowNav from "@/app/features/calendar/CalendarWindowNav";
+import CalendarViewToggle from "@/app/features/calendar/CalendarViewToggle";
 import CalendarLastSynced from "@/app/features/calendar/CalendarLastSynced";
 import ReviewQueueDrawer from "@/app/features/calendar/ReviewQueueDrawer";
+import type { CalendarView } from "@/shared/types/calendar/calendar-view";
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -49,10 +57,17 @@ export default function Calendar() {
   const [isQueueOpen, setIsQueueOpen] = useState(false);
   const { data: pendingCount = 0 } = useGetReviewQueueCountQuery();
 
-  // Resolve the current window from URL, defaulting to today → today + 30.
-  const fromIso = parseIsoOrNull(searchParams.get("from")) ?? todayIso();
-  const toIso =
-    parseIsoOrNull(searchParams.get("to")) ?? addDays(fromIso, CALENDAR_DEFAULT_WINDOW_DAYS);
+  // `from` is the anchor in both views: the window start for the timeline,
+  // the month to display for the month grid. The month view derives its own
+  // fetch window (whole weeks around that month) and ignores `to`.
+  const view = parseCalendarView(searchParams.get("view"));
+  const anchorIso = parseIsoOrNull(searchParams.get("from")) ?? todayIso();
+  const timelineToIso =
+    parseIsoOrNull(searchParams.get("to")) ?? addDays(anchorIso, CALENDAR_DEFAULT_WINDOW_DAYS);
+
+  const monthWindow = monthGridWindow(anchorIso);
+  const fromIso = view === "month" ? monthWindow.fromIso : anchorIso;
+  const toIso = view === "month" ? monthWindow.toIso : timelineToIso;
 
   // Memoize the filter arrays so the query cache key stays referentially
   // stable across renders that don't change the URL — without this, the
@@ -98,9 +113,36 @@ export default function Calendar() {
     setSearchParams(params, { replace: true });
   }
 
+  /** Month view: `from` is the anchor month and `to` doesn't apply. */
+  function updateAnchorMonth(nextAnchorIso: string) {
+    const params = new URLSearchParams(searchParams);
+    params.set("from", startOfMonth(nextAnchorIso));
+    params.delete("to");
+    setSearchParams(params, { replace: true });
+  }
+
   function handleToday() {
     const today = todayIso();
+    if (view === "month") {
+      updateAnchorMonth(today);
+      return;
+    }
     updateWindow(today, addDays(today, CALENDAR_DEFAULT_WINDOW_DAYS));
+  }
+
+  function handleViewChange(nextView: CalendarView) {
+    const params = new URLSearchParams(searchParams);
+    params.set("view", nextView);
+    if (nextView === "month") {
+      // Land on the month the operator was already looking at.
+      params.set("from", startOfMonth(anchorIso));
+      params.delete("to");
+    } else {
+      // Open the timeline on the same date, at its own default width.
+      params.set("from", anchorIso);
+      params.set("to", addDays(anchorIso, CALENDAR_DEFAULT_WINDOW_DAYS));
+    }
+    setSearchParams(params, { replace: true });
   }
 
   function handlePropertiesChange(ids: string[]) {
@@ -164,12 +206,21 @@ export default function Calendar() {
       <ReviewQueueDrawer isOpen={isQueueOpen} onClose={() => setIsQueueOpen(false)} />
 
       <div className="flex flex-wrap items-center gap-3">
-        <CalendarWindowNav
-          fromIso={fromIso}
-          toIso={toIso}
-          onChange={updateWindow}
-          onToday={handleToday}
-        />
+        {view === "month" ? (
+          <CalendarMonthNav
+            anchorIso={anchorIso}
+            onChange={updateAnchorMonth}
+            onToday={handleToday}
+          />
+        ) : (
+          <CalendarWindowNav
+            fromIso={fromIso}
+            toIso={toIso}
+            onChange={updateWindow}
+            onToday={handleToday}
+          />
+        )}
+        <CalendarViewToggle view={view} onChange={handleViewChange} />
         <PropertyMultiSelect
           properties={properties}
           selectedIds={selectedPropertyIds}
@@ -200,7 +251,7 @@ export default function Calendar() {
       ) : null}
 
       {isLoading ? (
-        <CalendarSkeleton />
+        <CalendarLoadingState view={view} />
       ) : hasNoListings && isEmpty ? (
         // A tenancy can exist with no listing behind it, so "no listings" is
         // only the right story when there's also nothing to show. Otherwise
@@ -222,7 +273,14 @@ export default function Calendar() {
       ) : (
         <>
           <div className="hidden md:block" data-testid="calendar-desktop">
-            <CalendarGrid events={eventsList} fromIso={fromIso} toIso={toIso} />
+            <CalendarViewport
+              view={view}
+              events={eventsList}
+              fromIso={fromIso}
+              toIso={toIso}
+              anchorIso={anchorIso}
+              todayIso={todayIso()}
+            />
           </div>
           <div className="md:hidden" data-testid="calendar-mobile">
             <CalendarAgendaList events={eventsList} />

--- a/apps/mybookkeeper/frontend/src/shared/lib/calendar-constants.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/calendar-constants.ts
@@ -1,4 +1,5 @@
 import type { CalendarSource } from "@/shared/types/calendar/calendar-source";
+import type { CalendarView } from "@/shared/types/calendar/calendar-view";
 
 /**
  * Fixed grid sizing for the unified calendar grid.
@@ -40,6 +41,55 @@ export const CALENDAR_WINDOW_PRESETS: ReadonlyArray<{ label: string; days: numbe
   { label: "3 mo", days: 90 },
   { label: "6 mo", days: 180 },
   { label: "Year", days: 365 },
+];
+
+/**
+ * Month-view geometry.
+ *
+ * The month grid is fluid — columns are sevenths of the available width, not
+ * fixed pixels — so only the vertical rhythm is pinned here. The row count is
+ * fixed at 6 so the page doesn't jump by a whole row between a 4-week-ish
+ * February and a 6-row March, and so the skeleton can mirror the loaded
+ * layout exactly.
+ */
+export const CALENDAR_WEEK_LENGTH = 7;
+export const CALENDAR_MONTH_WEEKS = 6;
+/** Event rows drawn per week before a day falls back to "+N more". */
+export const CALENDAR_MONTH_MAX_LANES = 4;
+export const CALENDAR_MONTH_LANE_HEIGHT_PX = 20;
+export const CALENDAR_MONTH_LANE_GAP_PX = 2;
+/** Space reserved at the top of a cell for the day number. */
+export const CALENDAR_MONTH_DAY_HEADER_PX = 24;
+/** Floor on week-row height so a quiet week still reads as a week. */
+export const CALENDAR_MONTH_MIN_ROW_PX = 104;
+
+/**
+ * The two calendar shapes, in toggle order. `month` is the default — it is
+ * the shape people already read fluently — and `timeline` stays available
+ * for the per-listing question the month grid can't answer.
+ */
+export const CALENDAR_VIEW_OPTIONS: ReadonlyArray<{ value: CalendarView; label: string }> = [
+  { value: "month", label: "Month" },
+  { value: "timeline", label: "Timeline" },
+];
+
+export const CALENDAR_DEFAULT_VIEW: CalendarView = "month";
+
+export function parseCalendarView(raw: string | null): CalendarView {
+  return CALENDAR_VIEW_OPTIONS.some((o) => o.value === raw)
+    ? (raw as CalendarView)
+    : CALENDAR_DEFAULT_VIEW;
+}
+
+/** Column headings, Sunday-first to match `Date#getUTCDay`. */
+export const CALENDAR_WEEKDAY_LABELS: readonly string[] = [
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
 ];
 
 /**

--- a/apps/mybookkeeper/frontend/src/shared/types/calendar/calendar-view.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/calendar/calendar-view.ts
@@ -1,0 +1,9 @@
+/**
+ * Which shape the calendar is drawn in.
+ *
+ * `month` is the familiar seven-column grid and answers "what's happening
+ * this month". `timeline` is one row per listing and answers "which room is
+ * free" — a question the month shape can't, since a cell stacks every listing
+ * together.
+ */
+export type CalendarView = "month" | "timeline";

--- a/apps/mybookkeeper/frontend/src/shared/types/calendar/month-event-segment.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/calendar/month-event-segment.ts
@@ -1,0 +1,24 @@
+import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
+
+/**
+ * One event clipped to one week row.
+ *
+ * A stay that crosses a Saturday produces two segments — one per week —
+ * so each can be positioned inside its own row. `continuesBefore` /
+ * `continuesAfter` tell the pill which ends to leave square, which is how
+ * a reader distinguishes "this stay starts Monday" from "this stay was
+ * already running when the week began".
+ */
+export interface MonthEventSegment {
+  event: CalendarEvent;
+  /** Column index within the week, 0 (Sunday) – 6 (Saturday). */
+  startCol: number;
+  /** Number of columns covered, 1 – 7. */
+  span: number;
+  /** The event started before this week's Sunday. */
+  continuesBefore: boolean;
+  /** The event runs past this week's Saturday. */
+  continuesAfter: boolean;
+  /** Vertical slot within the week row; 0 is the topmost. */
+  lane: number;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/calendar/month-grid-day.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/calendar/month-grid-day.ts
@@ -1,0 +1,10 @@
+/** One day cell in the month grid. */
+export interface MonthGridDay {
+  /** ISO `YYYY-MM-DD`. */
+  iso: string;
+  /** Day-of-month number, pre-computed so the cell needn't re-parse. */
+  dayOfMonth: number;
+  /** False for the leading/trailing days borrowed from the adjacent months. */
+  isInAnchorMonth: boolean;
+  isToday: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/calendar/month-grid-week.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/calendar/month-grid-week.ts
@@ -1,0 +1,19 @@
+import type { MonthEventSegment } from "@/shared/types/calendar/month-event-segment";
+import type { MonthGridDay } from "@/shared/types/calendar/month-grid-day";
+
+/** One Sunday-to-Saturday row of the month grid. */
+export interface MonthGridWeek {
+  /** ISO date of this row's Sunday — stable React key. */
+  startIso: string;
+  /** Exactly 7 days. */
+  days: MonthGridDay[];
+  /** Segments that fit within the visible lane budget. */
+  segments: MonthEventSegment[];
+  /**
+   * Per-day count of events pushed past the lane budget, keyed by ISO date.
+   * Days with nothing hidden are absent rather than zero.
+   */
+  overflowByDay: Record<string, number>;
+  /** Lanes actually drawn — drives the row's height. */
+  laneCount: number;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/calendar/month-grid.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/calendar/month-grid.ts
@@ -1,0 +1,12 @@
+import type { MonthGridWeek } from "@/shared/types/calendar/month-grid-week";
+
+/** A full month view: the anchor month padded out to whole weeks. */
+export interface MonthGrid {
+  /** ISO date of the first cell (the Sunday on or before the 1st). */
+  gridStartIso: string;
+  /** ISO date one day past the last cell — exclusive, iCal convention. */
+  gridEndIso: string;
+  /** e.g. "September 2026". */
+  monthLabel: string;
+  weeks: MonthGridWeek[];
+}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -432,8 +432,10 @@
       "frontend_tests": [
         "Calendar.test.tsx",
         "calendar-utils.test.ts",
+        "month-grid-utils.test.ts",
         "CalendarEventDetail.test.tsx",
         "CalendarLeaseEvent.test.tsx",
+        "CalendarMonthGrid.test.tsx",
         "CalendarUnlinkedLease.test.tsx",
         "ReviewQueueItem.test.tsx",
         "ReviewQueueDrawer.test.tsx"
@@ -441,6 +443,7 @@
       "e2e_specs": [
         "calendar.spec.ts",
         "calendar-lease-events.spec.ts",
+        "calendar-month-view.spec.ts",
         "calendar-unlinked-lease.spec.ts",
         "calendar-booking-notes.spec.ts",
         "calendar-review-queue-resolve.spec.ts"


### PR DESCRIPTION
Follow-up to #1057. That PR fixed *which* leases the calendar shows; this one changes *how* the calendar looks.

## Why

The calendar opened on a resource timeline — one row per listing, days as fixed 44px columns. It answers "which room is free on the 14th", but it reads nothing like a calendar, and a window wider than a couple of weeks pushes the page sideways.

## What changed

The month grid is now the default: a SUN–SAT, six-row grid where a stay is one pill spanning the days it covers. The timeline is still available behind a `[Month | Timeline]` toggle, and the choice lives in the URL (`?view=timeline`), so a shared link opens on whatever the sender was looking at.

- **Fluid columns.** Sevenths of the row width rather than pixels, so the month grid never scrolls horizontally at any viewport.
- **Lane packing.** Segments are placed by interval partitioning. Past a four-lane budget the day gets a "+N more" button rather than an unreadable stack; it opens a dialog listing *every* booking on that day, so an overflowed stay is never silently dropped.
- **Week-crossing stays.** A stay that crosses a Saturday becomes two segments, one per week, with the continuing ends squared off — a rounded end always means the stay actually starts or stops there.
- **Navigation.** Prev/next step by whole months in month view and by window length in timeline view; "Today" is view-aware. Both views get a skeleton that mirrors their own loaded layout.

Date handling stays string-first and UTC-anchored, matching `calendar-utils`: ISO comparisons are lexicographic (exact for `YYYY-MM-DD`) and immune to the timezone drift that bites date-only `Date` parsing. Event windows keep the API's half-open convention, so day D is covered when `starts_on <= D < ends_on`.

## Tests

- `month-grid-utils.test.ts` — 20 tests over the layout maths (month arithmetic and clamping, week windows, clipping, lane assignment, overflow counting).
- `CalendarMonthGrid.test.tsx` — 11 tests over the rendered grid.
- `Calendar.test.tsx` — existing timeline-shaped tests retargeted at `?view=timeline`, since month is now the default.
- `calendar-month-view.spec.ts` — E2E covering the default view, the pill's detail dialog, month stepping, the toggle surviving a reload, and the overflow affordance.

The overflow E2E **clicks** the "+N more" button rather than asserting it renders. That is deliberate: the pill layer is painted over the day cells, so a mispositioned button is visible but unclickable — a failure jsdom cannot see. It caught a real bug during this PR (the day cell's nested `h-full` grid collapsed to content height, stranding the button under the first lane of pills).

## Verification

Ran against the local stack (PG18 :5433, MinIO :9000, API :8000, Vite :5173):

- 86 unit tests pass across the five calendar test files; `tsc --noEmit` and eslint clean.
- All calendar E2E specs pass. `calendar-booking-notes.spec.ts`'s attachment test fails with a strict-mode locator violation — confirmed pre-existing by stashing this branch and re-running against a clean tree.
- Eyeballed the rendered month grid in light and dark mode, plus the "+N more" overflow and its day dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGrPnfsGueqXN6dVzHQpiw
