### PR TITLE
feat(mybookkeeper): give the utility-plan form inputs for the terms it could only read

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/AddUtilityPlanDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/AddUtilityPlanDialog.test.tsx
@@ -149,7 +149,7 @@ describe("AddUtilityPlanDialog — reading from a document", () => {
     mockExtract.mockReturnValue({
       unwrap: vi.fn().mockResolvedValue({
         ...DRAFT,
-        min_usage_fee_cents: 995,
+        notes: "Rate assumes autopay enrollment.",
         unrepresented: ["Rate steps to 21.4 c/kWh in months 11-12"],
       }),
     });
@@ -158,11 +158,105 @@ describe("AddUtilityPlanDialog — reading from a document", () => {
     await readTheDocument(user);
 
     await waitFor(() => {
-      expect(screen.getByText("Minimum usage fee: $9.95")).toBeInTheDocument();
+      expect(
+        screen.getByText("Notes: Rate assumes autopay enrollment."),
+      ).toBeInTheDocument();
     });
     expect(
       screen.getByText("Rate steps to 21.4 c/kWh in months 11-12"),
     ).toBeInTheDocument();
+  });
+
+  it("puts a minimum usage fee into its input rather than a notice", async () => {
+    // It used to land in the can't-hold notice for want of an input. Reading a
+    // term the operator then has to re-type by hand is the failure this closes.
+    const user = userEvent.setup();
+    mockExtract.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({
+        ...DRAFT,
+        min_usage_fee_cents: 995,
+        min_usage_threshold_kwh: 1000,
+      }),
+    });
+    renderDialog();
+
+    await readTheDocument(user);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("utility-plan-min-usage-fee-input")).toHaveValue(9.95);
+    });
+    expect(screen.getByTestId("utility-plan-min-usage-threshold-input")).toHaveValue(
+      1000,
+    );
+    expect(screen.queryByText("Minimum usage fee: $9.95")).not.toBeInTheDocument();
+  });
+
+  it("swaps the metered fields for the internet ones when the service changes", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    expect(screen.getByTestId("utility-plan-min-usage-fee-input")).toBeInTheDocument();
+    expect(screen.queryByTestId("utility-plan-internet-fields")).not.toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByTestId("utility-plan-service-select"),
+      "internet",
+    );
+
+    expect(screen.getByTestId("utility-plan-internet-fields")).toBeInTheDocument();
+    expect(screen.getByTestId("utility-plan-download-input")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("utility-plan-min-usage-fee-input"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("saves an internet plan's speeds and promo terms", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.selectOptions(
+      screen.getByTestId("utility-plan-property-select"),
+      "prop-1",
+    );
+    await user.type(screen.getByTestId("utility-plan-provider-input"), "Spectrum");
+    await user.selectOptions(
+      screen.getByTestId("utility-plan-service-select"),
+      "internet",
+    );
+    await user.type(screen.getByTestId("utility-plan-download-input"), "1000");
+    await user.type(screen.getByTestId("utility-plan-equipment-fee-input"), "15");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockCreate.mock.calls[0][0]).toMatchObject({
+      service_type: "internet",
+      download_mbps: 1000,
+      equipment_fee_monthly_cents: 1500,
+    });
+  });
+
+  it("refuses a promo price with no date it takes effect on", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.selectOptions(
+      screen.getByTestId("utility-plan-property-select"),
+      "prop-1",
+    );
+    await user.type(screen.getByTestId("utility-plan-provider-input"), "Spectrum");
+    await user.selectOptions(
+      screen.getByTestId("utility-plan-service-select"),
+      "internet",
+    );
+    await user.type(screen.getByTestId("utility-plan-post-promo-input"), "89.99");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() =>
+      expect(showError).toHaveBeenCalledWith(
+        "A post-promo price needs the date the promo ends.",
+      ),
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 
   it("shows a warning about a field that may be wrong", async () => {

--- a/apps/mybookkeeper/frontend/src/__tests__/EditUtilityPlanDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/EditUtilityPlanDialog.test.tsx
@@ -173,8 +173,8 @@ describe("EditUtilityPlanDialog — save", () => {
 
   /**
    * PATCH applies exactly the keys it receives, so a key the form does not own
-   * must never appear — sending null would erase the minimum-usage terms and
-   * the provenance note this plan carries.
+   * must never appear — sending null would erase the provenance note this plan
+   * carries.
    */
   it("never sends the fields it cannot edit", async () => {
     const user = userEvent.setup();
@@ -184,10 +184,25 @@ describe("EditUtilityPlanDialog — save", () => {
 
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     const [{ data }] = mockUpdate.mock.calls[0] as [{ data: Record<string, unknown> }];
-    expect(data).not.toHaveProperty("min_usage_fee_cents");
-    expect(data).not.toHaveProperty("min_usage_threshold_kwh");
     expect(data).not.toHaveProperty("notes");
     expect(data).not.toHaveProperty("property_id");
+  });
+
+  /**
+   * The other half of the same rule: a field the form DOES own must survive a
+   * save that never touched it. These two were previously omitted to protect
+   * them; now they are sent, so the protection has to come from the round trip.
+   */
+  it("returns the minimum-usage terms unchanged when they were not edited", async () => {
+    const user = userEvent.setup();
+
+    renderDialog();
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    const [{ data }] = mockUpdate.mock.calls[0] as [{ data: Record<string, unknown> }];
+    expect(data.min_usage_fee_cents).toBe(0);
+    expect(data.min_usage_threshold_kwh).toBe(999);
   });
 
   it("confirms and closes on success", async () => {

--- a/apps/mybookkeeper/frontend/src/__tests__/utility-plan-draft.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/utility-plan-draft.test.ts
@@ -131,35 +131,70 @@ describe("applyDraftToForm", () => {
 
     expect(values.monthlyBase).toBe("0.00");
   });
+
+  it("fills the minimum-usage terms the form now holds", () => {
+    const values = applyDraftToForm(
+      EMPTY_UTILITY_PLAN_FORM,
+      draft({ min_usage_fee_cents: 995, min_usage_threshold_kwh: 1000 }),
+    );
+
+    expect(values.minUsageFee).toBe("9.95");
+    expect(values.minUsageThreshold).toBe("1000");
+  });
+
+  it("fills the internet terms the form now holds", () => {
+    const values = applyDraftToForm(
+      EMPTY_UTILITY_PLAN_FORM,
+      draft({
+        service_type: "internet",
+        post_promo_monthly_cents: 8999,
+        equipment_fee_monthly_cents: 1500,
+        download_mbps: 1000,
+        upload_mbps: 35,
+        data_cap_gb: 1200,
+      }),
+    );
+
+    expect(values.serviceType).toBe("internet");
+    expect(values.postPromoMonthly).toBe("89.99");
+    expect(values.equipmentFeeMonthly).toBe("15.00");
+    expect(values.downloadMbps).toBe("1000");
+    expect(values.uploadMbps).toBe("35");
+    expect(values.dataCapGb).toBe("1200");
+  });
 });
 
 describe("draftFieldsTheFormCannotHold", () => {
   it("lists what was read but has no input yet", () => {
-    const dropped = draftFieldsTheFormCannotHold(
-      draft({
-        min_usage_fee_cents: 995,
-        download_mbps: 1000,
-        data_cap_gb: 1200,
-        notes: "Rate assumes autopay enrollment.",
-      }),
-    );
-
-    expect(dropped).toContain("Minimum usage fee: $9.95");
-    expect(dropped).toContain("Download speed: 1000 Mbps");
-    expect(dropped).toContain("Data cap: 1200 GB");
-    expect(dropped).toContain("Notes: Rate assumes autopay enrollment.");
+    expect(
+      draftFieldsTheFormCannotHold(draft({ notes: "Rate assumes autopay enrollment." })),
+    ).toEqual(["Notes: Rate assumes autopay enrollment."]);
   });
 
   it("says nothing when everything read fits the form", () => {
     expect(draftFieldsTheFormCannotHold(draft({ provider_name: "Reliant" }))).toEqual([]);
   });
 
-  it("still reports a stated zero fee", () => {
-    // "$0.00 minimum usage fee" is a recorded promise, not an absence — losing
-    // it silently is exactly the failure this list exists to prevent.
-    expect(draftFieldsTheFormCannotHold(draft({ min_usage_fee_cents: 0 }))).toEqual([
-      "Minimum usage fee: $0.00",
-    ]);
+  /**
+   * These seven used to land here. Every one now has an input, so a document
+   * stating them fills the form instead of listing them as dropped — which is
+   * the whole point of the change, and the assertion that would catch a
+   * regression where an input is removed but the notice is not restored.
+   */
+  it("no longer reports the terms the form gained inputs for", () => {
+    expect(
+      draftFieldsTheFormCannotHold(
+        draft({
+          min_usage_fee_cents: 0,
+          min_usage_threshold_kwh: 1000,
+          post_promo_monthly_cents: 8999,
+          equipment_fee_monthly_cents: 1500,
+          download_mbps: 1000,
+          upload_mbps: 35,
+          data_cap_gb: 1200,
+        }),
+      ),
+    ).toEqual([]);
   });
 
   it("ignores whitespace-only notes", () => {

--- a/apps/mybookkeeper/frontend/src/__tests__/utility-plan-form.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/utility-plan-form.test.ts
@@ -77,7 +77,41 @@ describe("toUtilityPlanFormValues", () => {
       hasBillCredit: false,
       billCreditAmount: "",
       billCreditThreshold: "",
+      minUsageFee: "0.00",
+      minUsageThreshold: "999",
+      postPromoMonthly: "",
+      equipmentFeeMonthly: "",
+      downloadMbps: "",
+      uploadMbps: "",
+      dataCapGb: "",
     });
+  });
+
+  it("prefills the internet terms of an internet plan", () => {
+    const values = toUtilityPlanFormValues(
+      makeDetail({
+        service_type: "internet",
+        post_promo_monthly_cents: 8999,
+        equipment_fee_monthly_cents: 1500,
+        download_mbps: 1000,
+        upload_mbps: 1000,
+        data_cap_gb: 1200,
+      }),
+    );
+
+    expect(values.postPromoMonthly).toBe("89.99");
+    expect(values.equipmentFeeMonthly).toBe("15.00");
+    expect(values.downloadMbps).toBe("1000");
+    expect(values.uploadMbps).toBe("1000");
+    expect(values.dataCapGb).toBe("1200");
+  });
+
+  it("keeps a stated zero minimum-usage fee rather than blanking it", () => {
+    // "$0.00 minimum usage fee" is a recorded promise, not an absence. Blanking
+    // it would send null back on the next save and erase what the EFL said.
+    const values = toUtilityPlanFormValues(makeDetail({ min_usage_fee_cents: 0 }));
+
+    expect(values.minUsageFee).toBe("0.00");
   });
 
   it("keeps a sub-cent TDU rate intact rather than rounding to two places", () => {
@@ -149,16 +183,65 @@ describe("toUtilityPlanFields", () => {
 
   /**
    * The API applies exactly the keys it receives (``exclude_unset``). Emitting
-   * these as null would erase the minimum-usage terms and the provenance note
-   * the seeded plans carry, neither of which this form can edit.
+   * ``notes`` as null would erase the provenance line the seeded plans carry,
+   * and this form still has no input for it.
    */
   it("omits the fields the form does not edit rather than nulling them", () => {
     const payload = toUtilityPlanFields(toUtilityPlanFormValues(makeDetail()));
 
-    expect(payload).not.toHaveProperty("min_usage_fee_cents");
-    expect(payload).not.toHaveProperty("min_usage_threshold_kwh");
     expect(payload).not.toHaveProperty("notes");
     expect(payload).not.toHaveProperty("property_id");
+  });
+
+  it("round-trips the minimum-usage terms it now edits", () => {
+    // Previously omitted so a PATCH couldn't erase them. Now that the form
+    // holds them, a save must carry them back unchanged.
+    const payload = toUtilityPlanFields(toUtilityPlanFormValues(makeDetail()));
+
+    expect(payload.min_usage_fee_cents).toBe(0);
+    expect(payload.min_usage_threshold_kwh).toBe(999);
+  });
+
+  it("round-trips the internet terms it now edits", () => {
+    const payload = toUtilityPlanFields(
+      toUtilityPlanFormValues(
+        makeDetail({
+          service_type: "internet",
+          post_promo_monthly_cents: 8999,
+          equipment_fee_monthly_cents: 1500,
+          download_mbps: 1000,
+          upload_mbps: 35,
+          data_cap_gb: 1200,
+        }),
+      ),
+    );
+
+    expect(payload.post_promo_monthly_cents).toBe(8999);
+    expect(payload.equipment_fee_monthly_cents).toBe(1500);
+    expect(payload.download_mbps).toBe(1000);
+    expect(payload.upload_mbps).toBe(35);
+    expect(payload.data_cap_gb).toBe(1200);
+  });
+
+  /**
+   * The inputs are hidden for services they don't describe, but the values
+   * behind them are still sent. Clearing them on a service-type change would
+   * destroy an internet plan's speeds the moment someone corrected a typo in
+   * its service — there is no CHECK constraint forcing the drop, unlike the
+   * bill-credit pair.
+   */
+  it("keeps internet terms when the service type is not internet", () => {
+    const payload = toUtilityPlanFields({
+      ...EMPTY_UTILITY_PLAN_FORM,
+      providerName: "Spectrum",
+      serviceType: "electricity",
+      downloadMbps: "1000",
+      termEndDate: "2027-02-17",
+      postPromoMonthly: "89.99",
+    });
+
+    expect(payload.download_mbps).toBe(1000);
+    expect(payload.post_promo_monthly_cents).toBe(8999);
   });
 
   it("turns an untouched optional field into null, not an empty string", () => {
@@ -236,5 +319,52 @@ describe("validateUtilityPlanForm", () => {
         billCreditThreshold: "",
       }),
     ).toBe("A bill credit needs both an amount and a usage threshold.");
+  });
+
+  it("rejects a post-promo price with no date it takes effect on", () => {
+    // The table rejects the same shape. Catching it here points at the field
+    // instead of costing a round trip that comes back as a raw 422.
+    expect(
+      validateUtilityPlanForm({
+        ...EMPTY_UTILITY_PLAN_FORM,
+        providerName: "Spectrum",
+        serviceType: "internet",
+        postPromoMonthly: "89.99",
+      }),
+    ).toBe("A post-promo price needs the date the promo ends.");
+  });
+
+  it("accepts a post-promo price once the term end date is set", () => {
+    expect(
+      validateUtilityPlanForm({
+        ...EMPTY_UTILITY_PLAN_FORM,
+        providerName: "Spectrum",
+        serviceType: "internet",
+        postPromoMonthly: "89.99",
+        termEndDate: "2027-02-17",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects a zero speed, which the table stores as null instead", () => {
+    expect(
+      validateUtilityPlanForm({
+        ...EMPTY_UTILITY_PLAN_FORM,
+        providerName: "Spectrum",
+        serviceType: "internet",
+        uploadMbps: "0",
+      }),
+    ).toBe("Speeds and data caps must be more than zero.");
+  });
+
+  it("accepts blank speeds, which mean not recorded", () => {
+    expect(
+      validateUtilityPlanForm({
+        ...EMPTY_UTILITY_PLAN_FORM,
+        providerName: "Spectrum",
+        serviceType: "internet",
+        downloadMbps: "1000",
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/mybookkeeper/frontend/src/app/features/utility/AddUtilityPlanDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/AddUtilityPlanDialog.tsx
@@ -13,7 +13,8 @@ import UtilityPlanDialogShell from "./UtilityPlanDialogShell";
 import UtilityPlanDocumentReader from "./UtilityPlanDocumentReader";
 import UtilityPlanDraftNotices from "./UtilityPlanDraftNotices";
 import UtilityPlanFormActions from "./UtilityPlanFormActions";
-import UtilityPlanFormFields, { UTILITY_PLAN_INPUT_CLASS } from "./UtilityPlanFormFields";
+import UtilityPlanFormFields from "./UtilityPlanFormFields";
+import { UTILITY_PLAN_INPUT_CLASS } from "./utility-plan-input-class";
 import { useUtilityPlanForm } from "./useUtilityPlanForm";
 
 export interface AddUtilityPlanDialogProps {

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDocumentReader.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDocumentReader.tsx
@@ -5,7 +5,7 @@ import { showError } from "@/shared/lib/toast-store";
 import { useGetDocumentsQuery } from "@/shared/store/documentsApi";
 import { useExtractUtilityPlanMutation } from "@/shared/store/utilityPlansApi";
 import type { UtilityPlanDraft } from "@/shared/types/utility/utility-plan-draft";
-import { UTILITY_PLAN_INPUT_CLASS } from "./UtilityPlanFormFields";
+import { UTILITY_PLAN_INPUT_CLASS } from "./utility-plan-input-class";
 
 export interface UtilityPlanDocumentReaderProps {
   onRead: (draft: UtilityPlanDraft) => void;

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormFields.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormFields.tsx
@@ -11,6 +11,8 @@ import {
 import type { UtilityPlanRateType } from "@/shared/types/utility/utility-plan-rate-type";
 import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
 import type { UtilityPlanFormState } from "./useUtilityPlanForm";
+import UtilityPlanInternetFields from "./UtilityPlanInternetFields";
+import { UTILITY_PLAN_INPUT_CLASS } from "./utility-plan-input-class";
 
 /**
  * The inputs edit one field at a time, so they take only that much of the form
@@ -22,7 +24,6 @@ export type UtilityPlanFormFieldsProps = Pick<
   "values" | "setField"
 >;
 
-export const UTILITY_PLAN_INPUT_CLASS = "w-full px-3 py-2 text-sm border rounded-md";
 
 /**
  * Every field of a utility plan except the property it belongs to.
@@ -257,6 +258,41 @@ export default function UtilityPlanFormFields({
           </FormField>
         </div>
       ) : null}
+
+      {values.serviceType === "internet" ? (
+        <UtilityPlanInternetFields values={values} setField={setField} />
+      ) : (
+        // The bill credit's mirror image: a penalty below a usage floor rather
+        // than a reward above one. Both are in kWh, so neither describes an
+        // internet plan.
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <FormField label="Minimum usage fee (USD)">
+            <input
+              type="number"
+              value={values.minUsageFee}
+              onChange={(e) => setField("minUsageFee", e.target.value)}
+              placeholder="9.95"
+              min="0"
+              step="0.01"
+              className={UTILITY_PLAN_INPUT_CLASS}
+              data-testid="utility-plan-min-usage-fee-input"
+            />
+          </FormField>
+
+          <FormField label="Charged below (kWh)">
+            <input
+              type="number"
+              value={values.minUsageThreshold}
+              onChange={(e) => setField("minUsageThreshold", e.target.value)}
+              placeholder="1000"
+              min="0"
+              step="1"
+              className={UTILITY_PLAN_INPUT_CLASS}
+              data-testid="utility-plan-min-usage-threshold-input"
+            />
+          </FormField>
+        </div>
+      )}
     </>
   );
 }

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormSkeleton.tsx
@@ -37,6 +37,13 @@ export default function UtilityPlanFormSkeleton() {
       </div>
       <div className="h-14 bg-muted rounded" />
       <div className="h-5 bg-muted rounded w-2/5" />
+      {/* The minimum-usage pair. A plan opens on its saved service type, and
+          every service but internet lands here; the internet block it gives way
+          to is a row taller, which stays inside the dialog's jump budget. */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="h-14 bg-muted rounded" />
+        <div className="h-14 bg-muted rounded" />
+      </div>
       <div className="flex gap-3 pt-2 justify-end">
         <div className="h-10 w-24 bg-muted rounded" />
         <div className="h-10 w-32 bg-muted rounded" />

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanInternetFields.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanInternetFields.tsx
@@ -1,0 +1,106 @@
+import FormField from "@/shared/components/ui/FormField";
+import { UTILITY_PLAN_INPUT_CLASS } from "./utility-plan-input-class";
+import type { UtilityPlanFormState } from "./useUtilityPlanForm";
+
+export type UtilityPlanInternetFieldsProps = Pick<
+  UtilityPlanFormState,
+  "values" | "setField"
+>;
+
+/**
+ * The terms that price an internet plan rather than a metered one.
+ *
+ * Rendered only for the internet service type, because none of it describes a
+ * kWh: a promo that steps up to a standard rate, a modem rental quoted outside
+ * the advertised price, and the speeds that say what the money actually buys.
+ *
+ * Hiding these does not clear them — see ``toUtilityPlanFields``. A plan whose
+ * service type is corrected keeps whatever it already recorded.
+ */
+export default function UtilityPlanInternetFields({
+  values,
+  setField,
+}: UtilityPlanInternetFieldsProps) {
+  return (
+    <div className="space-y-4" data-testid="utility-plan-internet-fields">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <FormField label="Price after the promo (USD/mo)">
+          <input
+            type="number"
+            value={values.postPromoMonthly}
+            onChange={(e) => setField("postPromoMonthly", e.target.value)}
+            placeholder="89.99"
+            min="0"
+            step="0.01"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-post-promo-input"
+          />
+        </FormField>
+
+        <FormField label="Equipment fee (USD/mo)">
+          <input
+            type="number"
+            value={values.equipmentFeeMonthly}
+            onChange={(e) => setField("equipmentFeeMonthly", e.target.value)}
+            placeholder="15"
+            min="0"
+            step="0.01"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-equipment-fee-input"
+          />
+        </FormField>
+      </div>
+
+      <p className="text-xs text-muted-foreground -mt-2">
+        A promo price needs the date it ends — set "Term ends" above, and the
+        renewal alert will name the day the bill goes up. Leave the data cap
+        blank if the plan is uncapped.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <FormField label="Download (Mbps)">
+          <input
+            type="number"
+            value={values.downloadMbps}
+            onChange={(e) => setField("downloadMbps", e.target.value)}
+            placeholder="1000"
+            min="1"
+            step="1"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-download-input"
+          />
+        </FormField>
+
+        <FormField label="Upload (Mbps)">
+          <input
+            type="number"
+            value={values.uploadMbps}
+            onChange={(e) => setField("uploadMbps", e.target.value)}
+            placeholder="1000"
+            min="1"
+            step="1"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-upload-input"
+          />
+        </FormField>
+
+        {/* Blank means uncapped, which is the usual case on fibre — the
+            backend rejects 0 so the two never collapse into each other. Said
+            in the hint above rather than the placeholder, which this column is
+            too narrow to show in full. */}
+        <FormField label="Data cap (GB)">
+          <input
+            type="number"
+            value={values.dataCapGb}
+            onChange={(e) => setField("dataCapGb", e.target.value)}
+            placeholder="1200"
+            min="1"
+            step="1"
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="utility-plan-data-cap-input"
+          />
+        </FormField>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/utility-plan-input-class.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/utility-plan-input-class.ts
@@ -1,0 +1,8 @@
+/**
+ * The one input styling the utility-plan dialogs share.
+ *
+ * Its own module rather than an export off ``UtilityPlanFormFields`` so the
+ * field components that make up that form can use it without importing their
+ * own parent — a cycle that only grows as the form is split further.
+ */
+export const UTILITY_PLAN_INPUT_CLASS = "w-full px-3 py-2 text-sm border rounded-md";

--- a/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-draft.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-draft.ts
@@ -67,6 +67,13 @@ function draftedFields(draft: UtilityPlanDraft): Partial<UtilityPlanFormValues> 
     etf: centsToDollarString(draft.early_termination_fee_cents),
     billCreditAmount: centsToDollarString(draft.bill_credit_amount_cents),
     billCreditThreshold: intToInputString(draft.bill_credit_threshold_kwh),
+    minUsageFee: centsToDollarString(draft.min_usage_fee_cents),
+    minUsageThreshold: intToInputString(draft.min_usage_threshold_kwh),
+    postPromoMonthly: centsToDollarString(draft.post_promo_monthly_cents),
+    equipmentFeeMonthly: centsToDollarString(draft.equipment_fee_monthly_cents),
+    downloadMbps: intToInputString(draft.download_mbps),
+    uploadMbps: intToInputString(draft.upload_mbps),
+    dataCapGb: intToInputString(draft.data_cap_gb),
   };
 
   const set: Partial<UtilityPlanFormValues> = {};
@@ -96,35 +103,22 @@ export function applyDraftToForm(
   };
 }
 
-/** Draft fields the form has no input for yet, keyed by what to call them. */
-const UNHELD_FIELD_LABELS: ReadonlyArray<
-  [keyof UtilityPlanDraft, (value: number) => string]
-> = [
-  ["min_usage_fee_cents", (v) => `Minimum usage fee: $${(v / 100).toFixed(2)}`],
-  ["min_usage_threshold_kwh", (v) => `Minimum usage threshold: ${v} kWh`],
-  ["post_promo_monthly_cents", (v) => `Price after the promo: $${(v / 100).toFixed(2)}/mo`],
-  ["equipment_fee_monthly_cents", (v) => `Equipment fee: $${(v / 100).toFixed(2)}/mo`],
-  ["download_mbps", (v) => `Download speed: ${v} Mbps`],
-  ["upload_mbps", (v) => `Upload speed: ${v} Mbps`],
-  ["data_cap_gb", (v) => `Data cap: ${v} GB`],
-];
-
 /**
  * Terms the document stated that this form cannot currently hold.
  *
- * Without this they would be read, returned, and silently dropped on the floor
- * — the operator would have no way to know the document said anything about a
- * minimum usage fee. Rendered alongside the backend's own ``unrepresented``
- * list, which covers terms the *database* has no column for; this one covers
- * terms the database holds but this form does not yet edit.
+ * Without this they would be read, returned, and silently dropped on the floor.
+ * Rendered alongside the backend's own ``unrepresented`` list, which covers
+ * terms the *database* has no column for; this one covers terms the database
+ * holds but this form does not yet edit.
+ *
+ * Down to ``notes`` alone. Every other field the reader can return now has an
+ * input, so the list is empty for most documents — which is the point, and the
+ * reason it stays: it is the seam that will catch the next column added to the
+ * draft ahead of its input. Notes is deliberately last to be held. ``PATCH``
+ * applies exactly the keys it is sent, and editing notes here would erase the
+ * provenance line the seeded plans carry.
  */
 export function draftFieldsTheFormCannotHold(draft: UtilityPlanDraft): string[] {
-  const dropped = UNHELD_FIELD_LABELS.flatMap(([key, label]) => {
-    const value = draft[key];
-    return typeof value === "number" ? [label(value)] : [];
-  });
-  if (draft.notes !== null && draft.notes.trim() !== "") {
-    dropped.push(`Notes: ${draft.notes.trim()}`);
-  }
-  return dropped;
+  if (draft.notes === null || draft.notes.trim() === "") return [];
+  return [`Notes: ${draft.notes.trim()}`];
 }

--- a/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-form.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-form.ts
@@ -28,6 +28,13 @@ export const EMPTY_UTILITY_PLAN_FORM: UtilityPlanFormValues = {
   hasBillCredit: false,
   billCreditAmount: "",
   billCreditThreshold: "",
+  minUsageFee: "",
+  minUsageThreshold: "",
+  postPromoMonthly: "",
+  equipmentFeeMonthly: "",
+  downloadMbps: "",
+  uploadMbps: "",
+  dataCapGb: "",
 };
 
 /** ``""`` → null so an untouched field is absent rather than zero. */
@@ -58,6 +65,10 @@ function centsToDollarString(value: number | null): string {
   return (value / 100).toFixed(2);
 }
 
+function intToInputString(value: number | null): string {
+  return value === null ? "" : String(value);
+}
+
 /**
  * ``"11.6000"`` → ``"11.6"``.
  *
@@ -83,16 +94,20 @@ export function toUtilityPlanFormValues(plan: UtilityPlanDetail): UtilityPlanFor
     tduCharge: rateToInputString(plan.tdu_charge_cents_per_kwh),
     avgPrice: rateToInputString(plan.avg_price_cents_per_kwh_at_1000),
     monthlyBase: centsToDollarString(plan.monthly_base_charge_cents),
-    termMonths: plan.term_months === null ? "" : String(plan.term_months),
+    termMonths: intToInputString(plan.term_months),
     serviceStartDate: plan.service_start_date ?? "",
     termEndDate: plan.term_end_date ?? "",
     etf: centsToDollarString(plan.early_termination_fee_cents),
     hasBillCredit: plan.has_bill_credit,
     billCreditAmount: centsToDollarString(plan.bill_credit_amount_cents),
-    billCreditThreshold:
-      plan.bill_credit_threshold_kwh === null
-        ? ""
-        : String(plan.bill_credit_threshold_kwh),
+    billCreditThreshold: intToInputString(plan.bill_credit_threshold_kwh),
+    minUsageFee: centsToDollarString(plan.min_usage_fee_cents),
+    minUsageThreshold: intToInputString(plan.min_usage_threshold_kwh),
+    postPromoMonthly: centsToDollarString(plan.post_promo_monthly_cents),
+    equipmentFeeMonthly: centsToDollarString(plan.equipment_fee_monthly_cents),
+    downloadMbps: intToInputString(plan.download_mbps),
+    uploadMbps: intToInputString(plan.upload_mbps),
+    dataCapGb: intToInputString(plan.data_cap_gb),
   };
 }
 
@@ -122,6 +137,19 @@ export function toUtilityPlanFields(
     bill_credit_threshold_kwh: values.hasBillCredit
       ? toInt(values.billCreditThreshold)
       : null,
+    min_usage_fee_cents: dollarsToCents(values.minUsageFee),
+    min_usage_threshold_kwh: toInt(values.minUsageThreshold),
+    // Sent whatever the service type is, unlike the bill-credit pair above.
+    // That pair MUST be dropped when its toggle is off or the row violates
+    // ``chk_utility_plan_bill_credit_complete``; these have no such constraint,
+    // so gating them on the service type would silently erase an internet
+    // plan's speeds the moment someone corrected its service to electricity.
+    // The inputs are hidden for services they don't describe, not cleared.
+    post_promo_monthly_cents: dollarsToCents(values.postPromoMonthly),
+    equipment_fee_monthly_cents: dollarsToCents(values.equipmentFeeMonthly),
+    download_mbps: toInt(values.downloadMbps),
+    upload_mbps: toInt(values.uploadMbps),
+    data_cap_gb: toInt(values.dataCapGb),
   };
 }
 
@@ -138,5 +166,21 @@ export function validateUtilityPlanForm(values: UtilityPlanFormValues): string |
   ) {
     return "A bill credit needs both an amount and a usage threshold.";
   }
+  // A price step with no date is one the renewal alert cannot announce, so the
+  // table rejects it outright (``chk_utility_plan_post_promo_needs_term_end``).
+  if (values.postPromoMonthly.trim() !== "" && values.termEndDate === "") {
+    return "A post-promo price needs the date the promo ends.";
+  }
+  // Zero is not a speed or a cap — it means "not recorded", which blank
+  // already says. The table keeps the two distinct by rejecting zero.
+  if ([values.downloadMbps, values.uploadMbps, values.dataCapGb].some(isNotPositive)) {
+    return "Speeds and data caps must be more than zero.";
+  }
   return null;
+}
+
+/** True for a filled-in field that parses to zero or less. Blank is fine. */
+function isNotPositive(value: string): boolean {
+  const parsed = toInt(value);
+  return parsed !== null && parsed <= 0;
 }

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-fields-payload.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-fields-payload.ts
@@ -8,10 +8,9 @@ import type { UtilityServiceType } from "@/shared/types/utility/utility-service-
  * ``UtilityPlanUpdateRequest``: adding ``property_id`` makes it a create body,
  * and it is assignable to an update body as is.
  *
- * ``min_usage_fee_cents``, ``min_usage_threshold_kwh`` and ``notes`` are
- * deliberately absent. The form does not edit them and ``PATCH`` applies
- * exactly the keys it is sent, so including them would erase what a seeded
- * plan records.
+ * ``notes`` is deliberately absent. The form does not edit it and ``PATCH``
+ * applies exactly the keys it is sent, so including it would erase the
+ * provenance note a seeded plan records.
  */
 export interface UtilityPlanFieldsPayload {
   service_type: UtilityServiceType;
@@ -33,4 +32,12 @@ export interface UtilityPlanFieldsPayload {
   has_bill_credit: boolean;
   bill_credit_amount_cents: number | null;
   bill_credit_threshold_kwh: number | null;
+  min_usage_fee_cents: number | null;
+  min_usage_threshold_kwh: number | null;
+
+  post_promo_monthly_cents: number | null;
+  equipment_fee_monthly_cents: number | null;
+  download_mbps: number | null;
+  upload_mbps: number | null;
+  data_cap_gb: number | null;
 }

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-form-values.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-form-values.ts
@@ -32,4 +32,12 @@ export interface UtilityPlanFormValues {
   hasBillCredit: boolean;
   billCreditAmount: string;
   billCreditThreshold: string;
+  minUsageFee: string;
+  minUsageThreshold: string;
+
+  postPromoMonthly: string;
+  equipmentFeeMonthly: string;
+  downloadMbps: string;
+  uploadMbps: string;
+  dataCapGb: string;
 }


### PR DESCRIPTION
Third of the utility-plan capture series, after #1061 (provenance + internet columns) and #1062 (read a plan off a document).

## What was wrong

The reader from #1062 returns seven terms the form had no field for — `min_usage_fee_cents`, `min_usage_threshold_kwh`, and the five internet columns. `draftFieldsTheFormCannotHold()` listed them in a "this form has no field for them yet" notice, and then they were dropped. The operator had to re-type by hand what had just been read off the document.

## What this does

Adds an input for all seven.

- **Internet block** (`UtilityPlanInternetFields.tsx`) — price after the promo, equipment fee, download, upload, data cap. Renders only when the service type is internet; none of it describes a kWh.
- **Minimum-usage pair** — the bill credit's mirror image, a penalty below a usage floor. Renders for every other service.

`draftFieldsTheFormCannotHold()` is down to `notes` alone. It stays because it is now the seam that will catch the next draft column added ahead of its input.

## The one real design call

**Hiding a block does not clear it.** The bill-credit pair *must* be dropped when its toggle goes off, or the row violates `chk_utility_plan_bill_credit_complete`. These seven have no such constraint, so gating what gets *sent* on the service type would erase an internet plan's speeds the moment someone corrected a typo in its service. The inputs are hidden for services they don't describe; the values behind them still round-trip.

`min_usage_fee_cents` / `min_usage_threshold_kwh` are consequently no longer omitted from the PATCH body. They were omitted to protect them from being nulled; now that the form owns them, a save carries them back instead. `notes` stays omitted.

## Guards

Two client-side checks mirror the table's CHECKs so the operator gets a message pointing at the field instead of a raw 422:

- a post-promo price needs the term end date it steps up on (`chk_utility_plan_post_promo_needs_term_end`)
- a speed or cap of zero is rejected — blank already means "not recorded" (`chk_utility_plan_speeds_positive`)

## Verification

Backend is untouched — no schema, endpoint, or migration change. `UtilityPlanCreateRequest` / `UpdateRequest` already accepted all seven.

- `bash scripts/run-affected-tests.sh` — 8 files, **111 frontend tests passing**. Backend leg correctly skipped (no backend files changed).
- `tsc --noEmit` clean, `npm run lint` 0 errors, `npm run build` clean.
- **Driven against the running app** (backend :8000, frontend :5173): created an internet plan with a promo price, speeds and a data cap; confirmed the guard fires when the term end date is missing; **switched the saved plan's service to electricity, saved, reopened — the speeds and promo price were still there.** Test row deleted afterwards; no console errors.
- `UtilityPlanFormSkeleton` gained a row to match the taller form, keeping the layout E2E's no-jolt budget.

## Operational migration

None. Frontend-only; no env var, no migration, no boot guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgX4F6Unf2PbXHwHAX2fVb
