### PR TITLE
feat(mybookkeeper): read utility plan terms from an uploaded document

### DIFF
--- a/apps/mybookkeeper/backend/app/api/utility_plans.py
+++ b/apps/mybookkeeper/backend/app/api/utility_plans.py
@@ -12,19 +12,23 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
 from app.core.context import RequestContext
 from app.core.permissions import current_org_member, require_write_access
+from app.core.rate_limit import utility_plan_extract_limiter
 from app.core.utility_plan_constants import EXPIRING_SOON_DAYS
 from app.schemas.properties.utility_plan_create_request import UtilityPlanCreateRequest
+from app.schemas.properties.utility_plan_draft import UtilityPlanDraft
+from app.schemas.properties.utility_plan_extract_request import UtilityPlanExtractRequest
 from app.schemas.properties.utility_plan_list_response import UtilityPlanListResponse
 from app.schemas.properties.utility_plan_renewal_alert_response import (
     UtilityPlanRenewalAlertResponse,
 )
 from app.schemas.properties.utility_plan_response import UtilityPlanResponse
 from app.schemas.properties.utility_plan_update_request import UtilityPlanUpdateRequest
-from app.services.properties import utility_plan_service
+from app.services.properties import utility_plan_extraction_service, utility_plan_service
 
 router = APIRouter(prefix="/utility-plans", tags=["utility-plans"])
 
 _NOT_FOUND_DETAIL = "Utility plan not found"
+_DOCUMENT_NOT_FOUND_DETAIL = "Document not found"
 
 
 @router.post("", response_model=UtilityPlanResponse, status_code=201)
@@ -39,6 +43,32 @@ async def create_plan(
             fields=payload.model_dump(),
         )
     except utility_plan_service.InvalidUtilityPlanError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.post("/extract", response_model=UtilityPlanDraft)
