### PR TITLE
fix(ci): un-own dependency manifests so Dependabot auto-merge can land

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,32 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 * @jykwon91
+
+# --- Dependency manifests: deliberately un-owned ---------------------------
+#
+# `main` enforces require_code_owner_reviews. CODEOWNERS accepts users and
+# teams but never GitHub App identities, so the `github-actions[bot]` approval
+# that .github/workflows/dependabot-auto-merge.yml casts can satisfy the
+# 1-approving-review rule yet never satisfy the code-owner rule. The result was
+# every Dependabot PR sitting with auto-merge enabled and permanently blocked on
+# REVIEW_REQUIRED — 30 of them had queued up by 2026-08-11.
+#
+# The entries below match a pattern with NO owner, which removes ownership for
+# those paths (last matching pattern wins). A PR touching only dependency
+# manifests therefore has no code owner, the bot approval is sufficient, and
+# auto-merge lands it. A PR touching any source file still matches `* @jykwon91`
+# above and still requires your review.
+#
+# `.github/workflows/**` is deliberately ABSENT from this list. Dependabot also
+# bumps GitHub Action SHAs, and workflow files are the supply-chain vector worth
+# keeping a human on — those PRs stay gated on your review by design.
+#
+# Keep in sync with .github/dependabot.yml's ecosystem directories.
+
+package.json
+package-lock.json
+**/package.json
+**/package-lock.json
+**/pyproject.toml
+**/requirements*.txt
+**/uv.lock


### PR DESCRIPTION
## Problem

Dependabot auto-merge has **never merged a PR**. 30 were open as of 2026-08-11, oldest #1018 from 2026-08-01.

The workflow from #937 is not failing — it runs green, `github-actions[bot]` approves, and `gh pr merge --auto` gets enabled (`autoMergeRequest` is set on #1053 and #1035). The PRs then sit blocked forever on `REVIEW_REQUIRED`.

Every Dependabot PR previously believed to have auto-merged — #952-954 (Jul 1), #923-933 (Jun 26-27) — was in fact merged by `jykwon91` by hand. That masked the failure until an unattended batch piled up.

## Root cause

Not the approve step. `main` enforces `require_code_owner_reviews: true`, and `.github/CODEOWNERS` was a bare:

```
* @jykwon91
```

So every file demands a review from that specific user. CODEOWNERS accepts users and teams but **never GitHub App identities**, so `github-actions[bot]`'s approval satisfies `required_approving_review_count: 1` and can never satisfy the code-owner rule. Auto-merge stays enabled-but-blocked.

This is precisely the "enable then block forever" scenario `dependabot-auto-merge.yml`'s header comment warns about — it just attributes it to a missing approval rather than to CODEOWNERS.

## Fix

Add a pattern with **no owner** for dependency manifests. Last matching pattern wins, so those paths become un-owned; a PR touching only manifests has no code owner, the code-owner rule is vacuously satisfied, the bot approval covers the count rule, and auto-merge lands it.

Covers the 28 tracked manifests across all 6 apps, both shared packages, and the scaffold template: `package.json`, `package-lock.json`, `pyproject.toml`, `requirements*.txt`, `uv.lock`.

Any PR touching a source file still matches `* @jykwon91` above and still requires your review.

## Deliberately excluded

`.github/workflows/**` stays owned. Dependabot also bumps GitHub Action SHAs (e.g. #1032, which rewrites 18 workflow files), and workflow files are the supply-chain vector worth keeping a human on. Those PRs remain gated on review by design.

## Verification

- `gh api repos/jykwon91/MyFreeApps/codeowners/errors?ref=fix/codeowners-dependabot-manifests` → `{"errors":[]}`
- Post-merge check: an open Dependabot PR that touches only manifests (e.g. #1053, `package-lock.json` only) should flip `reviewDecision` from `REVIEW_REQUIRED` to `APPROVED` and auto-merge on green.

## Note on drain rate

`required_status_checks.strict: true` means each PR must be up to date with `main` before merging, so the 30-PR backlog will drain roughly one at a time — each merge staleness-invalidates the rest and forces a Dependabot rebase plus a full CI re-run. Expected, not a defect; just don't expect all 30 to clear at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGrPnfsGueqXN6dVzHQpiw