+async def extract_plan_from_document(
+    payload: UtilityPlanExtractRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> UtilityPlanDraft:
+    """Read plan terms out of a document the caller already uploaded.
+
+    Nothing is saved — the response prefills the create form, and the operator
+    still reviews it. Declared before ``/{plan_id}`` so the literal path is not
+    swallowed by the UUID route.
+    """
+    utility_plan_extract_limiter.check(f"utility-plan-extract:{ctx.user_id}")
+    try:
+        return await utility_plan_extraction_service.extract_plan_from_document(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            document_id=payload.document_id,
+        )
+    except utility_plan_extraction_service.DocumentNotFoundError as exc:
+        raise HTTPException(
+            status_code=404, detail=_DOCUMENT_NOT_FOUND_DETAIL,
+        ) from exc
+    except utility_plan_extraction_service.UnreadableDocumentError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 

--- a/apps/mybookkeeper/backend/app/core/rate_limit.py
+++ b/apps/mybookkeeper/backend/app/core/rate_limit.py
@@ -48,6 +48,7 @@ __all__ = [
     "register_limiter",
     "password_reset_limiter",
     "export_limiter",
+    "utility_plan_extract_limiter",
     "frontend_error_limiter",
     "require_turnstile",
     "check_login_rate_limit",
@@ -68,6 +69,10 @@ totp_limiter = RateLimiter(max_attempts=20, window_seconds=300)
 register_limiter = RateLimiter(max_attempts=5, window_seconds=3600)
 password_reset_limiter = RateLimiter(max_attempts=5, window_seconds=3600)
 export_limiter = RateLimiter(max_attempts=20, window_seconds=3600)
+# Each call is a paid model request against a document the caller already has.
+# The daily upload cap bounds how many distinct documents exist but not how
+# many times one is re-read, so this bounds the re-reads.
+utility_plan_extract_limiter = RateLimiter(max_attempts=30, window_seconds=3600)
 frontend_error_limiter = RateLimiter(max_attempts=50, window_seconds=3600)
 
 

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_draft.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_draft.py
@@ -1,0 +1,69 @@
+"""Schema for the body of ``POST /utility-plans/extract``.
+
+Deliberately NOT a ``UtilityPlanCreateRequest``. A draft is what a document
+appeared to say; a create request is what the operator asserts is true. Three
+differences follow from that:
+
+- Every field is optional, including the ones a real plan requires. A document
+  that never names its provider produces a draft with no provider, and the form
+  asks for it — better than a 422 that discards everything else it did read.
+- No cross-field validation. ``validate_plan_fields`` rejects a bill credit
+  with no threshold; a document that states one and omits the other is exactly
+  the case the operator needs to see and fix, not have thrown away.
+- It carries ``warnings`` and ``unrepresented``, which describe the reading
+  rather than the plan, and have nowhere to live on a stored row.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class UtilityPlanDraft(BaseModel):
+    """A plan as read from a document — not yet saved, not yet validated."""
+
+    source_document_id: uuid.UUID
+
+    service_type: str | None = None
+    provider_name: str | None = None
+    plan_name: str | None = None
+    account_number: str | None = None
+    rate_type: str | None = None
+
+    energy_charge_cents_per_kwh: Decimal | None = None
+    tdu_charge_cents_per_kwh: Decimal | None = None
+    avg_price_cents_per_kwh_at_1000: Decimal | None = None
+    monthly_base_charge_cents: int | None = None
+
+    term_months: int | None = None
+    service_start_date: _dt.date | None = None
+    term_end_date: _dt.date | None = None
+    early_termination_fee_cents: int | None = None
+
+    has_bill_credit: bool = False
+    bill_credit_amount_cents: int | None = None
+    bill_credit_threshold_kwh: int | None = None
+    min_usage_fee_cents: int | None = None
+    min_usage_threshold_kwh: int | None = None
+
+    post_promo_monthly_cents: int | None = None
+    equipment_fee_monthly_cents: int | None = None
+    download_mbps: int | None = None
+    upload_mbps: int | None = None
+    data_cap_gb: int | None = None
+
+    notes: str | None = None
+
+    confidence: str = "low"
+    """How much of this came off the page rather than out of interpretation."""
+
+    warnings: list[str] = Field(default_factory=list)
+    """Reasons to distrust a specific field, e.g. a TDU rate from a stale EFL."""
+
+    unrepresented: list[str] = Field(default_factory=list)
+    """Real terms the schema has no column for. Dropping these silently would
+    make the plan look simpler than it is — the operator can paste them into
+    ``notes`` before saving."""

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_extract_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_extract_request.py
@@ -1,0 +1,20 @@
+"""Schema for ``POST /utility-plans/extract``."""
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class UtilityPlanExtractRequest(BaseModel):
+    """Names an already-uploaded document to read plan terms out of.
+
+    The document is uploaded through ``POST /documents/upload`` first rather
+    than posted here, so there is exactly one path that enforces the size cap,
+    the daily rate limit, and the content sniff — and so the resulting draft can
+    cite a document that actually exists.
+    """
+
+    document_id: uuid.UUID
+
+    model_config = ConfigDict(extra="forbid")

--- a/apps/mybookkeeper/backend/app/services/extraction/claude_service.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/claude_service.py
@@ -34,6 +34,7 @@ from app.db.session import AsyncSessionLocal
 from app.repositories import extraction_prompt_repo
 from app.services.extraction.prompts.base_prompt import DEFAULT_PROMPT
 from app.services.extraction.prompts.document_type_addendums import get_addendum_for_filename
+from app.services.extraction.prompts.utility_plan_prompt import UTILITY_PLAN_PROMPT
 from app.services.system.event_service import record_event
 from platform_shared.extraction import (
     ExtractionParseError,
@@ -54,6 +55,7 @@ __all__ = [
     "extract_from_text",
     "extract_from_image",
     "extract_from_email",
+    "run_utility_plan_extraction",
     "_create_with_backoff",
     "_ThrottleState",
     "_throttle",
@@ -246,6 +248,48 @@ async def extract_from_image(image_bytes: bytes, media_type: str, user_id: uuid.
     except ExtractionParseError:
         return _legacy_fallback()
     return _to_legacy(resp)
+
+
+async def run_utility_plan_extraction(
+    *,
+    text: str | None = None,
+    image_bytes: bytes | None = None,
+    media_type: str | None = None,
+    user_id: uuid.UUID | None = None,
+) -> dict:
+    """Read utility plan terms with UTILITY_PLAN_PROMPT instead of DEFAULT_PROMPT.
+
+    Shares the client, throttle and 429 backoff with transaction extraction —
+    they are the same account's rate limit — but nothing else. In particular it
+    does NOT append the user's stored extraction rules: those are written about
+    categorizing transactions, and a rule like "always categorize Constellation
+    as utilities" applied to a plan reading is noise at best.
+
+    Returns the model's parsed JSON object, or ``{}`` when the response was not
+    parseable. The caller builds a draft from whatever fields survive, so an
+    empty dict degrades to an empty form rather than an error.
+    """
+    if not _extraction.is_configured():
+        logger.warning("utility plan extraction requested without an API key")
+        return {}
+    try:
+        if image_bytes is not None:
+            resp = await _extraction.extract_document(
+                UTILITY_PLAN_PROMPT,
+                image_bytes,
+                media_type or "application/pdf",
+                on_rate_limit=_record_rate_limited,
+            )
+        else:
+            resp = await _extraction.extract_text(
+                UTILITY_PLAN_PROMPT,
+                (text or "")[:settings.max_text_chars],
+                on_rate_limit=_record_rate_limited,
+            )
+    except ExtractionParseError:
+        logger.warning("utility plan extraction: model response was not JSON")
+        return {}
+    return resp.data if isinstance(resp.data, dict) else {}
 
 
 async def extract_from_email(subject: str, body: str, user_id: uuid.UUID | None = None) -> dict:

--- a/apps/mybookkeeper/backend/app/services/extraction/prompts/utility_plan_prompt.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/prompts/utility_plan_prompt.py
@@ -1,0 +1,147 @@
+"""Prompt for reading a utility plan out of an EFL, bill, or enrollment notice.
+
+Deliberately separate from ``DEFAULT_PROMPT``. That prompt answers "what did
+this cost and how should it be categorized" — a transaction. This one answers
+"what are the terms I am on", which is a different question with a different
+shape: no amount, no date paid, no category, and a dozen fields the transaction
+prompt has never heard of.
+
+The instructions are written against Texas deregulated-electricity documents
+because that is what the data is, but the JSON contract covers gas, water and
+internet too.
+
+Two rules matter more than the rest, and both are about refusing to guess:
+
+1. **A missing value is null, never an inference.** These numbers drive
+   plan-vs-plan comparisons. A plausible-looking invented rate is worse than a
+   blank, because a blank is visibly unknown and a number is not.
+2. **Anything real that has no column goes in ``unrepresented``.** A second
+   bill-credit tier, a tiered TDU schedule, a bundled service — the schema
+   cannot hold it, so it has to be said out loud rather than dropped. Silence
+   would read as "the document did not mention it".
+"""
+
+UTILITY_PLAN_PROMPT = """You read utility service documents and report the plan terms they state.
+
+Typical inputs: a Texas Electricity Facts Label (EFL), an electricity or gas
+bill, an enrollment or plan-change notice, or an internet service agreement.
+
+Return ONLY a JSON object, no prose and no markdown fence, in this shape:
+
+{
+  "service_type": "electricity" | "natural_gas" | "water" | "internet" | null,
+  "provider_name": string | null,
+  "plan_name": string | null,
+  "account_number": string | null,
+  "rate_type": "fixed" | "variable" | "indexed" | "regulated" | null,
+
+  "energy_charge_cents_per_kwh": string | null,
+  "tdu_charge_cents_per_kwh": string | null,
+  "avg_price_cents_per_kwh_at_1000": string | null,
+  "monthly_base_charge_cents": integer | null,
+
+  "term_months": integer | null,
+  "service_start_date": "YYYY-MM-DD" | null,
+  "term_end_date": "YYYY-MM-DD" | null,
+  "early_termination_fee_cents": integer | null,
+
+  "has_bill_credit": boolean,
+  "bill_credit_amount_cents": integer | null,
+  "bill_credit_threshold_kwh": integer | null,
+  "min_usage_fee_cents": integer | null,
+  "min_usage_threshold_kwh": integer | null,
+
+  "post_promo_monthly_cents": integer | null,
+  "equipment_fee_monthly_cents": integer | null,
+  "download_mbps": integer | null,
+  "upload_mbps": integer | null,
+  "data_cap_gb": integer | null,
+
+  "document_issued_date": "YYYY-MM-DD" | null,
+  "confidence": "high" | "medium" | "low",
+  "notes": string | null,
+  "unrepresented": [string]
+}
+
+# Units, without exception
+
+- Fields ending in `_cents_per_kwh` are STRINGS with exactly four decimal
+  places: "10.0000", "5.1461". A rate of 5.3509 rounded to 5.35 misprices every
+  comparison built on it, so do not shorten.
+- Fields ending in `_cents` are INTEGERS of cents. $150.00 is 15000. $0.00 is 0.
+- Never return a currency symbol, a comma, or a percentage sign in any field.
+
+# Refusing to guess
+
+- If the document does not state a value, return null. Do not derive it, do not
+  carry it over from a similar plan, do not use a typical market figure.
+- `0` and `null` are different answers. An EFL that states "Minimum Usage Fee:
+  $0.00" means 0 — a recorded fact. An EFL that never mentions a minimum usage
+  fee means null. Report what the document did.
+- If the document is not a utility plan document at all, return every field
+  null, `has_bill_credit` false, `confidence` "low", and say so in `notes`.
+
+# Reading a Texas EFL
+
+- "Average Monthly Use" table: take the 1,000 kWh column into
+  `avg_price_cents_per_kwh_at_1000`. Ignore the 500 and 2,000 kWh columns; if
+  they reveal something the 1,000 figure hides (a steep tier), say so in
+  `notes`.
+- `energy_charge_cents_per_kwh` is the SUPPLIER's per-kWh charge only.
+- `tdu_charge_cents_per_kwh` is the utility's delivery charge (CenterPoint,
+  Oncor, AEP). Report it if stated, but it is a pass-through the utility
+  re-tariffs mid-term — so also set `document_issued_date` so the reader can
+  tell how stale it is. If the TDU charge is stated as a per-kWh rate plus a
+  fixed monthly amount, put the per-kWh part here and the monthly part in
+  `notes` — do not add them together.
+- `monthly_base_charge_cents` is the supplier's fixed monthly charge ("Base
+  Charge", "Monthly Service Fee"). If the EFL states it is $0, return 0.
+- Early termination fee: the flat amount, not "$20 per remaining month". If the
+  fee is per-month, leave `early_termination_fee_cents` null and describe it in
+  `notes` — a per-month fee stored as a flat one is simply wrong.
+- Usage bill credits: `bill_credit_amount_cents` is the credit, and
+  `bill_credit_threshold_kwh` is the usage at or above which it applies. If the
+  plan has MORE THAN ONE credit tier, report the lowest threshold's tier in the
+  fields and put every other tier in `unrepresented` — there is only one pair
+  of columns.
+- `rate_type`: "fixed" if the energy charge is fixed for the term, "variable"
+  if the price can change month to month, "indexed" if it tracks a published
+  index. Regulated gas and municipal water are "regulated".
+
+# Reading an internet document
+
+- `monthly_base_charge_cents` is the CURRENT monthly price — the promotional
+  price if one is running.
+- `post_promo_monthly_cents` is what it becomes when the promo ends. Only set
+  it if the document states a specific price; "then regular rates apply" with
+  no number is null plus a `notes` line.
+- `equipment_fee_monthly_cents` is modem/router/gateway rental, only when it is
+  billed separately from the monthly price.
+- Speeds are in Mbps. "1 Gig" / "1 Gbps" is 1000. "Up to 500 Mbps" is 500.
+- `data_cap_gb`: 1.2 TB is 1200. Unlimited is null, not 0.
+- Leave every `_kwh` field null — an internet plan does not price kilowatt-hours.
+
+# Reading a bill rather than a plan document
+
+A bill states usage and an amount owed, not contract terms. Extract only what
+it actually states about the plan — usually `provider_name`, `account_number`,
+`service_type`, and sometimes `plan_name` or a contract-end notice. Do NOT
+convert the bill's total into any rate field, and set `confidence` to "low"
+unless the bill genuinely restates the plan terms.
+
+# confidence
+
+- "high": the document is a plan document (EFL, agreement, enrollment notice)
+  and the fields were read directly off it.
+- "medium": a plan document that was partly illegible, or a bill that restated
+  the terms.
+- "low": a bill or notice that mostly implies the terms, or anything you had to
+  work to interpret.
+
+# unrepresented
+
+One plain sentence per real term you found that has no field above. Examples:
+"second bill credit of $15.00 for usage at or above 2,000 kWh", "TDU charge is
+tiered by season", "price includes bundled A/C and water-heater coverage".
+Return an empty list if everything the document stated fit.
+"""

--- a/apps/mybookkeeper/backend/app/services/properties/utility_plan_extraction_service.py
+++ b/apps/mybookkeeper/backend/app/services/properties/utility_plan_extraction_service.py
@@ -1,0 +1,295 @@
+"""Read a utility plan out of a document the operator already uploaded.
+
+Nothing here persists. The result is a draft the form prefills, so the operator
+still reviews and saves it — the model proposes, the operator asserts. That
+matters more than usual for this domain, because every field ends up in a
+plan-vs-plan comparison where a wrong number is indistinguishable from a right
+one.
+
+The document arrives by id, not by upload: ``POST /documents/upload`` already
+owns the size cap, the daily rate limit and the content sniff, and reusing it
+means the draft can cite a ``source_document_id`` that genuinely exists.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import uuid
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.core.storage import get_storage
+from app.core.utility_plan_constants import RATE_TYPES, SERVICE_TYPES
+from app.db.session import unit_of_work
+from app.repositories.documents import document_repo
+from app.schemas.properties.utility_plan_draft import UtilityPlanDraft
+from app.services.extraction.claude_service import run_utility_plan_extraction
+from app.services.extraction.extractor_service import (
+    extract_text_from_docx,
+    extract_text_from_pdf,
+    extract_text_from_spreadsheet,
+)
+
+logger = logging.getLogger(__name__)
+
+_CONFIDENCE_VALUES = frozenset({"high", "medium", "low"})
+
+# Below this, a PDF's embedded text layer is a scan artifact rather than the
+# document, and vision reads the page better. Same threshold the transaction
+# pipeline uses, for the same reason.
+_MIN_PDF_TEXT_CHARS = 50
+
+_RATE_FIELDS = (
+    "energy_charge_cents_per_kwh",
+    "tdu_charge_cents_per_kwh",
+    "avg_price_cents_per_kwh_at_1000",
+)
+_INT_FIELDS = (
+    "monthly_base_charge_cents",
+    "term_months",
+    "early_termination_fee_cents",
+    "bill_credit_amount_cents",
+    "bill_credit_threshold_kwh",
+    "min_usage_fee_cents",
+    "min_usage_threshold_kwh",
+    "post_promo_monthly_cents",
+    "equipment_fee_monthly_cents",
+    "download_mbps",
+    "upload_mbps",
+    "data_cap_gb",
+)
+_DATE_FIELDS = ("service_start_date", "term_end_date")
+_TEXT_FIELDS = ("provider_name", "plan_name", "account_number", "notes")
+
+# A TDU rate is a pass-through the utility re-tariffs mid-term, so the one
+# printed on an EFL is only true as of its issue date. Reading the 6734 EFL on
+# 2026-08-11 gave 6.0009 c/kWh against a then-current 5.1461 — a 0.85 c/kWh
+# error in every comparison, silently.
+_TDU_STALENESS_DAYS = 90
+
+
+class DocumentNotFoundError(LookupError):
+    """No such document, or it belongs to another organization."""
+
+
+class UnreadableDocumentError(ValueError):
+    """The document exists but its content cannot be sent to the model."""
+
+
+def _as_text(value: Any, *, max_length: int) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:max_length]
+
+
+def _as_int(value: Any) -> int | None:
+    """Ints only, and non-negative — a negative fee is a misread, not a value."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = int(Decimal(str(value)))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _as_rate(value: Any) -> Decimal | None:
+    """Four decimal places, because the fourth is load-bearing (5.3509)."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed.quantize(Decimal("0.0001"))
+
+
+def _as_date(value: Any) -> _dt.date | None:
+    if not value:
+        return None
+    try:
+        return _dt.date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+def _as_string_list(value: Any) -> list[str]:
+    """Strings only — this list is shown to the operator as prose.
+
+    Unlike the scalar fields, a non-string here is not worth coercing: a bare
+    ``1`` stringifies happily and then reads as a meaningless bullet under
+    "things this document says that the form cannot hold".
+    """
+    if not isinstance(value, list):
+        return []
+    return [
+        text
+        for item in value
+        if isinstance(item, str) and (text := _as_text(item, max_length=500))
+    ]
+
+
+def _known(value: Any, allowed: frozenset[str] | set[str]) -> str | None:
+    """Drop an enum value the database would reject at INSERT time.
+
+    The model is told the allowed values, but a hallucinated ``"fixed_rate"``
+    reaching the form as a selected option is worse than an empty select — the
+    operator would have to notice it was wrong rather than simply pick one.
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized if normalized in allowed else None
+
+
+def _warnings_for(raw: dict[str, Any], draft_fields: dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+
+    if draft_fields.get("tdu_charge_cents_per_kwh") is not None:
+        issued = _as_date(raw.get("document_issued_date"))
+        age = (_dt.date.today() - issued).days if issued else None
+        if age is None or age > _TDU_STALENESS_DAYS:
+            warnings.append(
+                "The delivery (TDU) charge is a pass-through the utility can "
+                "re-tariff mid-term, so the one printed on this document may no "
+                "longer be current. Check it against a recent bill before saving.",
+            )
+
+    if draft_fields.get("has_bill_credit") and (
+        draft_fields.get("bill_credit_amount_cents") is None
+        or draft_fields.get("bill_credit_threshold_kwh") is None
+    ):
+        warnings.append(
+            "This plan has a bill credit but the document did not state both "
+            "the amount and the usage it applies at. A plan cannot be saved "
+            "with only one of the two.",
+        )
+
+    if (
+        draft_fields.get("post_promo_monthly_cents") is not None
+        and draft_fields.get("term_end_date") is None
+    ):
+        warnings.append(
+            "A price applies after the promotional period, but the document did "
+            "not say when that period ends. Set an end date before saving.",
+        )
+
+    return warnings
+
+
+def build_draft(raw: dict[str, Any], *, document_id: uuid.UUID) -> UtilityPlanDraft:
+    """Coerce the model's JSON into a draft, dropping anything unusable.
+
+    Every field is parsed independently: one unreadable rate must not cost the
+    operator the eleven fields that were read correctly.
+    """
+    fields: dict[str, Any] = {
+        "service_type": _known(raw.get("service_type"), SERVICE_TYPES),
+        "rate_type": _known(raw.get("rate_type"), RATE_TYPES),
+        "has_bill_credit": raw.get("has_bill_credit") is True,
+    }
+    for name in _TEXT_FIELDS:
+        fields[name] = _as_text(
+            raw.get(name), max_length=5000 if name == "notes" else 255,
+        )
+    for name in _RATE_FIELDS:
+        fields[name] = _as_rate(raw.get(name))
+    for name in _INT_FIELDS:
+        fields[name] = _as_int(raw.get(name))
+    for name in _DATE_FIELDS:
+        fields[name] = _as_date(raw.get(name))
+
+    confidence = _known(raw.get("confidence"), _CONFIDENCE_VALUES) or "low"
+
+    return UtilityPlanDraft(
+        source_document_id=document_id,
+        confidence=confidence,
+        warnings=_warnings_for(raw, fields),
+        unrepresented=_as_string_list(raw.get("unrepresented")),
+        **fields,
+    )
+
+
+async def _load_document(
+    *, document_id: uuid.UUID, organization_id: uuid.UUID,
+) -> tuple[bytes, str, str]:
+    """Return (content, file_type, mime_type) for a document we own."""
+    async with unit_of_work() as db:
+        doc = await document_repo.get_by_id_with_content(
+            db, document_id, organization_id,
+        )
+        if doc is None:
+            raise DocumentNotFoundError(str(document_id))
+        storage_key = doc.file_storage_key
+        content = doc.file_content
+        file_type = doc.file_type or ""
+        mime_type = doc.file_mime_type or ""
+
+    if storage_key:
+        storage = get_storage()
+        if storage is None:
+            raise UnreadableDocumentError(
+                "This document is in object storage, which is not configured.",
+            )
+        content = storage.download_file(storage_key)
+
+    if not content:
+        raise UnreadableDocumentError("This document has no file content to read.")
+    return content, file_type, mime_type
+
+
+async def _extract_raw(
+    content: bytes, file_type: str, mime_type: str, *, user_id: uuid.UUID,
+) -> dict[str, Any]:
+    """Send the document to the model as text where possible, vision otherwise."""
+    if file_type == "image":
+        return await run_utility_plan_extraction(
+            image_bytes=content,
+            media_type=mime_type or "image/jpeg",
+            user_id=user_id,
+        )
+    if file_type == "pdf":
+        text = await extract_text_from_pdf(content)
+        if text and len(text) >= _MIN_PDF_TEXT_CHARS:
+            return await run_utility_plan_extraction(text=text, user_id=user_id)
+        # A scanned EFL has no text layer; the numbers are only in the pixels.
+        return await run_utility_plan_extraction(
+            image_bytes=content, media_type="application/pdf", user_id=user_id,
+        )
+    if file_type == "docx":
+        return await run_utility_plan_extraction(
+            text=await extract_text_from_docx(content), user_id=user_id,
+        )
+    if file_type == "spreadsheet":
+        return await run_utility_plan_extraction(
+            text=await extract_text_from_spreadsheet(content, ""), user_id=user_id,
+        )
+    raise UnreadableDocumentError(
+        "Plan terms can be read from a PDF, an image, a Word file or a spreadsheet.",
+    )
+
+
+async def extract_plan_from_document(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    document_id: uuid.UUID,
+) -> UtilityPlanDraft:
+    content, file_type, mime_type = await _load_document(
+        document_id=document_id, organization_id=organization_id,
+    )
+    raw = await _extract_raw(content, file_type, mime_type, user_id=user_id)
+    if not isinstance(raw, dict):
+        # A bare list or string means the model ignored the contract. An empty
+        # draft is honest; a partially-parsed one would not be.
+        logger.warning(
+            "utility plan extraction returned %s for document %s",
+            type(raw).__name__, document_id,
+        )
+        raw = {}
+    return build_draft(raw, document_id=document_id)

--- a/apps/mybookkeeper/backend/tests/test_utility_plan_extraction.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_plan_extraction.py
@@ -1,0 +1,275 @@
+"""Tests for reading a utility plan out of a document.
+
+The model's output is untrusted input. These tests are mostly about what
+happens when it is wrong — a hallucinated enum, a negative fee, a rate with two
+decimal places, a bare list instead of an object — because the failure mode
+that matters is not "extraction failed" (visible) but "extraction produced a
+plausible wrong number" (invisible, and it ends up in a price comparison).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.properties import utility_plan_extraction_service as svc
+
+DOC_ID = uuid.uuid4()
+
+
+def _draft(**raw):
+    return svc.build_draft(raw, document_id=DOC_ID)
+
+
+class TestBuildDraftReadsWhatIsThere:
+    def test_a_full_efl_reading_round_trips(self) -> None:
+        draft = _draft(
+            service_type="electricity",
+            provider_name="Constellation",
+            plan_name="12 Month Usage Bill Credit",
+            account_number="204430810",
+            rate_type="fixed",
+            energy_charge_cents_per_kwh="14.1100",
+            avg_price_cents_per_kwh_at_1000="17.1000",
+            monthly_base_charge_cents=0,
+            term_months=12,
+            service_start_date="2026-02-17",
+            term_end_date="2027-02-17",
+            early_termination_fee_cents=15000,
+            has_bill_credit=True,
+            bill_credit_amount_cents=3500,
+            bill_credit_threshold_kwh=1000,
+            min_usage_fee_cents=0,
+            confidence="high",
+        )
+
+        assert draft.service_type == "electricity"
+        assert draft.energy_charge_cents_per_kwh == Decimal("14.1100")
+        assert draft.term_end_date == _dt.date(2027, 2, 17)
+        assert draft.early_termination_fee_cents == 15000
+        assert draft.has_bill_credit is True
+        assert draft.confidence == "high"
+        assert draft.source_document_id == DOC_ID
+
+    def test_a_stated_zero_survives_as_zero(self) -> None:
+        """0 and null are different answers, and the difference is load-bearing.
+
+        "Minimum Usage Fee: $0.00" is a recorded fact; a plan that never
+        mentions one is unknown. Collapsing them would let a plan with a real
+        fee look identical to one that promises none.
+        """
+        draft = _draft(min_usage_fee_cents=0, monthly_base_charge_cents=0)
+
+        assert draft.min_usage_fee_cents == 0
+        assert draft.monthly_base_charge_cents == 0
+
+    def test_an_empty_reading_is_an_empty_draft_not_an_error(self) -> None:
+        draft = _draft()
+
+        assert draft.provider_name is None
+        assert draft.has_bill_credit is False
+        assert draft.confidence == "low"
+        assert draft.warnings == []
+        assert draft.unrepresented == []
+
+    def test_internet_fields_are_read_without_touching_the_kwh_ones(self) -> None:
+        draft = _draft(
+            service_type="internet",
+            rate_type="fixed",
+            monthly_base_charge_cents=5500,
+            post_promo_monthly_cents=9500,
+            equipment_fee_monthly_cents=1000,
+            download_mbps=1000,
+            upload_mbps=1000,
+            data_cap_gb=1200,
+            term_end_date="2027-02-17",
+        )
+
+        assert draft.download_mbps == 1000
+        assert draft.data_cap_gb == 1200
+        assert draft.energy_charge_cents_per_kwh is None
+        assert draft.avg_price_cents_per_kwh_at_1000 is None
+
+
+class TestBuildDraftRefusesJunk:
+    @pytest.mark.parametrize("value", ["fixed_rate", "FIXED RATE", "", None, 12, []])
+    def test_an_unknown_rate_type_is_dropped_not_passed_through(self, value) -> None:
+        """A hallucinated enum would fail the DB CHECK — as a 500, at save time.
+
+        Dropping it leaves the select empty, which the operator fills in. A
+        wrong preselected value is worse: it has to be noticed to be fixed.
+        """
+        assert _draft(rate_type=value).rate_type is None
+
+    @pytest.mark.parametrize("value", ["electric", "power", "fibre"])
+    def test_a_near_miss_service_type_is_dropped(self, value) -> None:
+        assert _draft(service_type=value).service_type is None
+
+    def test_a_known_value_in_the_wrong_case_is_accepted(self) -> None:
+        """The value is unambiguous; rejecting it would discard a correct read."""
+        assert _draft(rate_type="Fixed").rate_type == "fixed"
+        assert _draft(service_type="ELECTRICITY").service_type == "electricity"
+
+    @pytest.mark.parametrize(
+        "field", ["early_termination_fee_cents", "monthly_base_charge_cents"],
+    )
+    def test_a_negative_amount_is_dropped(self, field) -> None:
+        """No money field on this table can be negative; a minus sign is a misread."""
+        assert getattr(_draft(**{field: -1500}), field) is None
+
+    def test_a_negative_rate_is_dropped(self) -> None:
+        assert _draft(energy_charge_cents_per_kwh="-10.0").energy_charge_cents_per_kwh is None
+
+    @pytest.mark.parametrize("value", ["$150.00", "1,500", "n/a", "", "about 15"])
+    def test_an_unparseable_amount_is_dropped_not_coerced(self, value) -> None:
+        assert _draft(early_termination_fee_cents=value).early_termination_fee_cents is None
+
+    def test_a_rate_is_carried_to_four_decimal_places(self) -> None:
+        """5.3509 rounded to 5.35 misprices every comparison built on it."""
+        assert _draft(
+            tdu_charge_cents_per_kwh="5.3509",
+        ).tdu_charge_cents_per_kwh == Decimal("5.3509")
+
+    def test_a_short_rate_is_padded_rather_than_left_ragged(self) -> None:
+        assert _draft(
+            energy_charge_cents_per_kwh="10",
+        ).energy_charge_cents_per_kwh == Decimal("10.0000")
+
+    @pytest.mark.parametrize("value", ["2026-13-45", "Feb 17 2026", "", None])
+    def test_an_unparseable_date_is_dropped(self, value) -> None:
+        assert _draft(term_end_date=value).term_end_date is None
+
+    def test_a_truthy_non_boolean_does_not_claim_a_bill_credit(self) -> None:
+        """has_bill_credit is NOT NULL and gates two other columns."""
+        assert _draft(has_bill_credit="yes").has_bill_credit is False
+        assert _draft(has_bill_credit=1).has_bill_credit is False
+        assert _draft(has_bill_credit=True).has_bill_credit is True
+
+    def test_unrepresented_survives_only_as_a_list_of_strings(self) -> None:
+        assert _draft(unrepresented="a string").unrepresented == []
+        assert _draft(unrepresented=[1, None, "  ", "real term"]).unrepresented == [
+            "real term",
+        ]
+
+    def test_an_unknown_confidence_falls_back_to_low(self) -> None:
+        assert _draft(confidence="certain").confidence == "low"
+        assert _draft(confidence="high").confidence == "high"
+
+
+class TestDraftWarnings:
+    def test_an_old_tdu_rate_is_flagged_as_possibly_stale(self) -> None:
+        """The exact 2026-08-11 failure: an EFL's 6.0009 vs a current 5.1461."""
+        draft = _draft(
+            tdu_charge_cents_per_kwh="6.0009",
+            document_issued_date="2025-12-05",
+        )
+
+        assert any("TDU" in w for w in draft.warnings)
+
+    def test_a_tdu_rate_with_no_document_date_is_also_flagged(self) -> None:
+        """Unknown age is not the same as young."""
+        assert any("TDU" in w for w in _draft(tdu_charge_cents_per_kwh="5.1461").warnings)
+
+    def test_a_freshly_issued_tdu_rate_is_not_flagged(self) -> None:
+        recent = (_dt.date.today() - _dt.timedelta(days=5)).isoformat()
+
+        draft = _draft(tdu_charge_cents_per_kwh="5.1461", document_issued_date=recent)
+
+        assert draft.warnings == []
+
+    def test_no_tdu_rate_means_no_tdu_warning(self) -> None:
+        assert _draft(energy_charge_cents_per_kwh="10.0000").warnings == []
+
+    def test_half_a_bill_credit_is_flagged_rather_than_silently_unsavable(self) -> None:
+        """The CHECK constraint rejects the pair; the form should say why first."""
+        draft = _draft(has_bill_credit=True, bill_credit_amount_cents=3500)
+
+        assert any("bill credit" in w for w in draft.warnings)
+
+    def test_a_complete_bill_credit_is_not_flagged(self) -> None:
+        draft = _draft(
+            has_bill_credit=True,
+            bill_credit_amount_cents=3500,
+            bill_credit_threshold_kwh=1000,
+        )
+
+        assert draft.warnings == []
+
+    def test_a_post_promo_price_with_no_end_date_is_flagged(self) -> None:
+        draft = _draft(post_promo_monthly_cents=9500)
+
+        assert any("promotional" in w for w in draft.warnings)
+
+    def test_a_post_promo_price_with_an_end_date_is_not_flagged(self) -> None:
+        draft = _draft(post_promo_monthly_cents=9500, term_end_date="2027-02-17")
+
+        assert draft.warnings == []
+
+
+@pytest.mark.asyncio
+class TestExtractPlanFromDocument:
+    async def test_a_document_from_another_org_is_not_found(self) -> None:
+        with patch.object(
+            svc, "_load_document", side_effect=svc.DocumentNotFoundError(str(DOC_ID)),
+        ):
+            with pytest.raises(svc.DocumentNotFoundError):
+                await svc.extract_plan_from_document(
+                    user_id=uuid.uuid4(),
+                    organization_id=uuid.uuid4(),
+                    document_id=DOC_ID,
+                )
+
+    async def test_a_non_dict_response_degrades_to_an_empty_draft(self) -> None:
+        """The model ignoring the contract must not 500 the request."""
+        with patch.object(
+            svc, "_load_document", new=AsyncMock(return_value=(b"x", "pdf", "")),
+        ):
+            with patch.object(
+                svc, "_extract_raw", new=AsyncMock(return_value=["not", "an", "object"]),
+            ):
+                draft = await svc.extract_plan_from_document(
+                    user_id=uuid.uuid4(),
+                    organization_id=uuid.uuid4(),
+                    document_id=DOC_ID,
+                )
+
+        assert draft.provider_name is None
+        assert draft.confidence == "low"
+        assert draft.source_document_id == DOC_ID
+
+    async def test_an_unsupported_file_type_is_reported_not_sent_to_the_model(
+        self,
+    ) -> None:
+        with patch.object(
+            svc, "run_utility_plan_extraction", new=AsyncMock(),
+        ) as mock_model:
+            with pytest.raises(svc.UnreadableDocumentError):
+                await svc._extract_raw(b"x", "zip", "", user_id=uuid.uuid4())
+
+        mock_model.assert_not_called()
+
+    async def test_a_pdf_with_a_real_text_layer_is_read_as_text(self) -> None:
+        """Vision on a text PDF costs more and reads no better."""
+        with patch.object(
+            svc, "extract_text_from_pdf", new=AsyncMock(return_value="x" * 200),
+        ):
+            with patch.object(
+                svc, "run_utility_plan_extraction", new=AsyncMock(return_value={}),
+            ) as mock_model:
+                await svc._extract_raw(b"pdf", "pdf", "", user_id=uuid.uuid4())
+
+        assert mock_model.await_args.kwargs.get("text") is not None
+        assert mock_model.await_args.kwargs.get("image_bytes") is None
+
+    async def test_a_scanned_pdf_falls_back_to_vision(self) -> None:
+        """A scanned EFL has no text layer — the numbers are only in the pixels."""
+        with patch.object(svc, "extract_text_from_pdf", new=AsyncMock(return_value="")):
+            with patch.object(
+                svc, "run_utility_plan_extraction", new=AsyncMock(return_value={}),
+            ) as mock_model:
+                await svc._extract_raw(b"pdf", "pdf", "", user_id=uuid.uuid4())
+
+        assert mock_model.await_args.kwargs.get("image_bytes") == b"pdf"

--- a/apps/mybookkeeper/backend/tests/test_utility_plans_api.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_plans_api.py
@@ -14,10 +14,12 @@ from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from app.core.context import RequestContext
 from app.core.permissions import current_org_member, require_write_access
+from app.core.rate_limit import utility_plan_extract_limiter
 from app.core.utility_plan_constants import (
     EXPIRING_SOON_DAYS,
     RATE_TYPE_FIXED,
@@ -26,12 +28,17 @@ from app.core.utility_plan_constants import (
 )
 from app.main import app
 from app.models.organization.organization_member import OrgRole
+from app.schemas.properties.utility_plan_draft import UtilityPlanDraft
 from app.schemas.properties.utility_plan_list_response import UtilityPlanListResponse
 from app.schemas.properties.utility_plan_renewal_alert_response import (
     UtilityPlanRenewalAlertResponse,
 )
 from app.schemas.properties.utility_plan_response import UtilityPlanResponse
 from app.schemas.properties.utility_plan_summary import UtilityPlanSummary
+from app.services.properties.utility_plan_extraction_service import (
+    DocumentNotFoundError,
+    UnreadableDocumentError,
+)
 from app.services.properties.utility_plan_service import (
     InvalidUtilityPlanError,
     UtilityPlanNotFoundError,
@@ -43,6 +50,7 @@ PROPERTY_ID = uuid.uuid4()
 PLAN_ID = uuid.uuid4()
 
 _SERVICE = "app.api.utility_plans.utility_plan_service"
+_EXTRACTION = "app.api.utility_plans.utility_plan_extraction_service"
 
 
 def _ctx(role: OrgRole = OrgRole.OWNER) -> RequestContext:
@@ -295,6 +303,134 @@ class TestCreate:
             },
         )
         assert response.status_code == 422
+
+
+class TestExtract:
+    """``POST /utility-plans/extract`` — reads a document, saves nothing."""
+
+    def test_a_draft_comes_back_without_anything_being_saved(
+        self, client: TestClient,
+    ) -> None:
+        document_id = uuid.uuid4()
+        draft = UtilityPlanDraft(
+            source_document_id=document_id,
+            provider_name="Constellation",
+            rate_type="fixed",
+            confidence="high",
+        )
+        with patch(
+            f"{_EXTRACTION}.extract_plan_from_document",
+            new_callable=AsyncMock,
+            return_value=draft,
+        ) as mock_extract:
+            with patch(f"{_SERVICE}.create_plan", new_callable=AsyncMock) as mock_create:
+                response = client.post(
+                    "/utility-plans/extract",
+                    json={"document_id": str(document_id)},
+                )
+
+        assert response.status_code == 200
+        assert response.json()["provider_name"] == "Constellation"
+        assert mock_extract.await_args.kwargs["document_id"] == document_id
+        mock_create.assert_not_called()
+
+    def test_the_literal_path_is_not_swallowed_by_the_uuid_route(
+        self, client: TestClient,
+    ) -> None:
+        """``/extract`` is declared before ``/{plan_id}``; this pins that order.
+
+        Reversing them would send this request to ``get_plan``, which would
+        reject "extract" as a malformed UUID — a 422 that looks like a payload
+        problem and reads nothing like a routing bug.
+        """
+        with patch(f"{_SERVICE}.get_plan", new_callable=AsyncMock) as mock_get:
+            with patch(
+                f"{_EXTRACTION}.extract_plan_from_document",
+                new_callable=AsyncMock,
+                return_value=UtilityPlanDraft(source_document_id=uuid.uuid4()),
+            ):
+                response = client.post(
+                    "/utility-plans/extract",
+                    json={"document_id": str(uuid.uuid4())},
+                )
+
+        assert response.status_code == 200
+        mock_get.assert_not_called()
+
+    def test_a_document_we_do_not_own_returns_404(self, client: TestClient) -> None:
+        """Same answer as a document that does not exist — no existence oracle."""
+        with patch(
+            f"{_EXTRACTION}.extract_plan_from_document",
+            new_callable=AsyncMock,
+            side_effect=DocumentNotFoundError("nope"),
+        ):
+            response = client.post(
+                "/utility-plans/extract",
+                json={"document_id": str(uuid.uuid4())},
+            )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Document not found"
+
+    def test_an_unreadable_document_returns_422_with_the_reason(
+        self, client: TestClient,
+    ) -> None:
+        with patch(
+            f"{_EXTRACTION}.extract_plan_from_document",
+            new_callable=AsyncMock,
+            side_effect=UnreadableDocumentError("Plan terms can be read from a PDF."),
+        ):
+            response = client.post(
+                "/utility-plans/extract",
+                json={"document_id": str(uuid.uuid4())},
+            )
+
+        assert response.status_code == 422
+        assert "PDF" in response.json()["detail"]
+
+    def test_a_missing_document_id_returns_422(self, client: TestClient) -> None:
+        assert client.post("/utility-plans/extract", json={}).status_code == 422
+
+    def test_an_unknown_field_returns_422(self, client: TestClient) -> None:
+        response = client.post(
+            "/utility-plans/extract",
+            json={"document_id": str(uuid.uuid4()), "property_id": str(PROPERTY_ID)},
+        )
+        assert response.status_code == 422
+
+    def test_the_caller_is_throttled_before_the_model_is_called_again(
+        self, client: TestClient,
+    ) -> None:
+        """Each call is a paid model request; the upload cap does not bound re-reads."""
+        limiter = utility_plan_extract_limiter
+        with patch.object(limiter, "check", side_effect=HTTPException(429, "slow down")):
+            with patch(
+                f"{_EXTRACTION}.extract_plan_from_document", new_callable=AsyncMock,
+            ) as mock_extract:
+                response = client.post(
+                    "/utility-plans/extract",
+                    json={"document_id": str(uuid.uuid4())},
+                )
+
+        assert response.status_code == 429
+        mock_extract.assert_not_called()
+
+    def test_the_limit_is_keyed_per_user_not_globally(
+        self, client: TestClient,
+    ) -> None:
+        """A shared key would let one operator's reading lock everyone else out."""
+        with patch.object(utility_plan_extract_limiter, "check") as mock_check:
+            with patch(
+                f"{_EXTRACTION}.extract_plan_from_document",
+                new_callable=AsyncMock,
+                return_value=UtilityPlanDraft(source_document_id=uuid.uuid4()),
+            ):
+                client.post(
+                    "/utility-plans/extract",
+                    json={"document_id": str(uuid.uuid4())},
+                )
+
+        assert str(USER_ID) in mock_check.call_args.args[0]
 
 
 class TestList:

--- a/apps/mybookkeeper/frontend/src/__tests__/AddUtilityPlanDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/AddUtilityPlanDialog.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for the read-a-document path on the utility-plan add dialog.
+ *
+ * Verifies:
+ * - Reading a document prefills the form and records what it was read from
+ * - Terms the form has no field for are surfaced rather than dropped
+ * - A failed reading leaves the operator able to fill the form by hand
+ * - Saving without reading anything sends no source_document_id
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AddUtilityPlanDialog from "@/app/features/utility/AddUtilityPlanDialog";
+import { showError } from "@/shared/lib/toast-store";
+import type { UtilityPlanDraft } from "@/shared/types/utility/utility-plan-draft";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockCreate = vi.fn();
+const mockExtract = vi.fn();
+
+vi.mock("@/shared/store/utilityPlansApi", () => ({
+  useCreateUtilityPlanMutation: vi.fn(() => [mockCreate, { isLoading: false }]),
+  useExtractUtilityPlanMutation: vi.fn(() => [mockExtract, { isLoading: false }]),
+}));
+
+vi.mock("@/shared/store/propertiesApi", () => ({
+  useGetPropertiesQuery: vi.fn(() => ({
+    data: [{ id: "prop-1", name: "6734 Peerless St" }],
+  })),
+}));
+
+vi.mock("@/shared/store/documentsApi", () => ({
+  useGetDocumentsQuery: vi.fn(() => ({
+    data: [{ id: "doc-1", file_name: "constellation-efl.pdf" }],
+  })),
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+const DRAFT: UtilityPlanDraft = {
+  source_document_id: "doc-1",
+  service_type: "electricity",
+  provider_name: "Constellation",
+  plan_name: "12 Month Usage Bill Credit",
+  account_number: null,
+  rate_type: "fixed",
+  energy_charge_cents_per_kwh: "14.1100",
+  tdu_charge_cents_per_kwh: null,
+  avg_price_cents_per_kwh_at_1000: "17.1000",
+  monthly_base_charge_cents: 0,
+  term_months: 12,
+  service_start_date: null,
+  term_end_date: "2027-02-17",
+  early_termination_fee_cents: 15000,
+  has_bill_credit: true,
+  bill_credit_amount_cents: 3500,
+  bill_credit_threshold_kwh: 1000,
+  min_usage_fee_cents: 0,
+  min_usage_threshold_kwh: null,
+  post_promo_monthly_cents: null,
+  equipment_fee_monthly_cents: null,
+  download_mbps: null,
+  upload_mbps: null,
+  data_cap_gb: null,
+  notes: null,
+  confidence: "high",
+  warnings: [],
+  unrepresented: [],
+};
+
+function renderDialog() {
+  return render(<AddUtilityPlanDialog onClose={vi.fn()} />);
+}
+
+async function readTheDocument(user: ReturnType<typeof userEvent.setup>) {
+  await user.selectOptions(
+    screen.getByTestId("utility-plan-document-select"),
+    "doc-1",
+  );
+  await user.click(screen.getByTestId("utility-plan-read-document-button"));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreate.mockReturnValue({ unwrap: vi.fn().mockResolvedValue({ id: "plan-1" }) });
+  mockExtract.mockReturnValue({ unwrap: vi.fn().mockResolvedValue(DRAFT) });
+});
+
+describe("AddUtilityPlanDialog — reading from a document", () => {
+  it("prefills the form from what the document said", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await readTheDocument(user);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Constellation")).toBeInTheDocument();
+    });
+    expect(mockExtract).toHaveBeenCalledWith({ document_id: "doc-1" });
+    expect(screen.getByDisplayValue("14.11")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("2027-02-17")).toBeInTheDocument();
+  });
+
+  it("records which document the plan was read from when it saves", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await readTheDocument(user);
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Constellation")).toBeInTheDocument();
+    });
+    await user.selectOptions(
+      screen.getByTestId("utility-plan-property-select"),
+      "prop-1",
+    );
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockCreate.mock.calls[0][0]).toMatchObject({
+      property_id: "prop-1",
+      provider_name: "Constellation",
+      source_document_id: "doc-1",
+    });
+  });
+
+  it("sends no source document when the form was filled by hand", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.selectOptions(
+      screen.getByTestId("utility-plan-property-select"),
+      "prop-1",
+    );
+    await user.type(screen.getByTestId("utility-plan-provider-input"), "Reliant");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockCreate.mock.calls[0][0]).not.toHaveProperty("source_document_id");
+  });
+
+  it("surfaces terms the form has no field for instead of dropping them", async () => {
+    const user = userEvent.setup();
+    mockExtract.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        ...DRAFT,
+        min_usage_fee_cents: 995,
+        unrepresented: ["Rate steps to 21.4 c/kWh in months 11-12"],
+      }),
+    });
+    renderDialog();
+
+    await readTheDocument(user);
+
+    await waitFor(() => {
+      expect(screen.getByText("Minimum usage fee: $9.95")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Rate steps to 21.4 c/kWh in months 11-12"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a warning about a field that may be wrong", async () => {
+    const user = userEvent.setup();
+    mockExtract.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        ...DRAFT,
+        warnings: ["The delivery (TDU) charge may no longer be current."],
+      }),
+    });
+    renderDialog();
+
+    await readTheDocument(user);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("The delivery (TDU) charge may no longer be current."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("leaves the form usable when the reading fails", async () => {
+    const user = userEvent.setup();
+    mockExtract.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue(new Error("422")),
+    });
+    renderDialog();
+
+    await readTheDocument(user);
+
+    await waitFor(() => expect(showError).toHaveBeenCalled());
+    expect(screen.queryByTestId("utility-plan-draft-notices")).not.toBeInTheDocument();
+    expect(screen.getByTestId("utility-plan-save-button")).toBeInTheDocument();
+  });
+
+  it("does not call the model until a document is chosen", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByTestId("utility-plan-read-document-button"));
+
+    expect(mockExtract).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/UtilityPlans.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/UtilityPlans.test.tsx
@@ -42,6 +42,7 @@ vi.mock("@/shared/store/utilityPlansApi", () => ({
     { isLoading: false },
   ]),
   useCreateUtilityPlanMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useExtractUtilityPlanMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useUpdateUtilityPlanMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useGetUtilityPlanByIdQuery: vi.fn(() => ({
     data: undefined,

--- a/apps/mybookkeeper/frontend/src/__tests__/utility-plan-draft.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/utility-plan-draft.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyDraftToForm,
+  draftFieldsTheFormCannotHold,
+} from "@/shared/lib/utility-plan-draft";
+import { EMPTY_UTILITY_PLAN_FORM } from "@/shared/lib/utility-plan-form";
+import type { UtilityPlanDraft } from "@/shared/types/utility/utility-plan-draft";
+import type { UtilityPlanFormValues } from "@/shared/types/utility/utility-plan-form-values";
+
+function draft(overrides: Partial<UtilityPlanDraft> = {}): UtilityPlanDraft {
+  return {
+    source_document_id: "11111111-1111-1111-1111-111111111111",
+    service_type: null,
+    provider_name: null,
+    plan_name: null,
+    account_number: null,
+    rate_type: null,
+    energy_charge_cents_per_kwh: null,
+    tdu_charge_cents_per_kwh: null,
+    avg_price_cents_per_kwh_at_1000: null,
+    monthly_base_charge_cents: null,
+    term_months: null,
+    service_start_date: null,
+    term_end_date: null,
+    early_termination_fee_cents: null,
+    has_bill_credit: false,
+    bill_credit_amount_cents: null,
+    bill_credit_threshold_kwh: null,
+    min_usage_fee_cents: null,
+    min_usage_threshold_kwh: null,
+    post_promo_monthly_cents: null,
+    equipment_fee_monthly_cents: null,
+    download_mbps: null,
+    upload_mbps: null,
+    data_cap_gb: null,
+    notes: null,
+    confidence: "low",
+    warnings: [],
+    unrepresented: [],
+    ...overrides,
+  };
+}
+
+const TYPED: UtilityPlanFormValues = {
+  ...EMPTY_UTILITY_PLAN_FORM,
+  providerName: "Constellation",
+  accountNumber: "204430810",
+};
+
+describe("applyDraftToForm", () => {
+  it("fills the fields the document stated", () => {
+    const values = applyDraftToForm(
+      EMPTY_UTILITY_PLAN_FORM,
+      draft({
+        service_type: "electricity",
+        rate_type: "fixed",
+        provider_name: "Constellation",
+        energy_charge_cents_per_kwh: "14.1100",
+        early_termination_fee_cents: 15000,
+        term_end_date: "2027-02-17",
+      }),
+    );
+
+    expect(values.providerName).toBe("Constellation");
+    expect(values.energyCharge).toBe("14.11");
+    expect(values.etf).toBe("150.00");
+    expect(values.termEndDate).toBe("2027-02-17");
+  });
+
+  it("never blanks a field the operator already typed", () => {
+    // The whole reason the overlay is a merge and not a replace: the document
+    // is silent on the account number, and silence is not an instruction.
+    const values = applyDraftToForm(TYPED, draft({ provider_name: "Reliant" }));
+
+    expect(values.accountNumber).toBe("204430810");
+    expect(values.providerName).toBe("Reliant");
+  });
+
+  it("keeps a bill credit the operator ticked even when the document is silent", () => {
+    const values = applyDraftToForm(
+      { ...EMPTY_UTILITY_PLAN_FORM, hasBillCredit: true },
+      draft({ has_bill_credit: false }),
+    );
+
+    expect(values.hasBillCredit).toBe(true);
+  });
+
+  it("ticks the bill credit when the document states one", () => {
+    const values = applyDraftToForm(
+      EMPTY_UTILITY_PLAN_FORM,
+      draft({
+        has_bill_credit: true,
+        bill_credit_amount_cents: 3500,
+        bill_credit_threshold_kwh: 1000,
+      }),
+    );
+
+    expect(values.hasBillCredit).toBe(true);
+    expect(values.billCreditAmount).toBe("35.00");
+    expect(values.billCreditThreshold).toBe("1000");
+  });
+
+  it("ignores a service or rate type outside the allowed values", () => {
+    // The backend already drops these, so this is the second gate rather than
+    // the only one — but a bad value here would land in a select as a phantom
+    // option that silently fails to save.
+    const values = applyDraftToForm(
+      EMPTY_UTILITY_PLAN_FORM,
+      draft({ service_type: "electric", rate_type: "fixed_rate" }),
+    );
+
+    expect(values.serviceType).toBe(EMPTY_UTILITY_PLAN_FORM.serviceType);
+    expect(values.rateType).toBe(EMPTY_UTILITY_PLAN_FORM.rateType);
+  });
+
+  it("trims a padded rate so an untouched input doesn't look edited", () => {
+    const values = applyDraftToForm(
+      EMPTY_UTILITY_PLAN_FORM,
+      draft({ tdu_charge_cents_per_kwh: "5.3509", avg_price_cents_per_kwh_at_1000: "10.0000" }),
+    );
+
+    expect(values.tduCharge).toBe("5.3509");
+    expect(values.avgPrice).toBe("10");
+  });
+
+  it("keeps a stated zero rather than treating it as nothing read", () => {
+    const values = applyDraftToForm(
+      EMPTY_UTILITY_PLAN_FORM,
+      draft({ monthly_base_charge_cents: 0 }),
+    );
+
+    expect(values.monthlyBase).toBe("0.00");
+  });
+});
+
+describe("draftFieldsTheFormCannotHold", () => {
+  it("lists what was read but has no input yet", () => {
+    const dropped = draftFieldsTheFormCannotHold(
+      draft({
+        min_usage_fee_cents: 995,
+        download_mbps: 1000,
+        data_cap_gb: 1200,
+        notes: "Rate assumes autopay enrollment.",
+      }),
+    );
+
+    expect(dropped).toContain("Minimum usage fee: $9.95");
+    expect(dropped).toContain("Download speed: 1000 Mbps");
+    expect(dropped).toContain("Data cap: 1200 GB");
+    expect(dropped).toContain("Notes: Rate assumes autopay enrollment.");
+  });
+
+  it("says nothing when everything read fits the form", () => {
+    expect(draftFieldsTheFormCannotHold(draft({ provider_name: "Reliant" }))).toEqual([]);
+  });
+
+  it("still reports a stated zero fee", () => {
+    // "$0.00 minimum usage fee" is a recorded promise, not an absence — losing
+    // it silently is exactly the failure this list exists to prevent.
+    expect(draftFieldsTheFormCannotHold(draft({ min_usage_fee_cents: 0 }))).toEqual([
+      "Minimum usage fee: $0.00",
+    ]);
+  });
+
+  it("ignores whitespace-only notes", () => {
+    expect(draftFieldsTheFormCannotHold(draft({ notes: "   " }))).toEqual([]);
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/utility/AddUtilityPlanDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/AddUtilityPlanDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import FormField from "@/shared/components/ui/FormField";
+import { applyDraftToForm } from "@/shared/lib/utility-plan-draft";
 import {
   toUtilityPlanFields,
   validateUtilityPlanForm,
@@ -7,7 +8,10 @@ import {
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import { useGetPropertiesQuery } from "@/shared/store/propertiesApi";
 import { useCreateUtilityPlanMutation } from "@/shared/store/utilityPlansApi";
+import type { UtilityPlanDraft } from "@/shared/types/utility/utility-plan-draft";
 import UtilityPlanDialogShell from "./UtilityPlanDialogShell";
+import UtilityPlanDocumentReader from "./UtilityPlanDocumentReader";
+import UtilityPlanDraftNotices from "./UtilityPlanDraftNotices";
 import UtilityPlanFormActions from "./UtilityPlanFormActions";
 import UtilityPlanFormFields, { UTILITY_PLAN_INPUT_CLASS } from "./UtilityPlanFormFields";
 import { useUtilityPlanForm } from "./useUtilityPlanForm";
@@ -20,8 +24,14 @@ export interface AddUtilityPlanDialogProps {
 export default function AddUtilityPlanDialog({ onClose }: AddUtilityPlanDialogProps) {
   const { data: properties = [] } = useGetPropertiesQuery();
   const [createPlan, { isLoading }] = useCreateUtilityPlanMutation();
-  const { values, setField } = useUtilityPlanForm();
+  const { values, setField, replaceValues } = useUtilityPlanForm();
   const [propertyId, setPropertyId] = useState("");
+  const [draft, setDraft] = useState<UtilityPlanDraft | null>(null);
+
+  function handleRead(read: UtilityPlanDraft) {
+    setDraft(read);
+    replaceValues((previous) => applyDraftToForm(previous, read));
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -39,6 +49,9 @@ export default function AddUtilityPlanDialog({ onClose }: AddUtilityPlanDialogPr
       await createPlan({
         property_id: propertyId,
         ...toUtilityPlanFields(values),
+        // Recorded only when the form was actually seeded from a document, so
+        // the saved plan points back at what it was read from.
+        ...(draft ? { source_document_id: draft.source_document_id } : {}),
       }).unwrap();
       showSuccess("Utility plan added.");
       onClose();
@@ -54,6 +67,9 @@ export default function AddUtilityPlanDialog({ onClose }: AddUtilityPlanDialogPr
       onClose={onClose}
     >
       <form onSubmit={(e) => void handleSubmit(e)} className="p-5 space-y-4">
+        <UtilityPlanDocumentReader onRead={handleRead} />
+        {draft && <UtilityPlanDraftNotices draft={draft} />}
+
         <FormField label="Property" required>
           <select
             value={propertyId}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDocumentReader.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDocumentReader.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { LoadingButton } from "@platform/ui";
+import FormField from "@/shared/components/ui/FormField";
+import { showError } from "@/shared/lib/toast-store";
+import { useGetDocumentsQuery } from "@/shared/store/documentsApi";
+import { useExtractUtilityPlanMutation } from "@/shared/store/utilityPlansApi";
+import type { UtilityPlanDraft } from "@/shared/types/utility/utility-plan-draft";
+import { UTILITY_PLAN_INPUT_CLASS } from "./UtilityPlanFormFields";
+
+export interface UtilityPlanDocumentReaderProps {
+  onRead: (draft: UtilityPlanDraft) => void;
+}
+
+/**
+ * Fill the form from a document already in the library.
+ *
+ * It reads an existing document rather than uploading a new one on the spot,
+ * and that is deliberate: ``POST /documents/upload`` enqueues the transaction
+ * extractor, so uploading an Electricity Facts Label here would mint a junk
+ * transaction against the property. The operator uploads on the Documents page
+ * as usual, then points this at the file.
+ */
+export default function UtilityPlanDocumentReader({
+  onRead,
+}: UtilityPlanDocumentReaderProps) {
+  const { data: documents = [] } = useGetDocumentsQuery({ excludeProcessing: true });
+  const [extractPlan, { isLoading }] = useExtractUtilityPlanMutation();
+  const [documentId, setDocumentId] = useState("");
+
+  async function handleRead() {
+    if (!documentId) {
+      showError("Pick a document first.");
+      return;
+    }
+    try {
+      onRead(await extractPlan({ document_id: documentId }).unwrap());
+    } catch {
+      showError("I couldn't read that one. Try another file, or fill it in by hand.");
+    }
+  }
+
+  return (
+    <div className="rounded-md border p-3 space-y-3" data-testid="utility-plan-document-reader">
+      <div>
+        <p className="text-sm font-medium">Start from a document</p>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Point me at an Electricity Facts Label, a contract, or a bill and I'll fill
+          in what I can. Upload it on the Documents page first if it isn't here yet.
+        </p>
+      </div>
+
+      <FormField label="Document">
+        <select
+          value={documentId}
+          onChange={(e) => setDocumentId(e.target.value)}
+          className={UTILITY_PLAN_INPUT_CLASS}
+          data-testid="utility-plan-document-select"
+        >
+          <option value="">Select a document…</option>
+          {documents.map((document) => (
+            <option key={document.id} value={document.id}>
+              {document.file_name ?? "Untitled document"}
+            </option>
+          ))}
+        </select>
+      </FormField>
+
+      <LoadingButton
+        type="button"
+        variant="secondary"
+        size="md"
+        isLoading={isLoading}
+        loadingText="Reading..."
+        disabled={isLoading || !documentId}
+        onClick={() => void handleRead()}
+        data-testid="utility-plan-read-document-button"
+      >
+        Read the terms
+      </LoadingButton>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDraftNotices.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDraftNotices.tsx
@@ -1,0 +1,67 @@
+import AlertBox from "@/shared/components/ui/AlertBox";
+import { draftFieldsTheFormCannotHold } from "@/shared/lib/utility-plan-draft";
+import type { UtilityPlanDraft } from "@/shared/types/utility/utility-plan-draft";
+
+export interface UtilityPlanDraftNoticesProps {
+  draft: UtilityPlanDraft;
+}
+
+const CONFIDENCE_NOTE: Record<string, string> = {
+  high: "I read these straight off the document.",
+  medium: "Some of these I had to interpret — worth a look before you save.",
+  low: "I wasn't very sure about this one. Please check every field.",
+};
+
+/**
+ * What the reading said beyond the fields it filled in.
+ *
+ * Three separate lists, because they mean different things and the operator
+ * acts differently on each: ``warnings`` are fields that may be wrong,
+ * ``unrepresented`` are real terms the database has no column for, and the
+ * form-can't-hold list is terms the database holds but this form doesn't edit
+ * yet. All three exist so nothing the document said gets dropped in silence.
+ */
+export default function UtilityPlanDraftNotices({ draft }: UtilityPlanDraftNoticesProps) {
+  const unheld = draftFieldsTheFormCannotHold(draft);
+  const note = CONFIDENCE_NOTE[draft.confidence] ?? CONFIDENCE_NOTE.low;
+
+  return (
+    <div className="space-y-2" data-testid="utility-plan-draft-notices">
+      <AlertBox variant={draft.confidence === "high" ? "success" : "info"}>
+        {note}
+      </AlertBox>
+
+      {draft.warnings.map((warning) => (
+        <AlertBox key={warning} variant="warning">
+          {warning}
+        </AlertBox>
+      ))}
+
+      {unheld.length > 0 && (
+        <AlertBox variant="info">
+          <p className="font-medium">
+            The document also stated these, and this form has no field for them yet:
+          </p>
+          <ul className="mt-1 list-disc pl-5">
+            {unheld.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </AlertBox>
+      )}
+
+      {draft.unrepresented.length > 0 && (
+        <AlertBox variant="info">
+          <p className="font-medium">
+            And these terms don't fit anywhere in a plan record:
+          </p>
+          <ul className="mt-1 list-disc pl-5">
+            {draft.unrepresented.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </AlertBox>
+      )}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormFields.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormFields.tsx
@@ -12,7 +12,15 @@ import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-ra
 import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
 import type { UtilityPlanFormState } from "./useUtilityPlanForm";
 
-export type UtilityPlanFormFieldsProps = UtilityPlanFormState;
+/**
+ * The inputs edit one field at a time, so they take only that much of the form
+ * state. Aliasing the whole hook state here would make every caller forward
+ * setters these fields never touch.
+ */
+export type UtilityPlanFormFieldsProps = Pick<
+  UtilityPlanFormState,
+  "values" | "setField"
+>;
 
 export const UTILITY_PLAN_INPUT_CLASS = "w-full px-3 py-2 text-sm border rounded-md";
 

--- a/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlanForm.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlanForm.ts
@@ -8,6 +8,16 @@ export interface UtilityPlanFormState {
     key: K,
     value: UtilityPlanFormValues[K],
   ) => void;
+  /**
+   * Replace several fields at once, derived from the current values.
+   *
+   * Used by the read-a-document flow, which overlays a whole draft. It takes a
+   * function rather than an object so the overlay can decide per field whether
+   * to fill or leave alone, without racing the operator's own typing.
+   */
+  replaceValues: (
+    update: (previous: UtilityPlanFormValues) => UtilityPlanFormValues,
+  ) => void;
 }
 
 /**
@@ -30,5 +40,12 @@ export function useUtilityPlanForm(
     [],
   );
 
-  return { values, setField };
+  const replaceValues = useCallback(
+    (update: (previous: UtilityPlanFormValues) => UtilityPlanFormValues) => {
+      setValues(update);
+    },
+    [],
+  );
+
+  return { values, setField, replaceValues };
 }

--- a/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-draft.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-draft.ts
@@ -1,0 +1,130 @@
+import type { UtilityPlanDraft } from "@/shared/types/utility/utility-plan-draft";
+import type { UtilityPlanFormValues } from "@/shared/types/utility/utility-plan-form-values";
+import { UTILITY_PLAN_RATE_TYPES } from "@/shared/types/utility/utility-plan-rate-type";
+import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-rate-type";
+import { UTILITY_SERVICE_TYPES } from "@/shared/types/utility/utility-service-type";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+/**
+ * Turning a read document into form state.
+ *
+ * Pure and separate from the dialog so the merge rule is testable on its own.
+ * That rule is the whole point of this module: a draft only ever *fills* the
+ * form, it never blanks it. The operator may have typed the account number
+ * before reaching for the document, and a field the document didn't state must
+ * not erase it.
+ */
+
+/** Integer cents → the dollar string a money input expects: 439 → ``"4.39"``. */
+function centsToDollarString(value: number | null): string | null {
+  if (value === null) return null;
+  return (value / 100).toFixed(2);
+}
+
+/**
+ * ``"11.6000"`` → ``"11.6"``, matching how a saved plan seeds the same input.
+ *
+ * A number input normalizes its own value on edit, so the padded form makes an
+ * untouched field look dirty. The trimmed string is numerically identical.
+ */
+function rateToInputString(value: string | null): string | null {
+  if (value === null || value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? String(parsed) : null;
+}
+
+function intToInputString(value: number | null): string | null {
+  return value === null ? null : String(value);
+}
+
+function asServiceType(value: string | null): UtilityServiceType | null {
+  return UTILITY_SERVICE_TYPES.includes(value as UtilityServiceType)
+    ? (value as UtilityServiceType)
+    : null;
+}
+
+function asRateType(value: string | null): UtilityPlanRateType | null {
+  return UTILITY_PLAN_RATE_TYPES.includes(value as UtilityPlanRateType)
+    ? (value as UtilityPlanRateType)
+    : null;
+}
+
+/** Every field the form holds, as the draft would set it, or null to leave alone. */
+function draftedFields(draft: UtilityPlanDraft): Partial<UtilityPlanFormValues> {
+  const candidates: Partial<Record<keyof UtilityPlanFormValues, unknown>> = {
+    serviceType: asServiceType(draft.service_type),
+    rateType: asRateType(draft.rate_type),
+    providerName: draft.provider_name,
+    planName: draft.plan_name,
+    accountNumber: draft.account_number,
+    energyCharge: rateToInputString(draft.energy_charge_cents_per_kwh),
+    tduCharge: rateToInputString(draft.tdu_charge_cents_per_kwh),
+    avgPrice: rateToInputString(draft.avg_price_cents_per_kwh_at_1000),
+    monthlyBase: centsToDollarString(draft.monthly_base_charge_cents),
+    termMonths: intToInputString(draft.term_months),
+    serviceStartDate: draft.service_start_date,
+    termEndDate: draft.term_end_date,
+    etf: centsToDollarString(draft.early_termination_fee_cents),
+    billCreditAmount: centsToDollarString(draft.bill_credit_amount_cents),
+    billCreditThreshold: intToInputString(draft.bill_credit_threshold_kwh),
+  };
+
+  const set: Partial<UtilityPlanFormValues> = {};
+  for (const [key, value] of Object.entries(candidates)) {
+    if (value !== null) {
+      Object.assign(set, { [key]: value });
+    }
+  }
+  return set;
+}
+
+/**
+ * Overlay a draft onto the current form values.
+ *
+ * ``has_bill_credit`` is the one field taken unconditionally: it is a boolean
+ * with no "unknown" state, and the backend only reports true when the document
+ * actually said so.
+ */
+export function applyDraftToForm(
+  values: UtilityPlanFormValues,
+  draft: UtilityPlanDraft,
+): UtilityPlanFormValues {
+  return {
+    ...values,
+    ...draftedFields(draft),
+    hasBillCredit: values.hasBillCredit || draft.has_bill_credit,
+  };
+}
+
+/** Draft fields the form has no input for yet, keyed by what to call them. */
+const UNHELD_FIELD_LABELS: ReadonlyArray<
+  [keyof UtilityPlanDraft, (value: number) => string]
+> = [
+  ["min_usage_fee_cents", (v) => `Minimum usage fee: $${(v / 100).toFixed(2)}`],
+  ["min_usage_threshold_kwh", (v) => `Minimum usage threshold: ${v} kWh`],
+  ["post_promo_monthly_cents", (v) => `Price after the promo: $${(v / 100).toFixed(2)}/mo`],
+  ["equipment_fee_monthly_cents", (v) => `Equipment fee: $${(v / 100).toFixed(2)}/mo`],
+  ["download_mbps", (v) => `Download speed: ${v} Mbps`],
+  ["upload_mbps", (v) => `Upload speed: ${v} Mbps`],
+  ["data_cap_gb", (v) => `Data cap: ${v} GB`],
+];
+
+/**
+ * Terms the document stated that this form cannot currently hold.
+ *
+ * Without this they would be read, returned, and silently dropped on the floor
+ * — the operator would have no way to know the document said anything about a
+ * minimum usage fee. Rendered alongside the backend's own ``unrepresented``
+ * list, which covers terms the *database* has no column for; this one covers
+ * terms the database holds but this form does not yet edit.
+ */
+export function draftFieldsTheFormCannotHold(draft: UtilityPlanDraft): string[] {
+  const dropped = UNHELD_FIELD_LABELS.flatMap(([key, label]) => {
+    const value = draft[key];
+    return typeof value === "number" ? [label(value)] : [];
+  });
+  if (draft.notes !== null && draft.notes.trim() !== "") {
+    dropped.push(`Notes: ${draft.notes.trim()}`);
+  }
+  return dropped;
+}

--- a/apps/mybookkeeper/frontend/src/shared/store/utilityPlansApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/utilityPlansApi.ts
@@ -1,6 +1,7 @@
 import { baseApi } from "./baseApi";
 import type { UtilityPlanCreateRequest } from "@/shared/types/utility/utility-plan-create-request";
 import type { UtilityPlanDetail } from "@/shared/types/utility/utility-plan-detail";
+import type { UtilityPlanDraft } from "@/shared/types/utility/utility-plan-draft";
 import type { UtilityPlanListResponse } from "@/shared/types/utility/utility-plan-list-response";
 import type { UtilityPlanRenewalAlert } from "@/shared/types/utility/utility-plan-renewal-alert";
 import type { UtilityPlanUpdateRequest } from "@/shared/types/utility/utility-plan-update-request";
@@ -98,6 +99,18 @@ const utilityPlansApi = baseApi.injectEndpoints({
       ],
     }),
 
+    /**
+     * Read plan terms out of an already-uploaded document.
+     *
+     * A mutation rather than a query despite saving nothing: it is a paid model
+     * call the operator triggers deliberately, and caching it under the
+     * document id would silently return a stale reading after the file is
+     * replaced. It invalidates nothing — no row changed.
+     */
+    extractUtilityPlan: builder.mutation<UtilityPlanDraft, { document_id: string }>({
+      query: (data) => ({ url: "/utility-plans/extract", method: "POST", data }),
+    }),
+
     deleteUtilityPlan: builder.mutation<void, string>({
       query: (id) => ({ url: `/utility-plans/${id}`, method: "DELETE" }),
       invalidatesTags: [
@@ -113,6 +126,7 @@ export const {
   useGetUtilityPlanRenewalAlertsQuery,
   useGetUtilityPlanByIdQuery,
   useCreateUtilityPlanMutation,
+  useExtractUtilityPlanMutation,
   useUpdateUtilityPlanMutation,
   useDeleteUtilityPlanMutation,
 } = utilityPlansApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-draft.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-draft.ts
@@ -1,0 +1,56 @@
+/**
+ * A plan as read from a document — the response of ``POST /utility-plans/extract``.
+ *
+ * Mirrors ``schemas/properties/utility_plan_draft.py``. Deliberately NOT a
+ * ``UtilityPlanCreateRequest``: every field is optional (including the ones a
+ * real plan requires) because a document that never names its provider should
+ * still hand back the eleven fields it did state, and ``service_type`` /
+ * ``rate_type`` are plain strings rather than the unions because the backend
+ * only guarantees it dropped values outside them — it does not guarantee it
+ * found one.
+ *
+ * Rate fields arrive as strings, like every other rate on the wire, so 5.3509
+ * survives the JSON boundary intact.
+ */
+export interface UtilityPlanDraft {
+  source_document_id: string;
+
+  service_type: string | null;
+  provider_name: string | null;
+  plan_name: string | null;
+  account_number: string | null;
+  rate_type: string | null;
+
+  energy_charge_cents_per_kwh: string | null;
+  tdu_charge_cents_per_kwh: string | null;
+  avg_price_cents_per_kwh_at_1000: string | null;
+  monthly_base_charge_cents: number | null;
+
+  term_months: number | null;
+  service_start_date: string | null;
+  term_end_date: string | null;
+  early_termination_fee_cents: number | null;
+
+  has_bill_credit: boolean;
+  bill_credit_amount_cents: number | null;
+  bill_credit_threshold_kwh: number | null;
+  min_usage_fee_cents: number | null;
+  min_usage_threshold_kwh: number | null;
+
+  post_promo_monthly_cents: number | null;
+  equipment_fee_monthly_cents: number | null;
+  download_mbps: number | null;
+  upload_mbps: number | null;
+  data_cap_gb: number | null;
+
+  notes: string | null;
+
+  /** How much of this came off the page rather than out of interpretation. */
+  confidence: string;
+
+  /** Reasons to distrust a specific field, e.g. a TDU rate from a stale EFL. */
+  warnings: string[];
+
+  /** Real terms the schema has no column for. */
+  unrepresented: string[];
+}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -638,8 +638,12 @@
         "backend/app/schemas/properties/utility_plan_list_response.py",
         "backend/app/schemas/properties/utility_plan_renewal_alert_response.py",
         "backend/app/schemas/properties/utility_plan_validation.py",
+        "backend/app/schemas/properties/utility_plan_draft.py",
+        "backend/app/schemas/properties/utility_plan_extract_request.py",
         "backend/app/services/properties/utility_plan_service.py",
         "backend/app/services/properties/_utility_plan_helpers.py",
+        "backend/app/services/properties/utility_plan_extraction_service.py",
+        "backend/app/services/extraction/prompts/utility_plan_prompt.py",
         "backend/app/api/utility_plans.py",
         "backend/app/core/utility_plan_constants.py",
         "backend/app/cli/utility_plan_seed_row.py",
@@ -653,21 +657,25 @@
         "frontend/src/shared/types/utility/",
         "frontend/src/shared/store/utilityPlansApi.ts",
         "frontend/src/shared/lib/utility-plan-format.ts",
-        "frontend/src/shared/lib/utility-plan-form.ts"
+        "frontend/src/shared/lib/utility-plan-form.ts",
+        "frontend/src/shared/lib/utility-plan-draft.ts"
       ],
       "backend_tests": [
         "test_utility_plan_service.py",
         "test_utility_plan_repo.py",
         "test_utility_plans_api.py",
+        "test_utility_plan_extraction.py",
         "test_utility_plan_scheduler.py",
         "test_utility_plan_seed.py"
       ],
       "frontend_tests": [
         "UtilityPlans.test.tsx",
+        "AddUtilityPlanDialog.test.tsx",
         "EditUtilityPlanDialog.test.tsx",
         "UtilityPlanRenewalAlertCard.test.tsx",
         "utility-plan-format.test.ts",
         "utility-plan-form.test.ts",
+        "utility-plan-draft.test.ts",
         "Dashboard.test.tsx"
       ],
       "e2e_specs": [


### PR DESCRIPTION
## What

Entering a utility plan meant hand-typing fifteen fields off an Electricity Facts Label. This adds `POST /utility-plans/extract`, which reads those fields off a document already in the library and returns a **draft** the add form prefills. The endpoint saves nothing — the model proposes, the operator asserts. That distinction matters more than usual here, because every field ends up in a plan-vs-plan comparison where a wrong number is indistinguishable from a right one.

Second of three: #1061 added the schema (`source_document_id` + internet columns), this adds the reading, PR 3 adds internet-aware rendering.

## Design notes

**A draft is not a create request.** `UtilityPlanDraft` has every field optional and no cross-field validation. A document that states a bill credit but omits its threshold is exactly the case the operator needs to see and fix — 422-ing it would discard the eleven fields that read correctly.

**The model's output is untrusted input.** Enum values outside `SERVICE_TYPES`/`RATE_TYPES` are dropped rather than passed through: a hallucinated `"fixed_rate"` sitting preselected in a form is worse than an empty select, because it has to be *noticed* to be fixed. Same for negative money and unparseable rates. Rates quantize to 4dp — the fourth decimal is load-bearing (5.3509).

**Three warnings, for the things the operator cannot see.** A TDU charge is a pass-through the utility re-tariffs mid-term, so the one printed on an EFL is only true as of its issue date — reading the 6734 EFL on 2026-08-11 gave 6.0009 ¢/kWh against a then-current 5.1461, a silent 0.85 ¢/kWh error. Also flags half a bill credit and a post-promo price with no date it lands on.

**It takes a `document_id`, not a file.** `POST /documents/upload` already owns the size cap, the daily rate limit and the content sniff; reusing it means one path enforces those, and the resulting `source_document_id` points at a row that genuinely exists.

**The picker reads an existing document rather than uploading one.** Upload enqueues the transaction extractor — uploading an EFL through this flow would mint a junk transaction against the property.

**The draft fills the form, it never blanks it.** The operator may have typed the account number before reaching for the document; a field the document is silent on must not erase it.

**Nothing read is dropped in silence.** The form has no inputs for the internet/min-usage columns yet (PR 3), so anything read into them is listed back to the operator, alongside the backend's `unrepresented` list for terms the schema has no column for at all.

## Rate limit

30/hour per user. The daily upload cap bounds how many distinct documents exist, not how many times one is re-read, and each read is a paid model call.

## Tests

- **Backend, 45 new** — coercion (hallucinated enums, negative amounts, `"\$150.00"`, 4dp quantization, `0` vs `null`), all three warning branches, the text-vs-vision routing decision, a non-dict model response degrading to an empty draft rather than a 500, and the route's 404 / 422 / 429 mappings including that the limiter is keyed per user.
- **Frontend, 18 new** — the merge rule (fills, never blanks), unheld-field surfacing including a stated `\$0.00` fee, and the full read → prefill → save flow asserting `source_document_id` is recorded when read and absent when typed by hand.

Full backend suite green (3455 passed). Frontend: the 3 utility-plan files pass (35 tests); 9 failures elsewhere (`hourly-rate`, `PublicInquiryForm`, `PromoteFromInquiryPanel`, `LeaseTemplateUploadDialog`) are pre-existing and unrelated — e.g. `formatHourlyRate` rounding `\$45.55` where `\$45.56` is expected. `check-file-size.py` clean.

## Operational migration

None. No new required env var, no schema change, no default changed. The endpoint no-ops to an empty draft when `ANTHROPIC_API_KEY` is absent rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgX4F6Unf2PbXHwHAX2fVb