### PR TITLE
feat(mybookkeeper): flag utility plans priced above market

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/mktbench260811_market_rate_benchmarks.py
+++ b/apps/mybookkeeper/backend/alembic/versions/mktbench260811_market_rate_benchmarks.py
@@ -1,0 +1,142 @@
+"""add market_rate_benchmarks — what the market charges, to compare plans against
+
+``utility_plans`` records what is being paid. Nothing records what *could* be
+paid, so the only overpay the app can currently detect is a lapsed term. A plan
+signed at a good price two years ago and still comfortably inside its term looks
+completely healthy on the list while being the most expensive line in the
+portfolio.
+
+This table holds one operator-recorded market observation per (organization,
+service type). The comparison needs no more than that: the plan's advertised
+figure against the market's, with a materiality threshold so ordinary noise
+between two hand-recorded numbers does not raise a badge.
+
+Operator-maintained rather than scraped on purpose — the authoritative source
+differs per market and per service, and a confidently wrong automatic rate is
+worse than no rate at all. ``source`` and ``observed_on`` keep a stale or
+mis-sourced number visible rather than silently driving the flag.
+
+Revision ID: mktbench260811
+Revises: utilcap260811
+Create Date: 2026-08-11
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "mktbench260811"
+down_revision = "utilcap260811"
+branch_labels = None
+depends_on = None
+
+# Mirrors app.core.utility_plan_constants.SERVICE_TYPES. Spelled out rather
+# than imported so the migration keeps describing the schema as it was at this
+# revision even after the constant later gains a value.
+_SERVICE_TYPES = ("electricity", "internet", "natural_gas", "water")
+_SERVICE_TYPE_IN = ", ".join(f"'{v}'" for v in _SERVICE_TYPES)
+
+# Mirrors app.core.market_benchmark_constants.FLAT_RATE_SERVICE_TYPES — the
+# services quoted as a monthly amount rather than per unit consumed.
+_FLAT_SERVICE_TYPES = ("internet",)
+_FLAT_SERVICE_TYPE_IN = ", ".join(f"'{v}'" for v in _FLAT_SERVICE_TYPES)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "market_rate_benchmarks",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        # Provenance only — the row is scoped to the organization, so this is
+        # never a query filter. SET NULL rather than CASCADE: removing the
+        # member who looked the rate up must not delete the org's benchmark.
+        sa.Column(
+            "recorded_by_user_id", postgresql.UUID(as_uuid=True), nullable=True,
+        ),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("service_type", sa.String(length=20), nullable=False),
+        # Metered shape (electricity, gas): four decimals, same as the plan's
+        # own rate columns, because integer cents cannot hold 11.6000.
+        sa.Column("rate_cents_per_kwh", sa.Numeric(9, 4), nullable=True),
+        # Flat shape (internet).
+        sa.Column("monthly_cents", sa.BigInteger(), nullable=True),
+        sa.Column("source", sa.String(length=255), nullable=True),
+        sa.Column("observed_on", sa.Date(), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["recorded_by_user_id"], ["users.id"], ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE",
+        ),
+        sa.CheckConstraint(
+            f"service_type IN ({_SERVICE_TYPE_IN})",
+            name="chk_market_benchmark_service_type",
+        ),
+        # Exactly one shape: neither set compares against nothing, both set
+        # cannot say which comparison the row means.
+        sa.CheckConstraint(
+            "(rate_cents_per_kwh IS NULL) <> (monthly_cents IS NULL)",
+            name="chk_market_benchmark_one_shape",
+        ),
+        # ...and it must be the shape that service type is priced in. An
+        # electricity benchmark stored as monthly_cents would compare a per-kWh
+        # rate against a dollar amount and read as ~99% below market — a
+        # permanently wrong all-clear rather than a visible error.
+        sa.CheckConstraint(
+            f"(service_type IN ({_FLAT_SERVICE_TYPE_IN}))"
+            " = (monthly_cents IS NOT NULL)",
+            name="chk_market_benchmark_shape_matches_service",
+        ),
+        sa.CheckConstraint(
+            "(rate_cents_per_kwh IS NULL OR rate_cents_per_kwh > 0)"
+            " AND (monthly_cents IS NULL OR monthly_cents > 0)",
+            name="chk_market_benchmark_positive",
+        ),
+    )
+    op.create_index(
+        "ix_market_rate_benchmarks_recorded_by_user_id",
+        "market_rate_benchmarks",
+        ["recorded_by_user_id"],
+    )
+    op.create_index(
+        "ix_market_rate_benchmarks_organization_id",
+        "market_rate_benchmarks",
+        ["organization_id"],
+    )
+    # One benchmark per service per org — a superseded market observation has
+    # no value once a newer one exists, and keeping several would leave the
+    # comparison ambiguous about which to apply.
+    op.create_index(
+        "uq_market_benchmark_org_service",
+        "market_rate_benchmarks",
+        ["organization_id", "service_type"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_market_benchmark_org_service", table_name="market_rate_benchmarks")
+    op.drop_index(
+        "ix_market_rate_benchmarks_organization_id", table_name="market_rate_benchmarks",
+    )
+    op.drop_index(
+        "ix_market_rate_benchmarks_recorded_by_user_id",
+        table_name="market_rate_benchmarks",
+    )
+    op.drop_table("market_rate_benchmarks")

--- a/apps/mybookkeeper/backend/app/api/market_rate_benchmarks.py
+++ b/apps/mybookkeeper/backend/app/api/market_rate_benchmarks.py
@@ -1,0 +1,80 @@
+"""HTTP routes for market rate benchmarks.
+
+Route prefix: /market-rate-benchmarks.
+
+Keyed on service type rather than an id: there is at most one benchmark per
+service per organization, so the service type *is* the address. That makes the
+write a PUT (idempotent upsert) instead of a POST/PATCH pair.
+
+The comparison these benchmarks feed lives at ``/utility-plans/rate-comparison``
+— it returns plans, so it belongs on the plan resource next to
+``/renewal-alerts``.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Response
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.schemas.properties.market_rate_benchmark_response import (
+    MarketRateBenchmarkResponse,
+)
+from app.schemas.properties.market_rate_benchmark_upsert_request import (
+    MarketRateBenchmarkUpsertRequest,
+)
+from app.services.properties import market_rate_benchmark_service
+
+router = APIRouter(prefix="/market-rate-benchmarks", tags=["market-rate-benchmarks"])
+
+_NOT_FOUND_DETAIL = "No benchmark recorded for that service type"
+
+
+@router.get("", response_model=list[MarketRateBenchmarkResponse])
+async def list_benchmarks(
+    ctx: RequestContext = Depends(current_org_member),
+) -> list[MarketRateBenchmarkResponse]:
+    """Every benchmark the organization has recorded.
+
+    Unpaginated: capped at one row per service type by a unique index.
+    """
+    return await market_rate_benchmark_service.list_benchmarks(
+        organization_id=ctx.organization_id,
+    )
+
+
+@router.put("/{service_type}", response_model=MarketRateBenchmarkResponse)
+async def upsert_benchmark(
+    payload: MarketRateBenchmarkUpsertRequest,
+    service_type: str = Path(..., min_length=1, max_length=20),
+    ctx: RequestContext = Depends(require_write_access),
+) -> MarketRateBenchmarkResponse:
+    try:
+        return await market_rate_benchmark_service.upsert_benchmark(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            service_type=service_type,
+            rate_cents_per_kwh=payload.rate_cents_per_kwh,
+            monthly_cents=payload.monthly_cents,
+            source=payload.source,
+            observed_on=payload.observed_on,
+            notes=payload.notes,
+        )
+    except market_rate_benchmark_service.InvalidMarketRateBenchmarkError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.delete("/{service_type}", status_code=204)
+async def delete_benchmark(
+    service_type: str = Path(..., min_length=1, max_length=20),
+    ctx: RequestContext = Depends(require_write_access),
+) -> Response:
+    try:
+        await market_rate_benchmark_service.delete_benchmark(
+            organization_id=ctx.organization_id,
+            service_type=service_type,
+        )
+    except market_rate_benchmark_service.InvalidMarketRateBenchmarkError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except market_rate_benchmark_service.MarketRateBenchmarkNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL) from exc
+    return Response(status_code=204)

--- a/apps/mybookkeeper/backend/app/api/utility_plans.py
+++ b/apps/mybookkeeper/backend/app/api/utility_plans.py
@@ -18,12 +18,19 @@ from app.schemas.properties.utility_plan_create_request import UtilityPlanCreate
 from app.schemas.properties.utility_plan_draft import UtilityPlanDraft
 from app.schemas.properties.utility_plan_extract_request import UtilityPlanExtractRequest
 from app.schemas.properties.utility_plan_list_response import UtilityPlanListResponse
+from app.schemas.properties.utility_plan_rate_comparison_response import (
+    UtilityPlanRateComparisonResponse,
+)
 from app.schemas.properties.utility_plan_renewal_alert_response import (
     UtilityPlanRenewalAlertResponse,
 )
 from app.schemas.properties.utility_plan_response import UtilityPlanResponse
 from app.schemas.properties.utility_plan_update_request import UtilityPlanUpdateRequest
-from app.services.properties import utility_plan_extraction_service, utility_plan_service
+from app.services.properties import (
+    market_rate_benchmark_service,
+    utility_plan_extraction_service,
+    utility_plan_service,
+)
 
 router = APIRouter(prefix="/utility-plans", tags=["utility-plans"])
 
@@ -106,6 +113,22 @@ async def get_renewal_alerts(
         user_id=ctx.user_id,
         organization_id=ctx.organization_id,
         window_days=window_days,
+    )
+
+
+@router.get("/rate-comparison", response_model=UtilityPlanRateComparisonResponse)
+async def get_rate_comparison(
+    ctx: RequestContext = Depends(current_org_member),
+) -> UtilityPlanRateComparisonResponse:
+    """Current plans priced materially above the recorded market benchmark.
+
+    Lives on the plan resource rather than the benchmark one because it returns
+    plans. Declared before ``/{plan_id}`` so the literal path is not swallowed
+    by the UUID route.
+    """
+    return await market_rate_benchmark_service.get_rate_comparison(
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
     )
 
 

--- a/apps/mybookkeeper/backend/app/core/market_benchmark_constants.py
+++ b/apps/mybookkeeper/backend/app/core/market_benchmark_constants.py
@@ -1,0 +1,77 @@
+"""Constants for comparing a recorded plan against the going market rate.
+
+The renewal alert in ``utility_plan_constants`` answers "is my term about to
+lapse?". It says nothing about the case that costs more money in practice: a
+term that is nowhere near lapsing but was signed at a price the market has
+since moved well below. A plan can be perfectly *current* and still be the most
+expensive thing in the portfolio.
+
+Flagging that needs exactly two numbers — what the plan charges and what the
+market charges. Everything else (early-termination fees, bill credits, exact
+usage) belongs to the *decision* to switch, not to the flag that there is a
+decision worth making. Keeping the trigger cheap is deliberate: a flag that
+demanded a complete cost model would never fire, because the model would never
+be complete.
+
+``BENCHMARK_STATUSES`` is mirrored as a TypeScript union in
+``frontend/src/shared/types/utility/utility-plan-benchmark-status.ts`` — a value
+added here MUST be added there in the same PR.
+"""
+from app.core.utility_plan_constants import SERVICE_TYPE_INTERNET
+
+# Services priced as a flat monthly amount rather than per unit consumed.
+#
+# This is the single source of truth for which of a benchmark's two shapes a
+# service type must be recorded in: a flat service uses ``monthly_cents``,
+# everything else uses ``rate_cents_per_kwh``. Both sides of the comparison
+# derive the rule from here, and it is enforced in the request layer, the
+# service layer and a DB CHECK — a benchmark recorded in the wrong shape would
+# not fail, it would compare a monthly dollar amount against a per-kWh rate and
+# report a confidently wrong verdict.
+FLAT_RATE_SERVICE_TYPES: frozenset[str] = frozenset({SERVICE_TYPE_INTERNET})
+
+
+def is_flat_rate_service(service_type: str) -> bool:
+    """True when ``service_type`` is benchmarked as a monthly amount."""
+    return service_type in FLAT_RATE_SERVICE_TYPES
+
+
+# Outcome of comparing one plan against the benchmark for its service type.
+#   no_benchmark   — nothing recorded to compare against; the operator has not
+#                    told us what the market looks like yet
+#   not_comparable — a benchmark exists but this plan lacks the figure it would
+#                    be measured on (no advertised rate, or a regulated service
+#                    with no competing supplier to switch to)
+#   at_or_below    — the plan is at or under the market, within tolerance
+#   above          — the plan is materially above the market; worth shopping
+BENCHMARK_STATUS_NO_BENCHMARK = "no_benchmark"
+BENCHMARK_STATUS_NOT_COMPARABLE = "not_comparable"
+BENCHMARK_STATUS_AT_OR_BELOW = "at_or_below_market"
+BENCHMARK_STATUS_ABOVE = "above_market"
+
+BENCHMARK_STATUSES: frozenset[str] = frozenset({
+    BENCHMARK_STATUS_NO_BENCHMARK,
+    BENCHMARK_STATUS_NOT_COMPARABLE,
+    BENCHMARK_STATUS_AT_OR_BELOW,
+    BENCHMARK_STATUS_ABOVE,
+})
+
+# How far above the benchmark a plan must sit before it is worth surfacing.
+#
+# Not zero. A benchmark is one observation of a moving market, recorded by hand
+# on some particular day, and the plan's own figure is an advertised average at
+# an assumed usage level. Two numbers that imprecise will differ by a percent or
+# two in normal operation, and a badge that lights up for a 1% gap is a badge
+# the operator learns to ignore. 10% is wide enough to clear that noise and
+# still narrow enough to catch a real gap early — at Houston electricity rates
+# it is roughly a cent per kWh.
+MATERIAL_GAP_PCT = 10.0
+
+# How long a recorded benchmark is treated as describing the current market.
+#
+# Retail energy offers reprice constantly; an observation from last winter says
+# nothing useful about this summer. Past this age the comparison is still shown
+# but is labelled stale, so a flag is never silently resting on a number nobody
+# has revisited. Surfacing staleness beats expiring the benchmark outright,
+# which would just make the feature quietly stop working.
+BENCHMARK_STALE_AFTER_DAYS = 90

--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -32,7 +32,7 @@ from app.db.session import AsyncSessionLocal
 from app.schemas.user.user import UserRead, UserCreate, UserUpdate
 from app.services.storage.bucket_initializer import ensure_bucket
 from app.workers.upload_processor_worker import main as worker_main
-from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_policies, lease_templates, listings, properties, public_inquiries, public_welcome_manuals, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, exports, imports, health_dashboard, totp, taxpayer_profiles, utility_plans, welcome_manuals
+from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_policies, lease_templates, listings, market_rate_benchmarks, properties, public_inquiries, public_welcome_manuals, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, exports, imports, health_dashboard, totp, taxpayer_profiles, utility_plans, welcome_manuals
 
 logging.basicConfig(
     level=logging.INFO,
@@ -206,6 +206,7 @@ app.include_router(lease_templates.router)
 app.include_router(signed_leases.router)
 app.include_router(insurance_policies.router)
 app.include_router(utility_plans.router)
+app.include_router(market_rate_benchmarks.router)
 app.include_router(screening.router)
 app.include_router(vendors.router)
 app.include_router(reply_templates.router)

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -11,6 +11,7 @@ from app.models.properties.tenant import Tenant
 from app.models.properties.lease import Lease, LeaseStatus
 from app.models.properties.utility_account_link import UtilityAccountLink
 from app.models.properties.utility_plan import UtilityPlan
+from app.models.properties.market_rate_benchmark import MarketRateBenchmark
 from app.models.listings.listing import Listing
 from app.models.listings.listing_photo import ListingPhoto
 from app.models.listings.listing_external_id import ListingExternalId

--- a/apps/mybookkeeper/backend/app/models/properties/market_rate_benchmark.py
+++ b/apps/mybookkeeper/backend/app/models/properties/market_rate_benchmark.py
@@ -1,0 +1,162 @@
+"""ORM model for ``market_rate_benchmarks`` — what the market currently charges.
+
+One row per (organization, service type): the going rate the operator last
+observed, where they saw it, and the day they saw it. ``utility_plans`` records
+what is being paid; this records what could be paid, and the gap between them is
+the only thing a "you may be overpaying" flag needs.
+
+Scoped to the **organization alone**, unlike almost every other table in this
+app. What the market charges is a fact about the market, not about the member
+who looked it up, so a rate recorded by one member must be the same rate every
+other member is measured against. ``recorded_by_user_id`` is kept purely as
+provenance and is never a query filter — filtering on it would contradict the
+unique index below, and the second member of an organization would silently see
+"no market rate recorded" while their write collided with a row they could not
+read.
+
+Deliberately operator-maintained rather than scraped. The authoritative source
+differs per market (Power to Choose in deregulated Texas, a municipal tariff
+sheet elsewhere, a competitor quote for internet), and a wrong automatic number
+is worse than an absent one — it would flag confidently against a rate that does
+not apply to this address. ``source`` and ``observed_on`` exist so a stale or
+mis-sourced benchmark is visible instead of silently driving the badge.
+
+Two mutually exclusive shapes, because the services being compared are not
+priced the same way:
+
+``rate_cents_per_kwh``
+    Metered service (electricity, gas). Compared against a plan's
+    ``avg_price_cents_per_kwh_at_1000`` — the all-in advertised average, which
+    is the figure competitors publish and therefore the only one comparable
+    without knowing this property's usage.
+
+``monthly_cents``
+    Flat service (internet). Compared against the plan's monthly base plus
+    equipment fee, since a modem rental is part of what the bill actually costs.
+
+The CHECK enforces exactly one, so a row can never be ambiguous about which
+comparison it participates in.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.market_benchmark_constants import FLAT_RATE_SERVICE_TYPES
+from app.core.utility_plan_constants import SERVICE_TYPES
+from app.db.base import Base
+
+_SERVICE_TYPE_IN = ", ".join(f"'{v}'" for v in sorted(SERVICE_TYPES))
+_FLAT_SERVICE_TYPE_IN = ", ".join(f"'{v}'" for v in sorted(FLAT_RATE_SERVICE_TYPES))
+
+
+class MarketRateBenchmark(Base):
+    __tablename__ = "market_rate_benchmarks"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    # Provenance, NOT a tenant key — read the class docstring before filtering
+    # on it. Nullable with ``SET NULL`` so removing the member who recorded a
+    # rate leaves the organization's benchmark standing; the row describes the
+    # market, and the market does not belong to whoever happened to look it up.
+    recorded_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    service_type: Mapped[str] = mapped_column(String(20), nullable=False)
+
+    # Metered shape. Numeric for the same reason the plan's rates are: a rate
+    # carries four decimal places that integer cents cannot hold.
+    rate_cents_per_kwh: Mapped[Decimal | None] = mapped_column(
+        Numeric(9, 4), nullable=True,
+    )
+    # Flat shape.
+    monthly_cents: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+    # Where the number came from, in the operator's own words — "Power to
+    # Choose, 77021, 12-month fixed, 4★+". Free text on purpose: the useful
+    # provenance is the filters that produced the figure, which no enum could
+    # anticipate. Without it a benchmark is an unfalsifiable number.
+    source: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # The day it was observed, not the day the row was written — a benchmark
+    # entered from last month's notes should age from when it was true.
+    observed_on: Mapped[_dt.date] = mapped_column(Date, nullable=False)
+
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        onupdate=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            f"service_type IN ({_SERVICE_TYPE_IN})",
+            name="chk_market_benchmark_service_type",
+        ),
+        # Exactly one shape. Neither set is a row that compares against nothing;
+        # both set is a row that cannot say which comparison it means.
+        CheckConstraint(
+            "(rate_cents_per_kwh IS NULL) <> (monthly_cents IS NULL)",
+            name="chk_market_benchmark_one_shape",
+        ),
+        # ...and it must be the shape that service type is priced in. Without
+        # this, an electricity benchmark recorded as ``monthly_cents`` compares
+        # a per-kWh rate against a dollar amount: 15.06 against 6000 reads as
+        # 99.7% *below* market, so the plan is reported as fine forever. The
+        # row would be internally consistent and completely wrong.
+        CheckConstraint(
+            f"(service_type IN ({_FLAT_SERVICE_TYPE_IN}))"
+            " = (monthly_cents IS NOT NULL)",
+            name="chk_market_benchmark_shape_matches_service",
+        ),
+        CheckConstraint(
+            "(rate_cents_per_kwh IS NULL OR rate_cents_per_kwh > 0)"
+            " AND (monthly_cents IS NULL OR monthly_cents > 0)",
+            name="chk_market_benchmark_positive",
+        ),
+        # One benchmark per service per org. Unlike ``utility_plans``, history
+        # is not the point here — an outdated market observation has no value
+        # once a newer one exists, and keeping several would leave the
+        # comparison ambiguous about which to use.
+        Index(
+            "uq_market_benchmark_org_service",
+            "organization_id", "service_type",
+            unique=True,
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/repositories/properties/market_rate_benchmark_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/properties/market_rate_benchmark_repo.py
@@ -1,0 +1,159 @@
+"""Repository for ``market_rate_benchmarks``.
+
+Scoped by ``organization_id`` alone — see the model docstring. Every other
+utility table here scopes by ``(user_id, organization_id)``; this one must not,
+because its unique index is ``(organization_id, service_type)`` and a narrower
+read filter would let one member's write collide with a row they cannot see.
+
+No soft delete: a benchmark is a snapshot the operator can simply overwrite or
+remove. Keeping a tombstone would leave two rows competing to describe one
+market, which the unique index exists to prevent.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from sqlalchemy import Select, delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.properties.market_rate_benchmark import MarketRateBenchmark
+
+
+def _scope(stmt: Select, *, organization_id: uuid.UUID) -> Select:
+    return stmt.where(MarketRateBenchmark.organization_id == organization_id)
+
+
+async def get_by_service_type(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    service_type: str,
+) -> MarketRateBenchmark | None:
+    stmt = _scope(
+        select(MarketRateBenchmark).where(
+            MarketRateBenchmark.service_type == service_type,
+        ),
+        organization_id=organization_id,
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_for_org(
+    db: AsyncSession, *, organization_id: uuid.UUID,
+) -> list[MarketRateBenchmark]:
+    """Every benchmark for the org.
+
+    Unpaginated: the unique index caps this at one row per service type, so the
+    result can never outgrow the number of service types the app supports.
+    """
+    stmt = _scope(
+        select(MarketRateBenchmark),
+        organization_id=organization_id,
+    ).order_by(MarketRateBenchmark.service_type)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+def _apply_values(
+    benchmark: MarketRateBenchmark,
+    *,
+    recorded_by_user_id: uuid.UUID | None,
+    rate_cents_per_kwh: Decimal | None,
+    monthly_cents: int | None,
+    source: str | None,
+    observed_on: _dt.date,
+    notes: str | None,
+) -> None:
+    # Both shapes are assigned, not just the populated one: switching a service
+    # from a metered rate to a flat monthly must clear the figure that no longer
+    # applies, or the CHECK would reject the write.
+    benchmark.recorded_by_user_id = recorded_by_user_id
+    benchmark.rate_cents_per_kwh = rate_cents_per_kwh
+    benchmark.monthly_cents = monthly_cents
+    benchmark.source = source
+    benchmark.observed_on = observed_on
+    benchmark.notes = notes
+
+
+async def upsert(
+    db: AsyncSession,
+    *,
+    recorded_by_user_id: uuid.UUID | None,
+    organization_id: uuid.UUID,
+    service_type: str,
+    rate_cents_per_kwh: Decimal | None,
+    monthly_cents: int | None,
+    source: str | None,
+    observed_on: _dt.date,
+    notes: str | None,
+) -> MarketRateBenchmark:
+    """Create the org's benchmark for ``service_type``, or replace its values.
+
+    Read-then-write rather than a dialect-specific ``ON CONFLICT``, so the query
+    stays portable to SQLite in tests like the rest of this package. The insert
+    is wrapped in a SAVEPOINT and the unique-index violation is caught: two
+    writers that both miss on the read converge on an update instead of the
+    loser surfacing as a 500. Portable to both dialects, and it makes the
+    endpoint genuinely idempotent rather than idempotent-if-unraced.
+    """
+    values = {
+        "recorded_by_user_id": recorded_by_user_id,
+        "rate_cents_per_kwh": rate_cents_per_kwh,
+        "monthly_cents": monthly_cents,
+        "source": source,
+        "observed_on": observed_on,
+        "notes": notes,
+    }
+
+    existing = await get_by_service_type(
+        db, organization_id=organization_id, service_type=service_type,
+    )
+    if existing is not None:
+        _apply_values(existing, **values)
+        await db.flush()
+        return existing
+
+    benchmark = MarketRateBenchmark(
+        organization_id=organization_id,
+        service_type=service_type,
+        **values,
+    )
+    try:
+        async with db.begin_nested():
+            db.add(benchmark)
+            await db.flush()
+    except IntegrityError:
+        # Another writer inserted this org's row between our read and our
+        # write. The SAVEPOINT rolled back, so the session is usable: re-read
+        # the winner and apply our values on top.
+        db.expunge(benchmark)
+        winner = await get_by_service_type(
+            db, organization_id=organization_id, service_type=service_type,
+        )
+        if winner is None:
+            # The violation was not the unique index — surface it rather than
+            # swallowing a genuine constraint failure as a silent no-op.
+            raise
+        _apply_values(winner, **values)
+        await db.flush()
+        return winner
+    return benchmark
+
+
+async def delete_by_service_type(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    service_type: str,
+) -> bool:
+    result = await db.execute(
+        delete(MarketRateBenchmark).where(
+            MarketRateBenchmark.organization_id == organization_id,
+            MarketRateBenchmark.service_type == service_type,
+        )
+    )
+    return (result.rowcount or 0) > 0

--- a/apps/mybookkeeper/backend/app/schemas/properties/market_rate_benchmark_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/market_rate_benchmark_response.py
@@ -1,0 +1,29 @@
+"""One recorded market observation, as returned to the client.
+
+``is_stale`` is derived rather than stored so it cannot drift from the clock —
+same reason ``renewal_status`` is computed on read. See
+``_market_benchmark_compare.is_stale``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class MarketRateBenchmarkResponse(BaseModel):
+    id: uuid.UUID
+    service_type: str
+    # Exactly one of these is set; which one depends on the service type.
+    rate_cents_per_kwh: Decimal | None = None
+    monthly_cents: int | None = None
+    source: str | None = None
+    observed_on: _dt.date
+    notes: str | None = None
+    is_stale: bool
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/properties/market_rate_benchmark_upsert_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/market_rate_benchmark_upsert_request.py
@@ -1,0 +1,51 @@
+"""Schema for PUT /market-rate-benchmarks/{service_type}.
+
+An upsert rather than a create/update pair: there is at most one benchmark per
+(organization, service type), so the caller never needs to know whether one
+already exists, and the route can be driven straight from a single form.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.schemas.properties.utility_plan_validation import MAX_RATE_CENTS
+
+# The browser fills this field with *its* local date, which can be a calendar
+# day ahead of the server's. Rejecting on the server's date alone would 422 a
+# user east of the server for picking their own today. One day of slack absorbs
+# every real offset (max +14h) while still rejecting an actual forecast.
+_FUTURE_DATE_SLACK = _dt.timedelta(days=1)
+
+
+class MarketRateBenchmarkUpsertRequest(BaseModel):
+    # Exactly one of these two, matching ``chk_market_benchmark_one_shape``.
+    # Metered service is compared on ¢/kWh, flat service on dollars per month;
+    # a row carrying both could not say which comparison it participates in.
+    rate_cents_per_kwh: Decimal | None = Field(
+        None, gt=0, le=MAX_RATE_CENTS, decimal_places=4,
+    )
+    monthly_cents: int | None = Field(None, gt=0)
+
+    source: str | None = Field(None, max_length=255)
+    observed_on: _dt.date
+    notes: str | None = Field(None, max_length=5000)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _check_shape(self) -> MarketRateBenchmarkUpsertRequest:
+        has_rate = self.rate_cents_per_kwh is not None
+        has_monthly = self.monthly_cents is not None
+        if has_rate == has_monthly:
+            raise ValueError(
+                "Provide exactly one of rate_cents_per_kwh (metered service) "
+                "or monthly_cents (flat service).",
+            )
+        # A future-dated observation is a typo, not a forecast, and it would
+        # make the staleness check permanently pass.
+        if self.observed_on > _dt.date.today() + _FUTURE_DATE_SLACK:
+            raise ValueError("observed_on cannot be in the future.")
+        return self

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_rate_comparison_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_rate_comparison_response.py
@@ -1,0 +1,35 @@
+"""Dashboard payload for plans priced above the market.
+
+Shaped like ``UtilityPlanRenewalAlertResponse``: the card that consumes it
+wants a short list plus a count, not a page of rows it has to filter itself.
+
+Only *current* plans are measured. A superseded plan's price is history — the
+operator cannot act on it, so flagging it would be noise.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.properties.utility_plan_rate_comparison_row import (
+    UtilityPlanRateComparisonRow,
+)
+
+
+class UtilityPlanRateComparisonResponse(BaseModel):
+    # The gap that had to be exceeded for a row to land in ``above_market``, so
+    # the UI can say "more than N% above" without hardcoding the backend's
+    # threshold.
+    material_gap_pct: float
+    # Sorted widest gap first — the most expensive mistake reads first.
+    above_market: list[UtilityPlanRateComparisonRow]
+    # Current plans that could not be measured: no benchmark recorded for their
+    # service type, a regulated tariff with no competing supplier, or a missing
+    # figure on either side. Surfaced rather than dropped, because "we are not
+    # checking this one" is itself something the operator should see.
+    not_compared: list[UtilityPlanRateComparisonRow]
+    total_above_market: int
+    # True when any benchmark feeding this payload is past its freshness
+    # window, so the card can caveat the whole set in one line.
+    has_stale_benchmark: bool
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_rate_comparison_row.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_plan_rate_comparison_row.py
@@ -1,0 +1,27 @@
+"""One plan measured against the market benchmark for its service type."""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.properties.utility_plan_summary import UtilityPlanSummary
+
+
+class UtilityPlanRateComparisonRow(BaseModel):
+    plan: UtilityPlanSummary
+    # One of app.core.market_benchmark_constants.BENCHMARK_STATUSES.
+    status: str
+    # Both figures are in the unit the service type is compared in — ¢/kWh for
+    # metered service, cents per month for flat service. The client reads the
+    # unit from the plan's service_type rather than being told twice.
+    plan_figure: Decimal | None = None
+    benchmark_figure: Decimal | None = None
+    # Signed: negative means the plan beats the market, which is worth showing
+    # as the evidence that an earlier switch worked.
+    gap_pct: Decimal | None = None
+    # True when the benchmark behind this row is old enough that the comparison
+    # deserves a caveat rather than a confident badge.
+    benchmark_is_stale: bool = False
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/services/properties/_market_benchmark_compare.py
+++ b/apps/mybookkeeper/backend/app/services/properties/_market_benchmark_compare.py
@@ -1,0 +1,157 @@
+"""Pure comparison of one plan against one benchmark.
+
+No I/O, no ORM — every function takes plain values so the arithmetic that
+decides whether a badge lights up is directly testable without a database.
+
+The comparison is deliberately shallow. It answers "is this plan priced well
+above what the market charges?" and nothing more. It does not net off an early
+termination fee, model a bill credit against a usage distribution, or project an
+annual saving from historical kWh. Those belong to deciding whether to *act*,
+and requiring them would mean the flag could not fire until a complete cost
+model existed — which is precisely how a comparison feature ends up never
+shipping. Surface the gap; let the operator open the drill-down.
+
+Both sides of the comparison pick their figure from ``service_type`` via
+``is_flat_rate_service``, never from "whichever column happens to be populated".
+Deriving the two sides by different rules is how a monthly dollar amount ends up
+being divided by a per-kWh rate.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Protocol
+
+from app.core.market_benchmark_constants import (
+    BENCHMARK_STALE_AFTER_DAYS,
+    BENCHMARK_STATUS_ABOVE,
+    BENCHMARK_STATUS_AT_OR_BELOW,
+    BENCHMARK_STATUS_NO_BENCHMARK,
+    BENCHMARK_STATUS_NOT_COMPARABLE,
+    MATERIAL_GAP_PCT,
+    is_flat_rate_service,
+)
+from app.core.utility_plan_constants import RATE_TYPE_REGULATED
+
+
+class ComparablePlan(Protocol):
+    """The parts of a utility plan this module measures."""
+
+    service_type: str
+    rate_type: str
+    monthly_base_charge_cents: int | None
+    equipment_fee_monthly_cents: int | None
+    avg_price_cents_per_kwh_at_1000: Decimal | None
+
+
+class ComparableBenchmark(Protocol):
+    """The parts of a market benchmark this module measures against."""
+
+    service_type: str
+    rate_cents_per_kwh: Decimal | None
+    monthly_cents: int | None
+    observed_on: _dt.date
+
+
+@dataclass(frozen=True, slots=True)
+class PlanComparison:
+    """Outcome of measuring one plan against the market.
+
+    ``gap_pct`` is signed — negative means the plan beats the market, which is
+    worth showing rather than hiding, since it is the evidence that a previous
+    switch worked.
+    """
+
+    status: str
+    plan_figure: Decimal | None = None
+    benchmark_figure: Decimal | None = None
+    gap_pct: Decimal | None = None
+    is_stale: bool = False
+
+
+def comparable_plan_figure(plan: ComparablePlan) -> Decimal | None:
+    """The plan's number in the same shape as its service type's benchmark.
+
+    Metered service uses the advertised all-in average at 1,000 kWh — the
+    figure competitors publish, and so the only one comparable without knowing
+    this property's usage.
+
+    A flat service (internet) uses monthly base **plus** equipment fee. A modem
+    rental quoted outside the advertised price is still money leaving the
+    account every month, and omitting it would systematically understate what
+    the plan costs.
+    """
+    if is_flat_rate_service(plan.service_type):
+        base = plan.monthly_base_charge_cents
+        if base is None:
+            return None
+        equipment = plan.equipment_fee_monthly_cents or 0
+        return Decimal(base + equipment)
+
+    rate = plan.avg_price_cents_per_kwh_at_1000
+    return None if rate is None else Decimal(rate)
+
+
+def benchmark_figure(benchmark: ComparableBenchmark | None) -> Decimal | None:
+    """The benchmark's number, in the shape its service type is priced in.
+
+    Read from the column that service type is *supposed* to use rather than the
+    one that happens to be populated, so a row that somehow escaped the CHECK
+    yields no comparison instead of a wrong one.
+    """
+    if benchmark is None:
+        return None
+    if is_flat_rate_service(benchmark.service_type):
+        monthly = benchmark.monthly_cents
+        return None if monthly is None else Decimal(monthly)
+    rate = benchmark.rate_cents_per_kwh
+    return None if rate is None else Decimal(rate)
+
+
+def is_stale(observed_on: _dt.date, *, today: _dt.date | None = None) -> bool:
+    """True once an observation is too old to describe the current market."""
+    reference = today or _dt.date.today()
+    return (reference - observed_on).days > BENCHMARK_STALE_AFTER_DAYS
+
+
+def compare(
+    plan: ComparablePlan,
+    benchmark: ComparableBenchmark | None,
+    *,
+    today: _dt.date | None = None,
+    material_gap_pct: float = MATERIAL_GAP_PCT,
+) -> PlanComparison:
+    """Classify one plan against the benchmark for its service type.
+
+    A ``regulated`` plan is never comparable no matter what figures exist: a
+    tariffed monopoly has no competing supplier, so telling the operator it is
+    above market would be advice they cannot act on.
+    """
+    if benchmark is None:
+        return PlanComparison(status=BENCHMARK_STATUS_NO_BENCHMARK)
+
+    market = benchmark_figure(benchmark)
+    mine = comparable_plan_figure(plan)
+    stale = is_stale(benchmark.observed_on, today=today)
+
+    if plan.rate_type == RATE_TYPE_REGULATED or market is None or mine is None:
+        return PlanComparison(
+            status=BENCHMARK_STATUS_NOT_COMPARABLE, is_stale=stale,
+        )
+
+    gap_pct = (mine - market) / market * Decimal(100)
+    status = (
+        BENCHMARK_STATUS_ABOVE
+        if gap_pct > Decimal(str(material_gap_pct))
+        else BENCHMARK_STATUS_AT_OR_BELOW
+    )
+    return PlanComparison(
+        status=status,
+        plan_figure=mine,
+        benchmark_figure=market,
+        # Quantized for transport: the extra digits are false precision on two
+        # hand-recorded numbers, and they make the JSON noisy to read.
+        gap_pct=gap_pct.quantize(Decimal("0.1")),
+        is_stale=stale,
+    )

--- a/apps/mybookkeeper/backend/app/services/properties/market_rate_benchmark_service.py
+++ b/apps/mybookkeeper/backend/app/services/properties/market_rate_benchmark_service.py
@@ -1,0 +1,273 @@
+"""Service layer for market rate benchmarks and the rate comparison.
+
+Two responsibilities, both thin:
+
+CRUD over the operator's recorded market observations — at most one per service
+type, so the write is an upsert keyed on service type rather than an id.
+
+``get_rate_comparison``, which measures every *current* plan against the
+benchmark for its service type. It mirrors ``get_renewal_alerts``: same
+current-plan reduction, same "sorted most urgent first, plus a count" shape, so
+the two dashboard cards behave identically.
+
+All data access goes through repositories; this module never imports SQLAlchemy.
+The arithmetic is pure and lives in ``_market_benchmark_compare``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+from typing import Protocol
+
+from app.core.market_benchmark_constants import (
+    BENCHMARK_STATUS_ABOVE,
+    MATERIAL_GAP_PCT,
+    is_flat_rate_service,
+)
+from app.core.utility_plan_constants import SERVICE_TYPES
+from app.db.session import unit_of_work
+from app.repositories.properties import (
+    market_rate_benchmark_repo,
+    property_repo,
+    utility_plan_repo,
+)
+from app.schemas.properties.market_rate_benchmark_response import (
+    MarketRateBenchmarkResponse,
+)
+from app.schemas.properties.utility_plan_rate_comparison_response import (
+    UtilityPlanRateComparisonResponse,
+)
+from app.schemas.properties.utility_plan_rate_comparison_row import (
+    UtilityPlanRateComparisonRow,
+)
+from app.services.properties._market_benchmark_compare import (
+    ComparableBenchmark,
+    compare,
+    is_stale,
+)
+from app.services.properties._utility_plan_helpers import current_plan_ids, to_summary
+
+
+class _StoredBenchmark(ComparableBenchmark, Protocol):
+    """A persisted benchmark: the comparable figures plus its own metadata."""
+
+    id: uuid.UUID
+    source: str | None
+    notes: str | None
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+
+
+class MarketRateBenchmarkNotFoundError(LookupError):
+    pass
+
+
+class InvalidMarketRateBenchmarkError(ValueError):
+    """The payload does not describe a usable benchmark."""
+
+
+def _to_response(
+    benchmark: _StoredBenchmark, *, today: _dt.date | None = None,
+) -> MarketRateBenchmarkResponse:
+    return MarketRateBenchmarkResponse(
+        id=benchmark.id,
+        service_type=benchmark.service_type,
+        rate_cents_per_kwh=benchmark.rate_cents_per_kwh,
+        monthly_cents=benchmark.monthly_cents,
+        source=benchmark.source,
+        observed_on=benchmark.observed_on,
+        notes=benchmark.notes,
+        is_stale=is_stale(benchmark.observed_on, today=today),
+        created_at=benchmark.created_at,
+        updated_at=benchmark.updated_at,
+    )
+
+
+def _assert_known_service_type(service_type: str) -> None:
+    # The path parameter reaches the CHECK constraint otherwise, where an
+    # unknown value would surface as a 500 rather than a readable 4xx.
+    if service_type not in SERVICE_TYPES:
+        raise InvalidMarketRateBenchmarkError(
+            f"service_type must be one of: {', '.join(sorted(SERVICE_TYPES))}",
+        )
+
+
+def _assert_shape_matches_service(
+    service_type: str,
+    *,
+    rate_cents_per_kwh: Decimal | None,
+    monthly_cents: int | None,
+) -> None:
+    """The figure must be in the unit that service type is priced in.
+
+    The request schema can only check that exactly one shape was sent — the
+    service type is a path parameter it never sees. Without this check an
+    electricity rate recorded as ``monthly_cents`` divides a per-kWh figure by a
+    dollar amount and reports the plan as ~99% below market: not an error, just
+    a permanently wrong all-clear. The DB CHECK is the real guarantee; this is
+    what turns it into a readable 422 instead of an IntegrityError 500.
+    """
+    if is_flat_rate_service(service_type):
+        if monthly_cents is None:
+            raise InvalidMarketRateBenchmarkError(
+                f"{service_type} is priced per month — provide monthly_cents, "
+                "not rate_cents_per_kwh.",
+            )
+    elif rate_cents_per_kwh is None:
+        raise InvalidMarketRateBenchmarkError(
+            f"{service_type} is metered — provide rate_cents_per_kwh, "
+            "not monthly_cents.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Benchmark CRUD
+# ---------------------------------------------------------------------------
+
+async def list_benchmarks(
+    *,
+    organization_id: uuid.UUID,
+    today: _dt.date | None = None,
+) -> list[MarketRateBenchmarkResponse]:
+    async with unit_of_work() as db:
+        rows = await market_rate_benchmark_repo.list_for_org(
+            db, organization_id=organization_id,
+        )
+        return [_to_response(r, today=today) for r in rows]
+
+
+async def upsert_benchmark(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    service_type: str,
+    rate_cents_per_kwh: Decimal | None,
+    monthly_cents: int | None,
+    source: str | None,
+    observed_on: _dt.date,
+    notes: str | None,
+    today: _dt.date | None = None,
+) -> MarketRateBenchmarkResponse:
+    """Record the organization's market rate for ``service_type``.
+
+    ``user_id`` is stored as provenance only — the row it writes belongs to the
+    organization, so a second member updating it replaces the first member's
+    observation rather than creating a competing one.
+    """
+    _assert_known_service_type(service_type)
+    _assert_shape_matches_service(
+        service_type,
+        rate_cents_per_kwh=rate_cents_per_kwh,
+        monthly_cents=monthly_cents,
+    )
+    async with unit_of_work() as db:
+        benchmark = await market_rate_benchmark_repo.upsert(
+            db,
+            recorded_by_user_id=user_id,
+            organization_id=organization_id,
+            service_type=service_type,
+            rate_cents_per_kwh=rate_cents_per_kwh,
+            monthly_cents=monthly_cents,
+            source=source,
+            observed_on=observed_on,
+            notes=notes,
+        )
+        return _to_response(benchmark, today=today)
+
+
+async def delete_benchmark(
+    *,
+    organization_id: uuid.UUID,
+    service_type: str,
+) -> None:
+    _assert_known_service_type(service_type)
+    async with unit_of_work() as db:
+        deleted = await market_rate_benchmark_repo.delete_by_service_type(
+            db,
+            organization_id=organization_id,
+            service_type=service_type,
+        )
+    if not deleted:
+        raise MarketRateBenchmarkNotFoundError(service_type)
+
+
+# ---------------------------------------------------------------------------
+# Rate comparison
+# ---------------------------------------------------------------------------
+
+async def get_rate_comparison(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    today: _dt.date | None = None,
+    material_gap_pct: float = MATERIAL_GAP_PCT,
+) -> UtilityPlanRateComparisonResponse:
+    """Current plans measured against the market benchmark for their service.
+
+    Superseded plans are skipped for the same reason renewal alerts skip them:
+    their price is history, and nothing can be done about it.
+    """
+    async with unit_of_work() as db:
+        all_active = await utility_plan_repo.list_all_active_for_org(
+            db, user_id=user_id, organization_id=organization_id,
+        )
+        names = await property_repo.get_name_map(db, organization_id)
+        benchmarks = await market_rate_benchmark_repo.list_for_org(
+            db, organization_id=organization_id,
+        )
+
+    by_service = {b.service_type: b for b in benchmarks}
+    current_ids = current_plan_ids(all_active)
+
+    above_market: list[UtilityPlanRateComparisonRow] = []
+    not_compared: list[UtilityPlanRateComparisonRow] = []
+    has_stale = False
+
+    for plan in all_active:
+        if plan.id not in current_ids:
+            continue
+        result = compare(
+            plan,
+            by_service.get(plan.service_type),
+            today=today,
+            material_gap_pct=material_gap_pct,
+        )
+        has_stale = has_stale or result.is_stale
+        row = UtilityPlanRateComparisonRow(
+            plan=to_summary(
+                plan,
+                property_names=names,
+                current_ids=current_ids,
+                today=today,
+            ),
+            status=result.status,
+            plan_figure=result.plan_figure,
+            benchmark_figure=result.benchmark_figure,
+            gap_pct=result.gap_pct,
+            benchmark_is_stale=result.is_stale,
+        )
+        if result.status == BENCHMARK_STATUS_ABOVE:
+            above_market.append(row)
+        elif result.plan_figure is None:
+            # No usable comparison — no benchmark, a regulated tariff, or a
+            # figure missing on one side. Kept so the operator can see what is
+            # going unchecked rather than assuming everything was measured.
+            not_compared.append(row)
+
+    # Widest gap first: the most expensive mistake reads first. ``is not None``
+    # rather than ``or`` — Decimal("0") is falsy, so a genuine zero gap would
+    # otherwise take the missing-value branch.
+    above_market.sort(
+        key=lambda r: r.gap_pct if r.gap_pct is not None else Decimal(0),
+        reverse=True,
+    )
+    not_compared.sort(key=lambda r: (r.plan.service_type, r.plan.provider_name))
+
+    return UtilityPlanRateComparisonResponse(
+        material_gap_pct=material_gap_pct,
+        above_market=above_market,
+        not_compared=not_compared,
+        total_above_market=len(above_market),
+        has_stale_benchmark=has_stale,
+    )

--- a/apps/mybookkeeper/backend/tests/test_market_benchmark_compare.py
+++ b/apps/mybookkeeper/backend/tests/test_market_benchmark_compare.py
@@ -1,0 +1,253 @@
+"""Unit tests for the pure benchmark comparison.
+
+No database — every function here takes plain values, which is the point of
+keeping the arithmetic that decides whether a badge lights up out of the
+service layer.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from decimal import Decimal
+
+from app.core.market_benchmark_constants import (
+    BENCHMARK_STALE_AFTER_DAYS,
+    BENCHMARK_STATUS_ABOVE,
+    BENCHMARK_STATUS_AT_OR_BELOW,
+    BENCHMARK_STATUS_NO_BENCHMARK,
+    BENCHMARK_STATUS_NOT_COMPARABLE,
+)
+from app.core.utility_plan_constants import (
+    RATE_TYPE_FIXED,
+    RATE_TYPE_REGULATED,
+    SERVICE_TYPE_ELECTRICITY,
+    SERVICE_TYPE_INTERNET,
+    SERVICE_TYPE_NATURAL_GAS,
+)
+from app.services.properties._market_benchmark_compare import (
+    benchmark_figure,
+    comparable_plan_figure,
+    compare,
+    is_stale,
+)
+
+TODAY = _dt.date(2026, 8, 11)
+
+
+class _Plan:
+    """Minimal stand-in for the columns the comparison reads."""
+
+    def __init__(
+        self,
+        *,
+        service_type: str = SERVICE_TYPE_ELECTRICITY,
+        rate_type: str = RATE_TYPE_FIXED,
+        avg_price_cents_per_kwh_at_1000: Decimal | None = None,
+        monthly_base_charge_cents: int | None = None,
+        equipment_fee_monthly_cents: int | None = None,
+    ) -> None:
+        self.service_type = service_type
+        self.rate_type = rate_type
+        self.avg_price_cents_per_kwh_at_1000 = avg_price_cents_per_kwh_at_1000
+        self.monthly_base_charge_cents = monthly_base_charge_cents
+        self.equipment_fee_monthly_cents = equipment_fee_monthly_cents
+
+
+class _Benchmark:
+    def __init__(
+        self,
+        *,
+        service_type: str = SERVICE_TYPE_ELECTRICITY,
+        rate_cents_per_kwh: Decimal | None = None,
+        monthly_cents: int | None = None,
+        observed_on: _dt.date = TODAY,
+    ) -> None:
+        self.service_type = service_type
+        self.rate_cents_per_kwh = rate_cents_per_kwh
+        self.monthly_cents = monthly_cents
+        self.observed_on = observed_on
+
+
+class TestComparablePlanFigure:
+    def test_metered_plan_uses_the_advertised_all_in_average(self) -> None:
+        plan = _Plan(avg_price_cents_per_kwh_at_1000=Decimal("15.0600"))
+        assert comparable_plan_figure(plan) == Decimal("15.0600")
+
+    def test_internet_plan_adds_the_equipment_fee_to_the_base(self) -> None:
+        """A modem rental is money leaving the account, so it counts."""
+        plan = _Plan(
+            service_type=SERVICE_TYPE_INTERNET,
+            monthly_base_charge_cents=8000,
+            equipment_fee_monthly_cents=1000,
+        )
+        assert comparable_plan_figure(plan) == Decimal(9000)
+
+    def test_internet_plan_without_an_equipment_fee_uses_the_base_alone(self) -> None:
+        plan = _Plan(
+            service_type=SERVICE_TYPE_INTERNET,
+            monthly_base_charge_cents=8000,
+            equipment_fee_monthly_cents=None,
+        )
+        assert comparable_plan_figure(plan) == Decimal(8000)
+
+    def test_missing_figure_is_none_rather_than_zero(self) -> None:
+        """Zero would read as a free plan and flag every benchmark as beaten."""
+        assert comparable_plan_figure(_Plan()) is None
+        assert comparable_plan_figure(_Plan(service_type=SERVICE_TYPE_INTERNET)) is None
+
+
+class TestBenchmarkFigure:
+    def test_reads_the_shape_its_service_type_is_priced_in(self) -> None:
+        assert benchmark_figure(
+            _Benchmark(rate_cents_per_kwh=Decimal("11.1000")),
+        ) == Decimal("11.1000")
+        assert benchmark_figure(
+            _Benchmark(service_type=SERVICE_TYPE_INTERNET, monthly_cents=6000),
+        ) == Decimal(6000)
+
+    def test_a_figure_in_the_wrong_shape_yields_no_comparison(self) -> None:
+        """Both DB CHECK and service layer reject this; if one ever escaped,
+        reading it would divide a per-kWh rate by a dollar amount and report a
+        confidently wrong verdict. No figure beats a wrong figure."""
+        assert benchmark_figure(
+            _Benchmark(service_type=SERVICE_TYPE_ELECTRICITY, monthly_cents=6000),
+        ) is None
+        assert benchmark_figure(
+            _Benchmark(
+                service_type=SERVICE_TYPE_INTERNET,
+                rate_cents_per_kwh=Decimal("11.1000"),
+            ),
+        ) is None
+
+    def test_absent_benchmark_is_none(self) -> None:
+        assert benchmark_figure(None) is None
+
+
+class TestIsStale:
+    def test_fresh_observation_is_not_stale(self) -> None:
+        assert is_stale(TODAY - _dt.timedelta(days=1), today=TODAY) is False
+
+    def test_boundary_day_is_not_yet_stale(self) -> None:
+        observed = TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS)
+        assert is_stale(observed, today=TODAY) is False
+
+    def test_one_day_past_the_window_is_stale(self) -> None:
+        observed = TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS + 1)
+        assert is_stale(observed, today=TODAY) is True
+
+
+class TestCompare:
+    def test_no_benchmark_short_circuits(self) -> None:
+        result = compare(_Plan(avg_price_cents_per_kwh_at_1000=Decimal("15")), None)
+        assert result.status == BENCHMARK_STATUS_NO_BENCHMARK
+        assert result.gap_pct is None
+
+    def test_materially_higher_rate_is_above_market(self) -> None:
+        """The operator's real case: 15.06¢ against an 11.1¢ market."""
+        result = compare(
+            _Plan(avg_price_cents_per_kwh_at_1000=Decimal("15.0600")),
+            _Benchmark(rate_cents_per_kwh=Decimal("11.1000")),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_ABOVE
+        assert result.gap_pct == Decimal("35.7")
+        assert result.plan_figure == Decimal("15.0600")
+        assert result.benchmark_figure == Decimal("11.1000")
+
+    def test_gap_inside_the_threshold_is_not_flagged(self) -> None:
+        """9% apart is two hand-recorded numbers disagreeing, not an overpay."""
+        result = compare(
+            _Plan(avg_price_cents_per_kwh_at_1000=Decimal("12.0")),
+            _Benchmark(rate_cents_per_kwh=Decimal("11.0")),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_AT_OR_BELOW
+
+    def test_threshold_is_exclusive_so_exactly_ten_percent_is_not_flagged(self) -> None:
+        result = compare(
+            _Plan(avg_price_cents_per_kwh_at_1000=Decimal("11.0")),
+            _Benchmark(rate_cents_per_kwh=Decimal("10.0")),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_AT_OR_BELOW
+        assert result.gap_pct == Decimal("10.0")
+
+    def test_beating_the_market_reports_a_negative_gap(self) -> None:
+        result = compare(
+            _Plan(avg_price_cents_per_kwh_at_1000=Decimal("9.0")),
+            _Benchmark(rate_cents_per_kwh=Decimal("11.0")),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_AT_OR_BELOW
+        assert result.gap_pct < 0
+
+    def test_regulated_plan_is_never_comparable(self) -> None:
+        """A tariffed monopoly has no competitor to switch to."""
+        result = compare(
+            _Plan(
+                service_type=SERVICE_TYPE_NATURAL_GAS,
+                rate_type=RATE_TYPE_REGULATED,
+                avg_price_cents_per_kwh_at_1000=Decimal("99.0"),
+            ),
+            _Benchmark(rate_cents_per_kwh=Decimal("11.0")),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_NOT_COMPARABLE
+        assert result.gap_pct is None
+
+    def test_missing_plan_figure_is_not_comparable(self) -> None:
+        result = compare(
+            _Plan(),
+            _Benchmark(rate_cents_per_kwh=Decimal("11.0")),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_NOT_COMPARABLE
+
+    def test_internet_comparison_uses_monthly_cents_on_both_sides(self) -> None:
+        result = compare(
+            _Plan(
+                service_type=SERVICE_TYPE_INTERNET,
+                monthly_base_charge_cents=8000,
+                equipment_fee_monthly_cents=1500,
+            ),
+            _Benchmark(service_type=SERVICE_TYPE_INTERNET, monthly_cents=6000),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_ABOVE
+        assert result.plan_figure == Decimal(9500)
+
+    def test_stale_benchmark_still_compares_but_is_marked(self) -> None:
+        """Old data is worth caveating, not worth discarding."""
+        result = compare(
+            _Plan(avg_price_cents_per_kwh_at_1000=Decimal("15.0")),
+            _Benchmark(
+                rate_cents_per_kwh=Decimal("11.0"),
+                observed_on=TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS + 1),
+            ),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_ABOVE
+        assert result.is_stale is True
+
+    def test_not_comparable_still_reports_staleness(self) -> None:
+        result = compare(
+            _Plan(rate_type=RATE_TYPE_REGULATED),
+            _Benchmark(
+                rate_cents_per_kwh=Decimal("11.0"),
+                observed_on=TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS + 1),
+            ),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_NOT_COMPARABLE
+        assert result.is_stale is True
+
+    def test_threshold_is_caller_supplied(self) -> None:
+        plan = _Plan(avg_price_cents_per_kwh_at_1000=Decimal("12.0"))
+        benchmark = _Benchmark(rate_cents_per_kwh=Decimal("11.0"))
+        assert (
+            compare(plan, benchmark, today=TODAY, material_gap_pct=5.0).status
+            == BENCHMARK_STATUS_ABOVE
+        )
+        assert (
+            compare(plan, benchmark, today=TODAY, material_gap_pct=20.0).status
+            == BENCHMARK_STATUS_AT_OR_BELOW
+        )

--- a/apps/mybookkeeper/backend/tests/test_market_rate_benchmark_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_market_rate_benchmark_repo.py
@@ -1,0 +1,248 @@
+"""Repository tests for ``market_rate_benchmarks``.
+
+Focus is on tenant scoping and the upsert, which is the only non-obvious query
+here: it must replace values in place rather than accumulate rows, and it must
+clear the shape it is not writing so a service switching from a metered rate to
+a flat monthly does not leave both columns populated.
+
+Scoping is the subtle part. This table is scoped to the **organization alone**,
+unlike its siblings — the unique index is ``(organization_id, service_type)``,
+so a read filtered any more narrowly would let a second member of the same org
+miss a row their own write then collides with. The tests below pin that a
+second member sees, updates and deletes the same row.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.utility_plan_constants import (
+    SERVICE_TYPE_ELECTRICITY,
+    SERVICE_TYPE_INTERNET,
+)
+from app.repositories.properties import market_rate_benchmark_repo
+
+pytestmark = pytest.mark.asyncio
+
+OBSERVED = _dt.date(2026, 8, 11)
+
+
+async def _upsert(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID | None = None,
+    service_type: str = SERVICE_TYPE_ELECTRICITY,
+    rate_cents_per_kwh: Decimal | None = Decimal("11.1000"),
+    monthly_cents: int | None = None,
+    source: str | None = "Power to Choose, 77021",
+    observed_on: _dt.date = OBSERVED,
+    notes: str | None = None,
+):
+    return await market_rate_benchmark_repo.upsert(
+        db,
+        recorded_by_user_id=user_id,
+        organization_id=org_id,
+        service_type=service_type,
+        rate_cents_per_kwh=rate_cents_per_kwh,
+        monthly_cents=monthly_cents,
+        source=source,
+        observed_on=observed_on,
+        notes=notes,
+    )
+
+
+class TestUpsert:
+    async def test_creates_then_replaces_rather_than_accumulating(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id = uuid.uuid4()
+        first = await _upsert(db, org_id=org_id)
+        second = await _upsert(db, org_id=org_id, rate_cents_per_kwh=Decimal("10.8000"))
+
+        assert second.id == first.id
+        rows = await market_rate_benchmark_repo.list_for_org(db, organization_id=org_id)
+        assert len(rows) == 1
+        assert Decimal(str(rows[0].rate_cents_per_kwh)) == Decimal("10.8")
+
+    async def test_switching_shape_clears_the_figure_that_no_longer_applies(
+        self, db: AsyncSession,
+    ) -> None:
+        """Leaving both populated would violate the one-shape CHECK."""
+        org_id = uuid.uuid4()
+        await _upsert(db, org_id=org_id, service_type=SERVICE_TYPE_INTERNET,
+                      rate_cents_per_kwh=None, monthly_cents=6000)
+        updated = await _upsert(
+            db,
+            org_id=org_id,
+            service_type=SERVICE_TYPE_INTERNET,
+            rate_cents_per_kwh=None,
+            monthly_cents=7000,
+        )
+
+        assert updated.rate_cents_per_kwh is None
+        assert updated.monthly_cents == 7000
+
+    async def test_different_service_types_coexist(self, db: AsyncSession) -> None:
+        org_id = uuid.uuid4()
+        await _upsert(db, org_id=org_id)
+        await _upsert(
+            db,
+            org_id=org_id,
+            service_type=SERVICE_TYPE_INTERNET,
+            rate_cents_per_kwh=None,
+            monthly_cents=6000,
+        )
+
+        rows = await market_rate_benchmark_repo.list_for_org(db, organization_id=org_id)
+        assert {r.service_type for r in rows} == {
+            SERVICE_TYPE_ELECTRICITY,
+            SERVICE_TYPE_INTERNET,
+        }
+
+    async def test_rate_precision_survives_the_round_trip(
+        self, db: AsyncSession,
+    ) -> None:
+        row = await _upsert(
+            db, org_id=uuid.uuid4(), rate_cents_per_kwh=Decimal("10.8375"),
+        )
+        await db.refresh(row)
+        assert Decimal(str(row.rate_cents_per_kwh)) == Decimal("10.8375")
+
+    async def test_another_orgs_row_is_not_overwritten(self, db: AsyncSession) -> None:
+        """Without org scoping the read-then-write would clobber a neighbour."""
+        mine, theirs = uuid.uuid4(), uuid.uuid4()
+        await _upsert(db, org_id=theirs)
+        await _upsert(db, org_id=mine, rate_cents_per_kwh=Decimal("9.0000"))
+
+        their_rows = await market_rate_benchmark_repo.list_for_org(
+            db, organization_id=theirs,
+        )
+        assert len(their_rows) == 1
+        assert Decimal(str(their_rows[0].rate_cents_per_kwh)) == Decimal("11.1")
+
+    async def test_provenance_records_the_member_who_wrote_it(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, member_a, member_b = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        first = await _upsert(db, org_id=org_id, user_id=member_a)
+        assert first.recorded_by_user_id == member_a
+
+        updated = await _upsert(
+            db, org_id=org_id, user_id=member_b, rate_cents_per_kwh=Decimal("9.0000"),
+        )
+        assert updated.id == first.id
+        assert updated.recorded_by_user_id == member_b
+
+
+class TestOrganizationScoping:
+    """A benchmark belongs to the org, not to whoever looked the rate up."""
+
+    async def test_a_second_member_reads_the_same_row(self, db: AsyncSession) -> None:
+        org_id, member_a, member_b = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        await _upsert(db, org_id=org_id, user_id=member_a)
+
+        rows = await market_rate_benchmark_repo.list_for_org(db, organization_id=org_id)
+        assert len(rows) == 1
+        assert rows[0].recorded_by_user_id == member_a
+        assert member_b != member_a  # the read did not depend on the member
+
+    async def test_a_second_member_updates_rather_than_colliding(
+        self, db: AsyncSession,
+    ) -> None:
+        """Scoping reads by user would send this write into the unique index."""
+        org_id = uuid.uuid4()
+        first = await _upsert(db, org_id=org_id, user_id=uuid.uuid4())
+        second = await _upsert(
+            db,
+            org_id=org_id,
+            user_id=uuid.uuid4(),
+            rate_cents_per_kwh=Decimal("10.0000"),
+        )
+
+        assert second.id == first.id
+        assert len(
+            await market_rate_benchmark_repo.list_for_org(db, organization_id=org_id)
+        ) == 1
+
+
+class TestGetAndDelete:
+    async def test_get_is_scoped_to_the_owning_org(self, db: AsyncSession) -> None:
+        await _upsert(db, org_id=uuid.uuid4())
+
+        assert (
+            await market_rate_benchmark_repo.get_by_service_type(
+                db,
+                organization_id=uuid.uuid4(),
+                service_type=SERVICE_TYPE_ELECTRICITY,
+            )
+            is None
+        )
+
+    async def test_delete_removes_the_row_and_reports_it(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id = uuid.uuid4()
+        await _upsert(db, org_id=org_id)
+
+        assert (
+            await market_rate_benchmark_repo.delete_by_service_type(
+                db,
+                organization_id=org_id,
+                service_type=SERVICE_TYPE_ELECTRICITY,
+            )
+            is True
+        )
+        assert (
+            await market_rate_benchmark_repo.list_for_org(db, organization_id=org_id)
+            == []
+        )
+
+    async def test_a_second_member_can_remove_the_orgs_benchmark(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id = uuid.uuid4()
+        await _upsert(db, org_id=org_id, user_id=uuid.uuid4())
+
+        assert (
+            await market_rate_benchmark_repo.delete_by_service_type(
+                db,
+                organization_id=org_id,
+                service_type=SERVICE_TYPE_ELECTRICITY,
+            )
+            is True
+        )
+
+    async def test_delete_reports_false_when_nothing_matched(
+        self, db: AsyncSession,
+    ) -> None:
+        assert (
+            await market_rate_benchmark_repo.delete_by_service_type(
+                db,
+                organization_id=uuid.uuid4(),
+                service_type=SERVICE_TYPE_ELECTRICITY,
+            )
+            is False
+        )
+
+    async def test_delete_will_not_reach_another_orgs_row(
+        self, db: AsyncSession,
+    ) -> None:
+        theirs = uuid.uuid4()
+        await _upsert(db, org_id=theirs)
+
+        assert (
+            await market_rate_benchmark_repo.delete_by_service_type(
+                db,
+                organization_id=uuid.uuid4(),
+                service_type=SERVICE_TYPE_ELECTRICITY,
+            )
+            is False
+        )
+        assert len(
+            await market_rate_benchmark_repo.list_for_org(db, organization_id=theirs)
+        ) == 1

--- a/apps/mybookkeeper/backend/tests/test_market_rate_benchmark_service.py
+++ b/apps/mybookkeeper/backend/tests/test_market_rate_benchmark_service.py
@@ -1,0 +1,511 @@
+"""Tests for the rate-comparison service.
+
+The arithmetic itself is covered in ``test_market_benchmark_compare.py``. What
+these pin is the orchestration around it: which plans get measured (current
+ones only), how unmeasurable plans are surfaced rather than dropped, and the
+ordering that puts the most expensive mistake first.
+
+The service opens its own session via ``unit_of_work()``; ``_make_fake_uow``
+patches it to yield the in-memory SQLite test session instead.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.market_benchmark_constants import (
+    BENCHMARK_STALE_AFTER_DAYS,
+    BENCHMARK_STATUS_NOT_COMPARABLE,
+    BENCHMARK_STATUS_NO_BENCHMARK,
+)
+from app.core.utility_plan_constants import (
+    RATE_TYPE_FIXED,
+    RATE_TYPE_REGULATED,
+    SERVICE_TYPE_ELECTRICITY,
+    SERVICE_TYPE_INTERNET,
+    SERVICE_TYPE_NATURAL_GAS,
+)
+from app.models.properties.property import Property
+from app.repositories.properties import market_rate_benchmark_repo, utility_plan_repo
+from app.services.properties import market_rate_benchmark_service
+
+pytestmark = pytest.mark.asyncio
+
+TODAY = _dt.date(2026, 8, 11)
+
+_UOW_TARGET = "app.services.properties.market_rate_benchmark_service.unit_of_work"
+
+
+def _make_fake_uow(session: AsyncSession):
+    @asynccontextmanager
+    async def _fake_uow():
+        yield session
+    return _fake_uow
+
+
+async def _make_property(
+    db: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID, name: str,
+) -> Property:
+    prop = Property(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        name=name,
+        address=name,
+    )
+    db.add(prop)
+    await db.flush()
+    return prop
+
+
+async def _make_plan(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    property_id: uuid.UUID,
+    service_type: str = SERVICE_TYPE_ELECTRICITY,
+    provider_name: str = "Reliant",
+    rate_type: str = RATE_TYPE_FIXED,
+    **kwargs: object,
+):
+    return await utility_plan_repo.create(
+        db,
+        user_id=user_id,
+        organization_id=org_id,
+        property_id=property_id,
+        service_type=service_type,
+        provider_name=provider_name,
+        rate_type=rate_type,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+async def _make_benchmark(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    service_type: str = SERVICE_TYPE_ELECTRICITY,
+    rate_cents_per_kwh: Decimal | None = Decimal("11.1000"),
+    monthly_cents: int | None = None,
+    observed_on: _dt.date = TODAY,
+):
+    return await market_rate_benchmark_repo.upsert(
+        db,
+        recorded_by_user_id=user_id,
+        organization_id=org_id,
+        service_type=service_type,
+        rate_cents_per_kwh=rate_cents_per_kwh,
+        monthly_cents=monthly_cents,
+        source="Power to Choose, 77021, 12-month fixed, 4★+",
+        observed_on=observed_on,
+        notes=None,
+    )
+
+
+class TestGetRateComparison:
+    async def test_flags_a_plan_priced_above_the_market(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            avg_price_cents_per_kwh_at_1000=Decimal("15.0600"),
+            service_start_date=_dt.date(2026, 2, 17),
+        )
+        await _make_benchmark(db, org_id=org_id, user_id=user_id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await market_rate_benchmark_service.get_rate_comparison(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.total_above_market == 1
+        row = result.above_market[0]
+        assert row.plan.property_name == "6732 Peerless St"
+        assert row.gap_pct == Decimal("35.7")
+        assert result.has_stale_benchmark is False
+
+    async def test_a_well_priced_plan_appears_in_neither_list(
+        self, db: AsyncSession,
+    ) -> None:
+        """At-or-below is the quiet case — nothing for the operator to do."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            avg_price_cents_per_kwh_at_1000=Decimal("10.5000"),
+            service_start_date=_dt.date(2026, 2, 17),
+        )
+        await _make_benchmark(db, org_id=org_id, user_id=user_id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await market_rate_benchmark_service.get_rate_comparison(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.above_market == []
+        assert result.not_compared == []
+
+    async def test_superseded_plans_are_not_measured(self, db: AsyncSession) -> None:
+        """An old plan's price is history; flagging it would be noise."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            provider_name="Old and expensive",
+            avg_price_cents_per_kwh_at_1000=Decimal("22.0000"),
+            service_start_date=_dt.date(2024, 1, 1),
+        )
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            provider_name="Current",
+            avg_price_cents_per_kwh_at_1000=Decimal("10.5000"),
+            service_start_date=_dt.date(2026, 2, 17),
+        )
+        await _make_benchmark(db, org_id=org_id, user_id=user_id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await market_rate_benchmark_service.get_rate_comparison(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.above_market == []
+
+    async def test_plan_without_a_benchmark_is_surfaced_not_dropped(
+        self, db: AsyncSession,
+    ) -> None:
+        """Silence would read as an all-clear the app has not earned."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            avg_price_cents_per_kwh_at_1000=Decimal("15.0600"),
+            service_start_date=_dt.date(2026, 2, 17),
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await market_rate_benchmark_service.get_rate_comparison(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.above_market == []
+        assert [r.status for r in result.not_compared] == [BENCHMARK_STATUS_NO_BENCHMARK]
+
+    async def test_regulated_plan_is_reported_as_not_comparable(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_NATURAL_GAS,
+            provider_name="CenterPoint",
+            rate_type=RATE_TYPE_REGULATED,
+            avg_price_cents_per_kwh_at_1000=Decimal("99.0000"),
+            service_start_date=_dt.date(2026, 2, 17),
+        )
+        await _make_benchmark(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            service_type=SERVICE_TYPE_NATURAL_GAS,
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await market_rate_benchmark_service.get_rate_comparison(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.above_market == []
+        assert [r.status for r in result.not_compared] == [
+            BENCHMARK_STATUS_NOT_COMPARABLE,
+        ]
+
+    async def test_benchmarks_are_matched_by_service_type(
+        self, db: AsyncSession,
+    ) -> None:
+        """An electricity rate must never be measured against an internet one."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            service_type=SERVICE_TYPE_INTERNET,
+            provider_name="AT&T",
+            monthly_base_charge_cents=8000,
+            equipment_fee_monthly_cents=1000,
+            service_start_date=_dt.date(2026, 2, 17),
+        )
+        await _make_benchmark(db, org_id=org_id, user_id=user_id)
+        await _make_benchmark(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            service_type=SERVICE_TYPE_INTERNET,
+            rate_cents_per_kwh=None,
+            monthly_cents=6000,
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await market_rate_benchmark_service.get_rate_comparison(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.total_above_market == 1
+        assert result.above_market[0].plan_figure == Decimal(9000)
+        assert result.above_market[0].benchmark_figure == Decimal(6000)
+
+    async def test_widest_gap_sorts_first(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        cheap = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        dear = await _make_property(db, org_id, user_id, "6734 Peerless St")
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=cheap.id,
+            avg_price_cents_per_kwh_at_1000=Decimal("13.0000"),
+            service_start_date=_dt.date(2026, 2, 17),
+        )
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=dear.id,
+            avg_price_cents_per_kwh_at_1000=Decimal("16.2700"),
+            service_start_date=_dt.date(2026, 2, 17),
+        )
+        await _make_benchmark(db, org_id=org_id, user_id=user_id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await market_rate_benchmark_service.get_rate_comparison(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert [r.plan.property_name for r in result.above_market] == [
+            "6734 Peerless St",
+            "6732 Peerless St",
+        ]
+
+    async def test_stale_benchmark_is_reported_on_the_payload(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St")
+        await _make_plan(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            property_id=prop.id,
+            avg_price_cents_per_kwh_at_1000=Decimal("15.0600"),
+            service_start_date=_dt.date(2026, 2, 17),
+        )
+        await _make_benchmark(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            observed_on=TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS + 1),
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await market_rate_benchmark_service.get_rate_comparison(
+                user_id=user_id, organization_id=org_id, today=TODAY,
+            )
+
+        assert result.has_stale_benchmark is True
+        assert result.above_market[0].benchmark_is_stale is True
+
+    async def test_another_orgs_plans_are_not_measured(
+        self, db: AsyncSession,
+    ) -> None:
+        user_id = uuid.uuid4()
+        mine, theirs = uuid.uuid4(), uuid.uuid4()
+        their_prop = await _make_property(db, theirs, user_id, "Someone else's")
+        await _make_plan(
+            db,
+            org_id=theirs,
+            user_id=user_id,
+            property_id=their_prop.id,
+            avg_price_cents_per_kwh_at_1000=Decimal("15.0600"),
+            service_start_date=_dt.date(2026, 2, 17),
+        )
+        await _make_benchmark(db, org_id=mine, user_id=user_id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await market_rate_benchmark_service.get_rate_comparison(
+                user_id=user_id, organization_id=mine, today=TODAY,
+            )
+
+        assert result.above_market == []
+        assert result.not_compared == []
+
+
+class TestBenchmarkCrud:
+    async def test_upsert_then_list_round_trips(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            await market_rate_benchmark_service.upsert_benchmark(
+                user_id=user_id,
+                organization_id=org_id,
+                service_type=SERVICE_TYPE_ELECTRICITY,
+                rate_cents_per_kwh=Decimal("10.8000"),
+                monthly_cents=None,
+                source="Power to Choose",
+                observed_on=TODAY,
+                notes=None,
+                today=TODAY,
+            )
+            rows = await market_rate_benchmark_service.list_benchmarks(
+                organization_id=org_id, today=TODAY,
+            )
+
+        assert len(rows) == 1
+        assert rows[0].is_stale is False
+        assert Decimal(str(rows[0].rate_cents_per_kwh)) == Decimal("10.8")
+
+    async def test_a_second_member_of_the_org_sees_the_same_benchmark(
+        self, db: AsyncSession,
+    ) -> None:
+        """The market is a fact about the org, not about who looked it up."""
+        org_id, member_a, member_b = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            await market_rate_benchmark_service.upsert_benchmark(
+                user_id=member_a,
+                organization_id=org_id,
+                service_type=SERVICE_TYPE_ELECTRICITY,
+                rate_cents_per_kwh=Decimal("10.8000"),
+                monthly_cents=None,
+                source="Power to Choose",
+                observed_on=TODAY,
+                notes=None,
+                today=TODAY,
+            )
+            # Member B updates it: one row, replaced — not a second row that
+            # would collide with the (organization, service type) unique index.
+            await market_rate_benchmark_service.upsert_benchmark(
+                user_id=member_b,
+                organization_id=org_id,
+                service_type=SERVICE_TYPE_ELECTRICITY,
+                rate_cents_per_kwh=Decimal("9.5000"),
+                monthly_cents=None,
+                source="Power to Choose",
+                observed_on=TODAY,
+                notes=None,
+                today=TODAY,
+            )
+            rows = await market_rate_benchmark_service.list_benchmarks(
+                organization_id=org_id, today=TODAY,
+            )
+
+        assert len(rows) == 1
+        assert Decimal(str(rows[0].rate_cents_per_kwh)) == Decimal("9.5")
+
+    async def test_metered_service_rejects_a_flat_monthly(
+        self, db: AsyncSession,
+    ) -> None:
+        """15.06¢/kWh against 6000 reads as 99.7% *below* market — a
+        permanently wrong all-clear rather than a visible error."""
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            with pytest.raises(
+                market_rate_benchmark_service.InvalidMarketRateBenchmarkError,
+            ):
+                await market_rate_benchmark_service.upsert_benchmark(
+                    user_id=uuid.uuid4(),
+                    organization_id=uuid.uuid4(),
+                    service_type=SERVICE_TYPE_ELECTRICITY,
+                    rate_cents_per_kwh=None,
+                    monthly_cents=6000,
+                    source=None,
+                    observed_on=TODAY,
+                    notes=None,
+                )
+
+    async def test_flat_service_rejects_a_metered_rate(
+        self, db: AsyncSession,
+    ) -> None:
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            with pytest.raises(
+                market_rate_benchmark_service.InvalidMarketRateBenchmarkError,
+            ):
+                await market_rate_benchmark_service.upsert_benchmark(
+                    user_id=uuid.uuid4(),
+                    organization_id=uuid.uuid4(),
+                    service_type=SERVICE_TYPE_INTERNET,
+                    rate_cents_per_kwh=Decimal("11.1000"),
+                    monthly_cents=None,
+                    source=None,
+                    observed_on=TODAY,
+                    notes=None,
+                )
+
+    async def test_unknown_service_type_is_rejected_before_the_check_constraint(
+        self, db: AsyncSession,
+    ) -> None:
+        """Otherwise the CHECK surfaces as a 500 instead of a readable 422."""
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            with pytest.raises(
+                market_rate_benchmark_service.InvalidMarketRateBenchmarkError,
+            ):
+                await market_rate_benchmark_service.upsert_benchmark(
+                    user_id=uuid.uuid4(),
+                    organization_id=uuid.uuid4(),
+                    service_type="sewage",
+                    rate_cents_per_kwh=Decimal("1.0"),
+                    monthly_cents=None,
+                    source=None,
+                    observed_on=TODAY,
+                    notes=None,
+                )
+
+    async def test_delete_of_a_missing_benchmark_raises_not_found(
+        self, db: AsyncSession,
+    ) -> None:
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            with pytest.raises(
+                market_rate_benchmark_service.MarketRateBenchmarkNotFoundError,
+            ):
+                await market_rate_benchmark_service.delete_benchmark(
+                    organization_id=uuid.uuid4(),
+                    service_type=SERVICE_TYPE_ELECTRICITY,
+                )
+
+    async def test_stale_flag_is_derived_on_read(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        observed = TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS + 1)
+        await _make_benchmark(db, org_id=org_id, user_id=user_id, observed_on=observed)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            rows = await market_rate_benchmark_service.list_benchmarks(
+                organization_id=org_id, today=TODAY,
+            )
+
+        assert rows[0].is_stale is True

--- a/apps/mybookkeeper/backend/tests/test_market_rate_benchmarks_api.py
+++ b/apps/mybookkeeper/backend/tests/test_market_rate_benchmarks_api.py
@@ -1,0 +1,315 @@
+"""HTTP route tests for /market-rate-benchmarks and /utility-plans/rate-comparison.
+
+The service is mocked — its behaviour is covered in
+``test_market_rate_benchmark_service.py``. What these pin is the contract the
+routes own: payload validation (in particular the exactly-one-shape rule, which
+must surface as a readable 422 rather than an IntegrityError 500), status
+codes, the permission dependency each route hangs off, and the route-ordering
+hazard where ``/rate-comparison`` would be swallowed by ``/{plan_id}``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.market_benchmark_constants import (
+    BENCHMARK_STATUS_ABOVE,
+    MATERIAL_GAP_PCT,
+)
+from app.core.permissions import current_org_member, require_write_access
+from app.core.utility_plan_constants import (
+    RATE_TYPE_FIXED,
+    RENEWAL_STATUS_ACTIVE,
+    SERVICE_TYPE_ELECTRICITY,
+)
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.properties.market_rate_benchmark_response import (
+    MarketRateBenchmarkResponse,
+)
+from app.schemas.properties.utility_plan_rate_comparison_response import (
+    UtilityPlanRateComparisonResponse,
+)
+from app.schemas.properties.utility_plan_rate_comparison_row import (
+    UtilityPlanRateComparisonRow,
+)
+from app.schemas.properties.utility_plan_summary import UtilityPlanSummary
+from app.services.properties.market_rate_benchmark_service import (
+    InvalidMarketRateBenchmarkError,
+    MarketRateBenchmarkNotFoundError,
+)
+
+ORG_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+PROPERTY_ID = uuid.uuid4()
+PLAN_ID = uuid.uuid4()
+
+_SERVICE = "app.api.market_rate_benchmarks.market_rate_benchmark_service"
+_PLAN_ROUTE_SERVICE = "app.api.utility_plans.market_rate_benchmark_service"
+
+TODAY = _dt.date(2026, 8, 11)
+
+
+def _ctx(role: OrgRole = OrgRole.OWNER) -> RequestContext:
+    return RequestContext(organization_id=ORG_ID, user_id=USER_ID, org_role=role)
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[current_org_member] = lambda: _ctx()
+    app.dependency_overrides[require_write_access] = lambda: _ctx()
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _benchmark(**overrides) -> MarketRateBenchmarkResponse:
+    now = _dt.datetime.now(_dt.timezone.utc)
+    base = {
+        "id": uuid.uuid4(),
+        "service_type": SERVICE_TYPE_ELECTRICITY,
+        "rate_cents_per_kwh": Decimal("11.1000"),
+        "monthly_cents": None,
+        "source": "Power to Choose, 77021",
+        "observed_on": TODAY,
+        "notes": None,
+        "is_stale": False,
+        "created_at": now,
+        "updated_at": now,
+    }
+    base.update(overrides)
+    return MarketRateBenchmarkResponse(**base)
+
+
+def _summary() -> UtilityPlanSummary:
+    now = _dt.datetime.now(_dt.timezone.utc)
+    return UtilityPlanSummary(
+        id=PLAN_ID,
+        property_id=PROPERTY_ID,
+        property_name="6732 Peerless St",
+        service_type=SERVICE_TYPE_ELECTRICITY,
+        provider_name="Reliant",
+        plan_name=None,
+        rate_type=RATE_TYPE_FIXED,
+        avg_price_cents_per_kwh_at_1000=Decimal("15.0600"),
+        term_end_date=_dt.date(2027, 2, 17),
+        days_until_term_end=190,
+        renewal_status=RENEWAL_STATUS_ACTIVE,
+        is_current=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _comparison() -> UtilityPlanRateComparisonResponse:
+    return UtilityPlanRateComparisonResponse(
+        material_gap_pct=MATERIAL_GAP_PCT,
+        above_market=[
+            UtilityPlanRateComparisonRow(
+                plan=_summary(),
+                status=BENCHMARK_STATUS_ABOVE,
+                plan_figure=Decimal("15.0600"),
+                benchmark_figure=Decimal("11.1000"),
+                gap_pct=Decimal("35.7"),
+                benchmark_is_stale=False,
+            ),
+        ],
+        not_compared=[],
+        total_above_market=1,
+        has_stale_benchmark=False,
+    )
+
+
+class TestListBenchmarks:
+    def test_returns_the_recorded_benchmarks(self, client: TestClient) -> None:
+        with patch(f"{_SERVICE}.list_benchmarks", new=AsyncMock(return_value=[_benchmark()])):
+            response = client.get("/market-rate-benchmarks")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 1
+        assert body[0]["service_type"] == SERVICE_TYPE_ELECTRICITY
+        # Decimal is serialized as a string so four-decimal precision survives.
+        assert body[0]["rate_cents_per_kwh"] == "11.1000"
+
+    def test_hangs_off_the_read_permission(self, client: TestClient) -> None:
+        app.dependency_overrides[current_org_member] = lambda: _ctx(OrgRole.VIEWER)
+        with patch(f"{_SERVICE}.list_benchmarks", new=AsyncMock(return_value=[])):
+            assert client.get("/market-rate-benchmarks").status_code == 200
+
+
+class TestUpsertBenchmark:
+    def test_accepts_a_metered_rate(self, client: TestClient) -> None:
+        mock = AsyncMock(return_value=_benchmark())
+        with patch(f"{_SERVICE}.upsert_benchmark", new=mock):
+            response = client.put(
+                f"/market-rate-benchmarks/{SERVICE_TYPE_ELECTRICITY}",
+                json={"rate_cents_per_kwh": "11.1000", "observed_on": TODAY.isoformat()},
+            )
+
+        assert response.status_code == 200
+        assert mock.await_args.kwargs["rate_cents_per_kwh"] == Decimal("11.1000")
+        assert mock.await_args.kwargs["monthly_cents"] is None
+
+    def test_accepts_a_flat_monthly(self, client: TestClient) -> None:
+        mock = AsyncMock(
+            return_value=_benchmark(
+                service_type="internet", rate_cents_per_kwh=None, monthly_cents=6000,
+            ),
+        )
+        with patch(f"{_SERVICE}.upsert_benchmark", new=mock):
+            response = client.put(
+                "/market-rate-benchmarks/internet",
+                json={"monthly_cents": 6000, "observed_on": TODAY.isoformat()},
+            )
+
+        assert response.status_code == 200
+        assert mock.await_args.kwargs["monthly_cents"] == 6000
+
+    def test_rejects_both_shapes_at_once(self, client: TestClient) -> None:
+        """A row carrying both cannot say which comparison it participates in."""
+        response = client.put(
+            f"/market-rate-benchmarks/{SERVICE_TYPE_ELECTRICITY}",
+            json={
+                "rate_cents_per_kwh": "11.1000",
+                "monthly_cents": 6000,
+                "observed_on": TODAY.isoformat(),
+            },
+        )
+        assert response.status_code == 422
+
+    def test_rejects_neither_shape(self, client: TestClient) -> None:
+        response = client.put(
+            f"/market-rate-benchmarks/{SERVICE_TYPE_ELECTRICITY}",
+            json={"observed_on": TODAY.isoformat()},
+        )
+        assert response.status_code == 422
+
+    def test_rejects_a_non_positive_rate(self, client: TestClient) -> None:
+        response = client.put(
+            f"/market-rate-benchmarks/{SERVICE_TYPE_ELECTRICITY}",
+            json={"rate_cents_per_kwh": "0", "observed_on": TODAY.isoformat()},
+        )
+        assert response.status_code == 422
+
+    def test_rejects_a_future_observation(self, client: TestClient) -> None:
+        """A future date is a typo, and it would never age into staleness."""
+        next_week = _dt.date.today() + _dt.timedelta(days=7)
+        response = client.put(
+            f"/market-rate-benchmarks/{SERVICE_TYPE_ELECTRICITY}",
+            json={"rate_cents_per_kwh": "11.1", "observed_on": next_week.isoformat()},
+        )
+        assert response.status_code == 422
+
+    def test_accepts_a_client_whose_today_is_a_day_ahead(
+        self, client: TestClient,
+    ) -> None:
+        """The browser sends *its* local date, which can lead the server's.
+
+        Without a day of slack, a user east of the server is rejected for
+        picking today on their own calendar — a 422 they cannot act on.
+        """
+        with patch(_SERVICE) as service:
+            service.upsert_benchmark = AsyncMock(return_value=_benchmark())
+            tomorrow = _dt.date.today() + _dt.timedelta(days=1)
+            response = client.put(
+                f"/market-rate-benchmarks/{SERVICE_TYPE_ELECTRICITY}",
+                json={
+                    "rate_cents_per_kwh": "11.1",
+                    "observed_on": tomorrow.isoformat(),
+                },
+            )
+        assert response.status_code == 200
+
+    def test_rejects_unknown_fields(self, client: TestClient) -> None:
+        response = client.put(
+            f"/market-rate-benchmarks/{SERVICE_TYPE_ELECTRICITY}",
+            json={
+                "rate_cents_per_kwh": "11.1",
+                "observed_on": TODAY.isoformat(),
+                "wishful_thinking": True,
+            },
+        )
+        assert response.status_code == 422
+
+    def test_unknown_service_type_is_a_422_not_a_500(self, client: TestClient) -> None:
+        with patch(
+            f"{_SERVICE}.upsert_benchmark",
+            new=AsyncMock(side_effect=InvalidMarketRateBenchmarkError("nope")),
+        ):
+            response = client.put(
+                "/market-rate-benchmarks/sewage",
+                json={"rate_cents_per_kwh": "11.1", "observed_on": TODAY.isoformat()},
+            )
+        assert response.status_code == 422
+
+    def test_hangs_off_the_write_permission(self, client: TestClient) -> None:
+        from fastapi import HTTPException
+
+        def _deny():
+            raise HTTPException(status_code=403, detail="Read-only")
+
+        app.dependency_overrides[require_write_access] = _deny
+        response = client.put(
+            f"/market-rate-benchmarks/{SERVICE_TYPE_ELECTRICITY}",
+            json={"rate_cents_per_kwh": "11.1", "observed_on": TODAY.isoformat()},
+        )
+        assert response.status_code == 403
+
+
+class TestDeleteBenchmark:
+    def test_returns_204_on_success(self, client: TestClient) -> None:
+        with patch(f"{_SERVICE}.delete_benchmark", new=AsyncMock(return_value=None)):
+            response = client.delete(
+                f"/market-rate-benchmarks/{SERVICE_TYPE_ELECTRICITY}",
+            )
+        assert response.status_code == 204
+
+    def test_returns_404_when_nothing_was_recorded(self, client: TestClient) -> None:
+        with patch(
+            f"{_SERVICE}.delete_benchmark",
+            new=AsyncMock(side_effect=MarketRateBenchmarkNotFoundError("electricity")),
+        ):
+            response = client.delete(
+                f"/market-rate-benchmarks/{SERVICE_TYPE_ELECTRICITY}",
+            )
+        assert response.status_code == 404
+
+
+class TestRateComparisonRoute:
+    def test_returns_the_comparison(self, client: TestClient) -> None:
+        with patch(
+            f"{_PLAN_ROUTE_SERVICE}.get_rate_comparison",
+            new=AsyncMock(return_value=_comparison()),
+        ):
+            response = client.get("/utility-plans/rate-comparison")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total_above_market"] == 1
+        assert body["above_market"][0]["gap_pct"] == "35.7"
+        assert body["material_gap_pct"] == MATERIAL_GAP_PCT
+
+    def test_literal_path_is_not_swallowed_by_the_uuid_route(
+        self, client: TestClient,
+    ) -> None:
+        """Declaring ``/{plan_id}`` first would turn this into a 422."""
+        with patch(
+            f"{_PLAN_ROUTE_SERVICE}.get_rate_comparison",
+            new=AsyncMock(return_value=_comparison()),
+        ) as mock:
+            client.get("/utility-plans/rate-comparison")
+        assert mock.await_count == 1
+
+    def test_hangs_off_the_read_permission(self, client: TestClient) -> None:
+        app.dependency_overrides[current_org_member] = lambda: _ctx(OrgRole.VIEWER)
+        with patch(
+            f"{_PLAN_ROUTE_SERVICE}.get_rate_comparison",
+            new=AsyncMock(return_value=_comparison()),
+        ):
+            assert client.get("/utility-plans/rate-comparison").status_code == 200

--- a/apps/mybookkeeper/frontend/e2e/utility-plan-comparison-layout.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-plan-comparison-layout.spec.ts
@@ -1,0 +1,217 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * Layout E2E for the dashboard rate-comparison card and the market-rate dialog.
+ *
+ * Verifies:
+ *   1. The card's loading skeleton has the same row count and the same
+ *      text-block-plus-pill shape as the loaded card, so the dashboard does not
+ *      shift when the comparison arrives.
+ *   2. Neither the dashboard nor the dialog overflows horizontally at mobile /
+ *      tablet / desktop widths.
+ *   3. The dialog's close control meets the 44px touch-target minimum.
+ */
+
+/** Matches the placeholder row count in ``UtilityPlanComparisonCardSkeleton``. */
+const SKELETON_ROW_COUNT = 2;
+
+/**
+ * Benchmarks are keyed on (organization, service type) and this account is
+ * shared with every other utility spec, so this file works in ``internet`` —
+ * a service no sibling spec writes — and runs serially, because two tests
+ * upserting the same row concurrently would race on the unique index.
+ */
+const SERVICE_TYPE = "internet";
+const BENCHMARK_URL = `/market-rate-benchmarks/${SERVICE_TYPE}`;
+
+function isoDateOffset(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+async function seedPlan(
+  api: APIRequestContext,
+  propertyId: string,
+  providerName: string,
+): Promise<string> {
+  const res = await api.post("/utility-plans", {
+    data: {
+      property_id: propertyId,
+      service_type: SERVICE_TYPE,
+      provider_name: providerName,
+      rate_type: "fixed",
+      // Flat service is priced per month, and the comparison adds the
+      // equipment fee — $90 against a $60 market is comfortably flagged.
+      monthly_base_charge_cents: 8000,
+      equipment_fee_monthly_cents: 1000,
+      service_start_date: isoDateOffset(-60),
+      term_end_date: isoDateOffset(300),
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedPlan failed: ${res.status()} ${await res.text()}`);
+  }
+  return (await res.json()).id;
+}
+
+async function hasHorizontalOverflow(
+  page: import("@playwright/test").Page,
+): Promise<boolean> {
+  return page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+  );
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Utility plan comparison layout", () => {
+  test("skeleton row count and shape match the loaded card", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    let propertyId: string | null = null;
+    let planId: string | null = null;
+    let benchmarkRecorded = false;
+
+    try {
+      const property = await createProperty(api, {
+        name: `E2E Comparison Layout ${runId}`,
+      });
+      propertyId = property.id;
+      planId = await seedPlan(api, propertyId, `E2E Comparison Power ${runId}`);
+
+      const benchRes = await api.put(BENCHMARK_URL, {
+        data: {
+          monthly_cents: 6000,
+          source: `E2E comparison layout ${runId}`,
+          observed_on: isoDateOffset(0),
+        },
+      });
+      expect(benchRes.ok()).toBe(true);
+      benchmarkRecorded = true;
+
+      // Hold the comparison response long enough to observe the skeleton. The
+      // glob is exact so the sibling `/utility-plans` list call is untouched.
+      await page.route("**/api/utility-plans/rate-comparison", async (route) => {
+        await new Promise((r) => setTimeout(r, 1500));
+        await route.continue();
+      });
+
+      const navPromise = page.goto("/");
+
+      const skeleton = page.getByTestId("utility-plan-comparison-card-loading");
+      await expect(skeleton).toBeVisible({ timeout: 15000 });
+      await expect(skeleton.locator("ul > li")).toHaveCount(SKELETON_ROW_COUNT);
+      // Each placeholder row reserves exactly one gap-pill slot, like a real row.
+      await expect(skeleton.locator(".rounded-full")).toHaveCount(SKELETON_ROW_COUNT);
+
+      await navPromise;
+
+      const card = page.getByTestId("utility-plan-comparison-card");
+      await expect(card).toBeVisible({ timeout: 20000 });
+      const row = page.getByTestId(`utility-plan-comparison-${planId}`);
+      await expect(row).toBeVisible();
+      // One gap pill per row, loaded and loading alike — that 1:1 ratio is the
+      // shape the skeleton promises, and it keeps the right-hand column from
+      // jumping when the data lands. Counted rather than compared to a fixed
+      // number because the account is shared with the sibling utility specs.
+      // Scoped to the above-market list specifically: the card also renders a
+      // "not checked" list, whose rows carry no gap pill by design.
+      const loadedRows = page.locator(
+        '[data-testid="utility-plan-comparison-above-list"] > li',
+      );
+      const loadedCount = await loadedRows.count();
+      expect(loadedCount).toBeGreaterThanOrEqual(1);
+      await expect(
+        page.locator('[data-testid^="utility-plan-comparison-gap-"]'),
+      ).toHaveCount(loadedCount);
+    } finally {
+      if (benchmarkRecorded) {
+        await api.delete(BENCHMARK_URL).catch(() => {});
+      }
+      if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+
+  test("the card and dialog fit every viewport and keep 44px touch targets", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    let propertyId: string | null = null;
+    let planId: string | null = null;
+    let benchmarkRecorded = false;
+
+    try {
+      const property = await createProperty(api, {
+        name: `E2E Wide Comparison Property Name That Could Overflow ${runId}`,
+      });
+      propertyId = property.id;
+      planId = await seedPlan(
+        api,
+        propertyId,
+        `E2E Comparison Provider With A Deliberately Long Name ${runId}`,
+      );
+
+      const benchRes = await api.put(BENCHMARK_URL, {
+        data: {
+          monthly_cents: 6000,
+          source: `E2E a deliberately long provenance string for overflow ${runId}`,
+          observed_on: isoDateOffset(0),
+        },
+      });
+      expect(benchRes.ok()).toBe(true);
+      benchmarkRecorded = true;
+
+      for (const size of [
+        { width: 375, height: 800 },
+        { width: 768, height: 900 },
+        { width: 1440, height: 900 },
+      ]) {
+        await page.setViewportSize(size);
+        await page.goto("/");
+        await expect(page.getByTestId(`utility-plan-comparison-${planId}`)).toBeVisible({
+          timeout: 20000,
+        });
+        expect(
+          await hasHorizontalOverflow(page),
+          `dashboard overflow at ${size.width}px`,
+        ).toBe(false);
+
+        await page.goto("/utility-plans");
+        await expect(page.getByTestId(`market-rate-${SERVICE_TYPE}`)).toBeVisible({
+          timeout: 15000,
+        });
+        expect(
+          await hasHorizontalOverflow(page),
+          `plans page overflow at ${size.width}px`,
+        ).toBe(false);
+      }
+
+      // The dialog is the tightest layout — a modal on a 375px viewport.
+      await page.setViewportSize({ width: 375, height: 800 });
+      await page.goto("/utility-plans");
+      await page.getByTestId("record-market-rate-button").click();
+      await expect(page.getByTestId("market-rate-benchmark-dialog")).toBeVisible();
+      expect(await hasHorizontalOverflow(page), "dialog overflow at 375px").toBe(false);
+
+      const close = page
+        .getByTestId("market-rate-benchmark-dialog")
+        .getByRole("button", { name: "Close" });
+      const box = await close.boundingBox();
+      expect(box, "close control has no box").not.toBeNull();
+      expect(box!.width, "close width").toBeGreaterThanOrEqual(44);
+      expect(box!.height, "close height").toBeGreaterThanOrEqual(44);
+    } finally {
+      if (benchmarkRecorded) {
+        await api.delete(BENCHMARK_URL).catch(() => {});
+      }
+      if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/e2e/utility-plan-rate-benchmark.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-plan-rate-benchmark.spec.ts
@@ -1,0 +1,267 @@
+import { test, expect, type APIRequestContext, type Page } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * Rate-benchmark full-flow behavioural E2E.
+ *
+ * Drives the real journey the feature exists for: a plan comfortably inside its
+ * term — so the renewal card says nothing about it — gets flagged once a market
+ * rate is recorded through the dialog. That is the gap this feature closes; a
+ * lapsed plan would have been caught by the renewal card already.
+ *
+ * Verifies UI state AND backend state via the public API, and cleans up every
+ * seeded row in `finally` per the project's "never leave test data" rule.
+ *
+ * The benchmark is org-scoped and this account is shared with the sibling
+ * utility specs, so every assertion targets the seeded plan's own row rather
+ * than a total, and the benchmark is deleted on the way out.
+ */
+
+interface BenchmarkRow {
+  id: string;
+  service_type: string;
+  rate_cents_per_kwh: string | null;
+  monthly_cents: number | null;
+  source: string | null;
+  observed_on: string;
+  is_stale: boolean;
+}
+
+interface ComparisonRow {
+  plan: { id: string; provider_name: string };
+  status: string;
+  plan_figure: string | null;
+  benchmark_figure: string | null;
+  gap_pct: string | null;
+  benchmark_is_stale: boolean;
+}
+
+interface Comparison {
+  material_gap_pct: number;
+  above_market: ComparisonRow[];
+  not_compared: ComparisonRow[];
+  total_above_market: number;
+  has_stale_benchmark: boolean;
+}
+
+/** ``offsetDays`` from today as ``YYYY-MM-DD``. Negative is in the past. */
+function isoDateOffset(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+async function seedPlan(
+  api: APIRequestContext,
+  propertyId: string,
+  providerName: string,
+): Promise<string> {
+  const res = await api.post("/utility-plans", {
+    data: {
+      property_id: propertyId,
+      service_type: "electricity",
+      provider_name: providerName,
+      rate_type: "fixed",
+      plan_name: "12 Month Fixed",
+      avg_price_cents_per_kwh_at_1000: "15.0600",
+      term_months: 12,
+      // Well inside its term: the renewal card has nothing to say here, which
+      // is exactly the blind spot the comparison covers.
+      service_start_date: isoDateOffset(-60),
+      term_end_date: isoDateOffset(300),
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedPlan failed: ${res.status()} ${await res.text()}`);
+  }
+  return (await res.json()).id;
+}
+
+async function fetchComparison(api: APIRequestContext): Promise<Comparison> {
+  const res = await api.get("/utility-plans/rate-comparison");
+  if (!res.ok()) {
+    throw new Error(`fetchComparison failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function fetchBenchmarks(api: APIRequestContext): Promise<BenchmarkRow[]> {
+  const res = await api.get("/market-rate-benchmarks");
+  if (!res.ok()) {
+    throw new Error(`fetchBenchmarks failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function waitForListPage(page: Page): Promise<void> {
+  await expect(page.getByRole("heading", { name: "Utility Plans" })).toBeVisible({
+    timeout: 10000,
+  });
+  await page.waitForLoadState("networkidle");
+}
+
+test.describe("Utility plan rate benchmark", () => {
+  test("record a market rate, see an in-term plan flagged as above market, remove it", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const providerName = `E2E Benchmark Power ${runId}`;
+    let propertyId: string | null = null;
+    let planId: string | null = null;
+    let benchmarkRecorded = false;
+
+    try {
+      const property = await createProperty(api, {
+        name: `E2E Benchmark Property ${runId}`,
+      });
+      propertyId = property.id;
+      planId = await seedPlan(api, propertyId, providerName);
+
+      // ── Before any benchmark: nothing is being checked ───────────────────
+      const before = await fetchComparison(api);
+      expect(before.above_market.some((r) => r.plan.id === planId)).toBe(false);
+      // The plan is surfaced as unmeasured rather than silently dropped.
+      expect(
+        before.not_compared.find((r) => r.plan.id === planId)?.status,
+      ).toBe("no_benchmark");
+
+      await page.goto("/utility-plans");
+      await waitForListPage(page);
+      // Scoped to electricity rather than asserting the summary is empty: the
+      // account is shared with the sibling comparison-layout spec, which writes
+      // an `internet` benchmark, and a global empty-state assertion would fail
+      // purely because that file happened to run alongside this one.
+      await expect(page.getByTestId("market-rate-electricity")).toBeHidden();
+
+      // ── Record the market rate through the dialog ────────────────────────
+      await page.getByTestId("record-market-rate-button").click();
+      await expect(page.getByTestId("market-rate-benchmark-dialog")).toBeVisible();
+
+      await page.getByTestId("benchmark-figure").fill("11.1");
+      await page
+        .getByTestId("benchmark-source")
+        .fill(`Power to Choose 77021 ${runId}`);
+      await page.getByTestId("utility-plan-save-button").click();
+      benchmarkRecorded = true;
+
+      await expect(page.getByTestId("market-rate-benchmark-dialog")).toBeHidden({
+        timeout: 15000,
+      });
+
+      // Backend state, not just the UI: the rate landed in the metered shape.
+      const benchmarks = await fetchBenchmarks(api);
+      const electricity = benchmarks.find((b) => b.service_type === "electricity");
+      expect(electricity, "no electricity benchmark was saved").toBeTruthy();
+      expect(Number(electricity!.rate_cents_per_kwh)).toBeCloseTo(11.1, 4);
+      expect(electricity!.monthly_cents).toBeNull();
+      expect(electricity!.is_stale).toBe(false);
+
+      // ── The plan is now measured and flagged ────────────────────────────
+      const after = await fetchComparison(api);
+      const row = after.above_market.find((r) => r.plan.id === planId);
+      expect(row, "the seeded plan was not flagged as above market").toBeTruthy();
+      expect(row!.status).toBe("above_market");
+      // 15.06 against 11.10 is ~35.7% — well past the materiality threshold.
+      expect(Number(row!.gap_pct)).toBeGreaterThan(after.material_gap_pct);
+
+      // ── The list page reflects what it is comparing against ─────────────
+      await page.reload();
+      await waitForListPage(page);
+      await expect(page.getByTestId("market-rate-electricity")).toContainText(
+        "11.1¢/kWh",
+      );
+
+      // ── The dashboard card names the plan ───────────────────────────────
+      await page.goto("/");
+      const card = page.getByTestId("utility-plan-comparison-card");
+      await expect(card).toBeVisible({ timeout: 15000 });
+      await expect(page.getByTestId(`utility-plan-comparison-${planId}`)).toContainText(
+        "paying 15.06¢/kWh vs market 11.1¢/kWh",
+      );
+      await expect(
+        page.getByTestId(`utility-plan-comparison-gap-${planId}`),
+      ).toContainText("above market");
+
+      // ── Removing the benchmark stops the flag ───────────────────────────
+      const deleted = await api.delete("/market-rate-benchmarks/electricity");
+      expect(deleted.ok()).toBe(true);
+      benchmarkRecorded = false;
+
+      const cleared = await fetchComparison(api);
+      expect(cleared.above_market.some((r) => r.plan.id === planId)).toBe(false);
+    } finally {
+      if (benchmarkRecorded) {
+        await api.delete("/market-rate-benchmarks/electricity").catch(() => {});
+      }
+      if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+
+  test("a regulated plan is never flagged, however it is priced", async ({
+    api,
+  }) => {
+    const runId = Date.now();
+    let propertyId: string | null = null;
+    let planId: string | null = null;
+    let benchmarkRecorded = false;
+
+    try {
+      const property = await createProperty(api, {
+        name: `E2E Regulated Property ${runId}`,
+      });
+      propertyId = property.id;
+
+      const planRes = await api.post("/utility-plans", {
+        data: {
+          property_id: propertyId,
+          service_type: "natural_gas",
+          provider_name: `E2E CenterPoint ${runId}`,
+          // A tariffed monopoly: telling the operator it is above market would
+          // be advice they cannot act on.
+          rate_type: "regulated",
+          avg_price_cents_per_kwh_at_1000: "99.0000",
+          service_start_date: isoDateOffset(-60),
+        },
+      });
+      expect(planRes.ok()).toBe(true);
+      planId = (await planRes.json()).id;
+
+      const benchRes = await api.put("/market-rate-benchmarks/natural_gas", {
+        data: {
+          rate_cents_per_kwh: "1.0000",
+          source: `E2E regulated check ${runId}`,
+          observed_on: isoDateOffset(0),
+        },
+      });
+      expect(benchRes.ok()).toBe(true);
+      benchmarkRecorded = true;
+
+      const comparison = await fetchComparison(api);
+      expect(comparison.above_market.some((r) => r.plan.id === planId)).toBe(false);
+      expect(
+        comparison.not_compared.find((r) => r.plan.id === planId)?.status,
+      ).toBe("not_comparable");
+    } finally {
+      if (benchmarkRecorded) {
+        await api.delete("/market-rate-benchmarks/natural_gas").catch(() => {});
+      }
+      if (planId) await api.delete(`/utility-plans/${planId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+
+  test("the API rejects a benchmark that carries both shapes", async ({ api }) => {
+    // The DB CHECK is the real guarantee; this pins that it surfaces as a
+    // readable 422 rather than an IntegrityError 500.
+    const res = await api.put("/market-rate-benchmarks/electricity", {
+      data: {
+        rate_cents_per_kwh: "11.1000",
+        monthly_cents: 6000,
+        observed_on: isoDateOffset(0),
+      },
+    });
+    expect(res.status()).toBe(422);
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/MarketRateBenchmarkDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/MarketRateBenchmarkDialog.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for the market-rate dialog.
+ *
+ * Two things matter here. The unit asked for must follow the service type —
+ * internet is quoted per month, everything else per kWh — because a rate
+ * recorded in the wrong unit produces a comparison that is confidently wrong
+ * rather than merely absent. And switching service must reload the fields from
+ * *that* type's saved benchmark rather than carrying the previous one across.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { showError } from "@/shared/lib/toast-store";
+import { store } from "@/shared/store";
+import MarketRateBenchmarkDialog from "@/app/features/utility/MarketRateBenchmarkDialog";
+import type { MarketRateBenchmark } from "@/shared/types/utility/market-rate-benchmark";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockUpsert = vi.fn();
+const mockDelete = vi.fn();
+let mockBenchmarks: MarketRateBenchmark[] = [];
+
+vi.mock("@/shared/store/marketRateBenchmarksApi", () => ({
+  useGetMarketRateBenchmarksQuery: vi.fn(() => ({
+    data: mockBenchmarks,
+    isLoading: false,
+  })),
+  useUpsertMarketRateBenchmarkMutation: vi.fn(() => [
+    mockUpsert,
+    { isLoading: false },
+  ]),
+  useDeleteMarketRateBenchmarkMutation: vi.fn(() => [
+    mockDelete,
+    { isLoading: false },
+  ]),
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+function makeBenchmark(overrides: Partial<MarketRateBenchmark> = {}): MarketRateBenchmark {
+  return {
+    id: "bench-1",
+    service_type: "electricity",
+    rate_cents_per_kwh: "11.1000",
+    monthly_cents: null,
+    source: "Power to Choose, 77021",
+    observed_on: "2026-08-01",
+    notes: null,
+    is_stale: false,
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const onClose = vi.fn();
+
+function renderDialog() {
+  return render(
+    <Provider store={store}>
+      <MarketRateBenchmarkDialog onClose={onClose} />
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBenchmarks = [];
+  mockUpsert.mockReturnValue({ unwrap: () => Promise.resolve(makeBenchmark()) });
+  mockDelete.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("MarketRateBenchmarkDialog — the unit follows the service type", () => {
+  it("asks for ¢/kWh for a metered service", () => {
+    renderDialog();
+
+    expect(screen.getByLabelText(/Going rate \(¢\/kWh/)).toBeInTheDocument();
+  });
+
+  it("asks for $/month once internet is selected", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.selectOptions(screen.getByTestId("benchmark-service-type"), "internet");
+
+    expect(screen.getByLabelText("Going rate ($/month)")).toBeInTheDocument();
+  });
+
+  it("sends a metered rate as rate_cents_per_kwh only", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("benchmark-figure"), "10.8");
+    await user.type(screen.getByTestId("benchmark-source"), "Power to Choose");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const arg = mockUpsert.mock.calls[0][0];
+    expect(arg.serviceType).toBe("electricity");
+    expect(arg.data.rate_cents_per_kwh).toBe("10.8");
+    expect(arg.data.monthly_cents).toBeUndefined();
+  });
+
+  it("converts a flat monthly to integer cents", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.selectOptions(screen.getByTestId("benchmark-service-type"), "internet");
+    await user.type(screen.getByTestId("benchmark-figure"), "60.00");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    const arg = mockUpsert.mock.calls[0][0];
+    expect(arg.data.monthly_cents).toBe(6000);
+    expect(arg.data.rate_cents_per_kwh).toBeUndefined();
+  });
+});
+
+describe("MarketRateBenchmarkDialog — existing values", () => {
+  it("prefills from the saved benchmark for the selected service", () => {
+    mockBenchmarks = [makeBenchmark()];
+
+    renderDialog();
+
+    expect(screen.getByTestId("benchmark-figure")).toHaveValue(11.1);
+    expect(screen.getByTestId("benchmark-source")).toHaveValue(
+      "Power to Choose, 77021",
+    );
+    expect(screen.getByTestId("utility-plan-save-button")).toHaveTextContent(
+      "Update rate",
+    );
+  });
+
+  it("does not carry one service's figure across to another", async () => {
+    mockBenchmarks = [makeBenchmark()];
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.selectOptions(screen.getByTestId("benchmark-service-type"), "internet");
+
+    expect(screen.getByTestId("benchmark-figure")).toHaveValue(null);
+    expect(screen.getByTestId("utility-plan-save-button")).toHaveTextContent(
+      "Save rate",
+    );
+  });
+});
+
+describe("MarketRateBenchmarkDialog — submit guard", () => {
+  it("keeps save disabled until a positive figure is entered", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    expect(screen.getByTestId("utility-plan-save-button")).toBeDisabled();
+
+    await user.type(screen.getByTestId("benchmark-figure"), "10.8");
+
+    expect(screen.getByTestId("utility-plan-save-button")).toBeEnabled();
+  });
+
+  it("closes once the save resolves", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("benchmark-figure"), "10.8");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays open when the save fails", async () => {
+    mockUpsert.mockReturnValue({
+      unwrap: () => Promise.reject(new Error("boom")),
+    });
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("benchmark-figure"), "10.8");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the backend's reason rather than a generic retry", async () => {
+    // "Try again" on a payload the server will reject identically every time
+    // sends the operator round a loop they cannot exit.
+    mockUpsert.mockReturnValue({
+      unwrap: () =>
+        Promise.reject({
+          status: 422,
+          data: { detail: "electricity is metered — provide rate_cents_per_kwh." },
+        }),
+    });
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("benchmark-figure"), "10.8");
+    await user.click(screen.getByTestId("utility-plan-save-button"));
+
+    expect(showError).toHaveBeenCalledWith(
+      "electricity is metered — provide rate_cents_per_kwh.",
+    );
+  });
+});
+
+describe("MarketRateBenchmarkDialog — removing a rate", () => {
+  it("offers no removal when nothing is recorded for this service", () => {
+    renderDialog();
+
+    expect(screen.queryByTestId("benchmark-remove-button")).not.toBeInTheDocument();
+  });
+
+  it("removes the recorded rate and closes", async () => {
+    mockBenchmarks = [makeBenchmark()];
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByTestId("benchmark-remove-button"));
+
+    expect(mockDelete).toHaveBeenCalledWith("electricity");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays open when the removal fails", async () => {
+    mockBenchmarks = [makeBenchmark()];
+    mockDelete.mockReturnValue({ unwrap: () => Promise.reject(new Error("boom")) });
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByTestId("benchmark-remove-button"));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/UtilityPlanComparisonCard.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/UtilityPlanComparisonCard.test.tsx
@@ -1,0 +1,431 @@
+/**
+ * Unit tests for the dashboard rate-comparison card.
+ *
+ * The behaviour worth protecting is the ``no-benchmark`` case: with nothing
+ * recorded to compare against, the card must say so rather than fall through to
+ * an all-clear. Silence there would read as "your rates are fine" when the
+ * truth is "nothing was checked" — which is the exact failure this card exists
+ * to fix, since a plan can sit comfortably inside its term and still be the
+ * most expensive line in the portfolio.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { store } from "@/shared/store";
+import UtilityPlanComparisonCard from "@/app/features/utility/UtilityPlanComparisonCard";
+import type { MarketRateBenchmark } from "@/shared/types/utility/market-rate-benchmark";
+import type { UtilityPlanRateComparison } from "@/shared/types/utility/utility-plan-rate-comparison";
+import type { UtilityPlanRateComparisonRow } from "@/shared/types/utility/utility-plan-rate-comparison-row";
+import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockRefetch = vi.fn();
+let mockComparison: UtilityPlanRateComparison | undefined;
+let mockComparisonLoading = false;
+let mockComparisonError = false;
+let mockBenchmarks: MarketRateBenchmark[] = [];
+let mockBenchmarksLoading = false;
+let mockBenchmarksError = false;
+let mockPlanTotal = 0;
+let mockPlansLoading = false;
+let mockPlansError = false;
+
+vi.mock("@/shared/store/marketRateBenchmarksApi", () => ({
+  useGetUtilityPlanRateComparisonQuery: vi.fn(() => ({
+    data: mockComparison,
+    isLoading: mockComparisonLoading,
+    isError: mockComparisonError,
+    isFetching: false,
+    refetch: mockRefetch,
+  })),
+  useGetMarketRateBenchmarksQuery: vi.fn(() => ({
+    data: mockBenchmarks,
+    isLoading: mockBenchmarksLoading,
+    isError: mockBenchmarksError,
+  })),
+}));
+
+vi.mock("@/shared/store/utilityPlansApi", () => ({
+  useGetUtilityPlansQuery: vi.fn(() => ({
+    data: { items: [], total: mockPlanTotal, has_more: false },
+    isLoading: mockPlansLoading,
+    isError: mockPlansError,
+  })),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+function makePlan(overrides: Partial<UtilityPlanSummary> = {}): UtilityPlanSummary {
+  return {
+    id: "plan-a",
+    property_id: "prop-1",
+    property_name: "6732 Peerless St",
+    service_type: "electricity",
+    provider_name: "Reliant",
+    plan_name: "Truly Free Nights",
+    rate_type: "fixed",
+    avg_price_cents_per_kwh_at_1000: "15.0600",
+    term_end_date: "2027-02-17",
+    days_until_term_end: 190,
+    renewal_status: "active",
+    is_current: true,
+    created_at: "2026-02-17T00:00:00Z",
+    updated_at: "2026-02-17T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRow(
+  overrides: Partial<UtilityPlanRateComparisonRow> = {},
+): UtilityPlanRateComparisonRow {
+  return {
+    plan: makePlan(),
+    status: "above_market",
+    plan_figure: "15.0600",
+    benchmark_figure: "11.1000",
+    gap_pct: "35.7",
+    benchmark_is_stale: false,
+    ...overrides,
+  };
+}
+
+function makeBenchmark(): MarketRateBenchmark {
+  return {
+    id: "bench-1",
+    service_type: "electricity",
+    rate_cents_per_kwh: "11.1000",
+    monthly_cents: null,
+    source: "Power to Choose, 77021",
+    observed_on: "2026-08-11",
+    notes: null,
+    is_stale: false,
+    created_at: "2026-08-11T00:00:00Z",
+    updated_at: "2026-08-11T00:00:00Z",
+  };
+}
+
+function renderCard() {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <UtilityPlanComparisonCard />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockComparison = undefined;
+  mockComparisonLoading = false;
+  mockComparisonError = false;
+  mockBenchmarks = [];
+  mockBenchmarksLoading = false;
+  mockBenchmarksError = false;
+  mockPlanTotal = 0;
+  mockPlansLoading = false;
+  mockPlansError = false;
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("UtilityPlanComparisonCard — when it renders at all", () => {
+  it("renders nothing when the operator tracks no utility plans", () => {
+    mockPlanTotal = 0;
+    mockBenchmarks = [makeBenchmark()];
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [],
+      not_compared: [],
+      total_above_market: 0,
+      has_stale_benchmark: false,
+    };
+
+    const { container } = renderCard();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("prompts for a market rate rather than implying an all-clear", () => {
+    mockPlanTotal = 3;
+    mockBenchmarks = [];
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [],
+      not_compared: [],
+      total_above_market: 0,
+      has_stale_benchmark: false,
+    };
+
+    renderCard();
+
+    expect(
+      screen.getByTestId("utility-plan-comparison-card-no-benchmark"),
+    ).toHaveTextContent("No market rate recorded yet");
+    expect(
+      screen.queryByTestId("utility-plan-comparison-card-clear"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("states the all-clear once a benchmark exists and nothing is above it", () => {
+    mockPlanTotal = 3;
+    mockBenchmarks = [makeBenchmark()];
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [],
+      not_compared: [],
+      total_above_market: 0,
+      has_stale_benchmark: false,
+    };
+
+    renderCard();
+
+    expect(
+      screen.getByTestId("utility-plan-comparison-card-clear"),
+    ).toHaveTextContent("No plan is priced more than 10% above the market rate");
+  });
+
+  it("shows a skeleton matching the loaded card while loading", () => {
+    mockComparisonLoading = true;
+
+    renderCard();
+
+    const skeleton = screen.getByTestId("utility-plan-comparison-card-loading");
+    expect(skeleton).toHaveAttribute("aria-busy", "true");
+    // Two placeholder rows, each ending in a pill slot — the loaded shape.
+    expect(skeleton.querySelectorAll(".rounded-full")).toHaveLength(2);
+  });
+
+  it("offers a retry when the comparison query fails", async () => {
+    mockComparisonError = true;
+    mockPlanTotal = 3;
+    const user = userEvent.setup();
+
+    renderCard();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not read a failed benchmarks query as 'none recorded'", () => {
+    // The two are indistinguishable in the payload but opposite in meaning:
+    // one means nothing to compare against, the other means we don't know.
+    mockPlanTotal = 3;
+    mockBenchmarksError = true;
+    mockBenchmarks = [];
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [],
+      not_compared: [],
+      total_above_market: 0,
+      has_stale_benchmark: false,
+    };
+
+    renderCard();
+
+    expect(
+      screen.queryByTestId("utility-plan-comparison-card-no-benchmark"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("does not read a failed plans query as 'no plans tracked'", () => {
+    mockPlansError = true;
+    mockPlanTotal = 0;
+    mockBenchmarks = [makeBenchmark()];
+
+    renderCard();
+
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+});
+
+describe("UtilityPlanComparisonCard — above-market rows", () => {
+  beforeEach(() => {
+    mockPlanTotal = 3;
+    mockBenchmarks = [makeBenchmark()];
+  });
+
+  it("names the property, both figures, and the gap", () => {
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [makeRow()],
+      not_compared: [],
+      total_above_market: 1,
+      has_stale_benchmark: false,
+    };
+
+    renderCard();
+
+    const row = screen.getByTestId("utility-plan-comparison-plan-a");
+    expect(row).toHaveTextContent("6732 Peerless St");
+    expect(row).toHaveTextContent("paying 15.06¢/kWh vs market 11.1¢/kWh");
+    expect(screen.getByTestId("utility-plan-comparison-gap-plan-a")).toHaveTextContent(
+      "35.7% above market",
+    );
+  });
+
+  it("counts the flagged plans in the heading", () => {
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [
+        makeRow(),
+        makeRow({ plan: makePlan({ id: "plan-b", property_name: "6734 Peerless St" }) }),
+      ],
+      not_compared: [],
+      total_above_market: 2,
+      has_stale_benchmark: false,
+    };
+
+    renderCard();
+
+    expect(screen.getByTestId("utility-plan-comparison-card")).toHaveTextContent(
+      "Paying above market (2)",
+    );
+  });
+
+  it("formats an internet row as a monthly amount, not a rate", () => {
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [
+        makeRow({
+          plan: makePlan({ id: "plan-net", service_type: "internet", provider_name: "AT&T" }),
+          plan_figure: "9000",
+          benchmark_figure: "6000",
+          gap_pct: "50.0",
+        }),
+      ],
+      not_compared: [],
+      total_above_market: 1,
+      has_stale_benchmark: false,
+    };
+
+    renderCard();
+
+    expect(screen.getByTestId("utility-plan-comparison-plan-net")).toHaveTextContent(
+      "paying $90.00/mo vs market $60.00/mo",
+    );
+  });
+
+  it("caveats the whole set when a benchmark behind it is stale", () => {
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [makeRow({ benchmark_is_stale: true })],
+      not_compared: [],
+      total_above_market: 1,
+      has_stale_benchmark: true,
+    };
+
+    renderCard();
+
+    expect(
+      screen.getByTestId("utility-plan-comparison-stale-notice"),
+    ).toHaveTextContent("recorded a while ago");
+  });
+
+  it("omits the stale caveat when every benchmark is fresh", () => {
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [makeRow()],
+      not_compared: [],
+      total_above_market: 1,
+      has_stale_benchmark: false,
+    };
+
+    renderCard();
+
+    expect(
+      screen.queryByTestId("utility-plan-comparison-stale-notice"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("marks which individual row rests on an old observation", () => {
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [
+        makeRow({ benchmark_is_stale: true }),
+        makeRow({ plan: makePlan({ id: "plan-fresh" }) }),
+      ],
+      not_compared: [],
+      total_above_market: 2,
+      has_stale_benchmark: true,
+    };
+
+    renderCard();
+
+    expect(
+      screen.getByTestId("utility-plan-comparison-stale-plan-a"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("utility-plan-comparison-stale-plan-fresh"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("UtilityPlanComparisonCard — what was not checked", () => {
+  beforeEach(() => {
+    mockPlanTotal = 3;
+    mockBenchmarks = [makeBenchmark()];
+  });
+
+  it("lists unmeasured plans with the reason, alongside flagged ones", () => {
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [makeRow()],
+      not_compared: [
+        makeRow({
+          plan: makePlan({ id: "plan-gas", service_type: "natural_gas" }),
+          status: "not_comparable",
+          plan_figure: null,
+          benchmark_figure: null,
+          gap_pct: null,
+        }),
+      ],
+      total_above_market: 1,
+      has_stale_benchmark: false,
+    };
+
+    renderCard();
+
+    const row = screen.getByTestId("utility-plan-not-compared-plan-gas");
+    expect(row).toHaveTextContent("Not comparable");
+    expect(
+      screen.getByTestId("utility-plan-comparison-not-compared"),
+    ).toHaveTextContent("Not checked (1)");
+  });
+
+  it("qualifies the all-clear with what it did not measure", () => {
+    // "Nothing was flagged" and "nothing was checked" look identical from the
+    // outside, and only one of them is good news.
+    mockComparison = {
+      material_gap_pct: 10,
+      above_market: [],
+      not_compared: [
+        makeRow({
+          plan: makePlan({ id: "plan-gas", service_type: "natural_gas" }),
+          status: "no_benchmark",
+          plan_figure: null,
+          benchmark_figure: null,
+          gap_pct: null,
+        }),
+      ],
+      total_above_market: 0,
+      has_stale_benchmark: true,
+    };
+
+    renderCard();
+
+    expect(screen.getByTestId("utility-plan-comparison-card-clear")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("utility-plan-not-compared-plan-gas"),
+    ).toHaveTextContent("No market rate recorded");
+    // An all-clear resting on a stale observation must say so, exactly as the
+    // above-market list does.
+    expect(
+      screen.getByTestId("utility-plan-comparison-stale-notice"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/utility-plan-format.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/utility-plan-format.test.ts
@@ -7,8 +7,10 @@
  */
 import { describe, it, expect } from "vitest";
 import {
+  formatBenchmarkGap,
   formatCents,
   formatCentsPerKwh,
+  formatComparisonFigure,
   formatPlanDate,
   formatRenewalCountdown,
 } from "@/shared/lib/utility-plan-format";
@@ -81,5 +83,39 @@ describe("formatPlanDate", () => {
   it("falls back to a dash for missing or invalid input", () => {
     expect(formatPlanDate(null)).toBe("—");
     expect(formatPlanDate("garbage")).toBe("—");
+  });
+});
+
+describe("formatBenchmarkGap", () => {
+  it("spells out the direction so a negative does not read as bad news", () => {
+    expect(formatBenchmarkGap("35.7")).toBe("35.7% above market");
+    expect(formatBenchmarkGap("-12.0")).toBe("12% below market");
+  });
+
+  it("names an exact tie rather than showing 0%", () => {
+    expect(formatBenchmarkGap("0")).toBe("level with market");
+  });
+
+  it("falls back to a dash for missing or invalid input", () => {
+    expect(formatBenchmarkGap(null)).toBe("—");
+    expect(formatBenchmarkGap("garbage")).toBe("—");
+  });
+});
+
+describe("formatComparisonFigure", () => {
+  it("quotes metered service per kWh", () => {
+    expect(formatComparisonFigure("15.0600", "electricity")).toBe("15.06¢/kWh");
+    expect(formatComparisonFigure("0.9500", "natural_gas")).toBe("0.95¢/kWh");
+  });
+
+  it("quotes internet as a monthly amount, parsing the Decimal string", () => {
+    // Sending 9000 as "9000" must not become $9,000.00 or 9000¢/kWh.
+    expect(formatComparisonFigure("9000", "internet")).toBe("$90.00/mo");
+  });
+
+  it("falls back to a dash for missing or invalid input", () => {
+    expect(formatComparisonFigure(null, "internet")).toBe("—");
+    expect(formatComparisonFigure("garbage", "internet")).toBe("—");
+    expect(formatComparisonFigure(null, "electricity")).toBe("—");
   });
 });

--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/DashboardSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/DashboardSkeleton.tsx
@@ -1,5 +1,6 @@
 import Skeleton from "@/shared/components/ui/Skeleton";
 import Card from "@/shared/components/ui/Card";
+import UtilityPlanComparisonCardSkeleton from "@/app/features/utility/UtilityPlanComparisonCardSkeleton";
 
 export default function DashboardSkeleton() {
   return (
@@ -39,6 +40,10 @@ export default function DashboardSkeleton() {
           ))}
         </div>
       </Card>
+
+      {/* Rate comparison card. Rendered from the card's own skeleton rather
+          than re-described here, so the two cannot drift apart. */}
+      <UtilityPlanComparisonCardSkeleton />
 
       {/* Monthly Average card — matches MonthlyAverageCard */}
       <Card>

--- a/apps/mybookkeeper/frontend/src/app/features/utility/MarketRateBenchmarkDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/MarketRateBenchmarkDialog.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { UTILITY_PLAN_INPUT_CLASS } from "./utility-plan-input-class";
+import MarketRateBenchmarkForm from "./MarketRateBenchmarkForm";
+import UtilityPlanDialogShell from "./UtilityPlanDialogShell";
+import { useGetMarketRateBenchmarksQuery } from "@/shared/store/marketRateBenchmarksApi";
+import {
+  UTILITY_SERVICE_TYPES,
+  UTILITY_SERVICE_TYPE_LABELS,
+} from "@/shared/types/utility/utility-service-type";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+export interface MarketRateBenchmarkDialogProps {
+  onClose: () => void;
+}
+
+/**
+ * Records what the market currently charges, one service type at a time.
+ *
+ * Operator-entered rather than fetched: the authoritative source differs per
+ * market and per service — Power to Choose in deregulated Texas, a tariff sheet
+ * elsewhere, a competitor quote for internet — and a confidently wrong
+ * automatic rate would be worse than none, because the badge it drives would
+ * look just as certain.
+ */
+export default function MarketRateBenchmarkDialog({
+  onClose,
+}: MarketRateBenchmarkDialogProps) {
+  const [serviceType, setServiceType] = useState<UtilityServiceType>("electricity");
+  const { data: benchmarks } = useGetMarketRateBenchmarksQuery();
+  const existing = benchmarks?.find((b) => b.service_type === serviceType);
+
+  return (
+    <UtilityPlanDialogShell
+      title="Record the market rate"
+      testId="market-rate-benchmark-dialog"
+      onClose={onClose}
+    >
+      <div className="p-5 space-y-4">
+        <p className="text-sm text-muted-foreground">
+          What a comparable plan costs today. Your plans get measured against
+          this, so note where the figure came from — a rate with no source is
+          impossible to check later.
+        </p>
+
+        <div>
+          <label
+            htmlFor="benchmark-service-type"
+            className="block text-sm font-medium mb-1"
+          >
+            Service
+          </label>
+          <select
+            id="benchmark-service-type"
+            value={serviceType}
+            onChange={(e) => setServiceType(e.target.value as UtilityServiceType)}
+            className={UTILITY_PLAN_INPUT_CLASS}
+            data-testid="benchmark-service-type"
+          >
+            {UTILITY_SERVICE_TYPES.map((type) => (
+              <option key={type} value={type}>
+                {UTILITY_SERVICE_TYPE_LABELS[type]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <MarketRateBenchmarkForm
+          key={serviceType}
+          serviceType={serviceType}
+          existing={existing}
+          onSaved={onClose}
+          onCancel={onClose}
+        />
+      </div>
+    </UtilityPlanDialogShell>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/MarketRateBenchmarkForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/MarketRateBenchmarkForm.tsx
@@ -1,0 +1,134 @@
+import { UTILITY_PLAN_INPUT_CLASS } from "./utility-plan-input-class";
+import UtilityPlanFormActions from "./UtilityPlanFormActions";
+import { useMarketRateBenchmarkForm } from "./useMarketRateBenchmarkForm";
+import type { MarketRateBenchmark } from "@/shared/types/utility/market-rate-benchmark";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+export interface MarketRateBenchmarkFormProps {
+  serviceType: UtilityServiceType;
+  existing: MarketRateBenchmark | undefined;
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * The fields of the market-rate dialog, for one service type.
+ *
+ * Split from the dialog so the parent can remount it with ``key={serviceType}``
+ * — switching service must reload the fields from *that* type's saved
+ * benchmark, and state seeded in a ``useState`` initializer would otherwise
+ * carry the previous type's figure across.
+ */
+export default function MarketRateBenchmarkForm({
+  serviceType,
+  existing,
+  onSaved,
+  onCancel,
+}: MarketRateBenchmarkFormProps) {
+  const form = useMarketRateBenchmarkForm({ serviceType, existing, onSaved });
+
+  const figureLabel = form.isFlat
+    ? "Going rate ($/month)"
+    : "Going rate (¢/kWh, all-in at 1,000 kWh)";
+  const figureHint = form.isFlat
+    ? "Include any equipment fee — that is how your own plans are measured."
+    : "The advertised all-in average, including delivery charges.";
+
+  return (
+    <form onSubmit={(e) => void form.handleSubmit(e)} className="space-y-4">
+      <div>
+        <label htmlFor="benchmark-figure" className="block text-sm font-medium mb-1">
+          {figureLabel}
+        </label>
+        <input
+          id="benchmark-figure"
+          type="number"
+          inputMode="decimal"
+          step={form.isFlat ? "0.01" : "0.0001"}
+          min="0"
+          value={form.figure}
+          onChange={(e) => form.setFigure(e.target.value)}
+          className={UTILITY_PLAN_INPUT_CLASS}
+          data-testid="benchmark-figure"
+          required
+        />
+        <p className="text-xs text-muted-foreground mt-1">{figureHint}</p>
+      </div>
+
+      <div>
+        <label htmlFor="benchmark-source" className="block text-sm font-medium mb-1">
+          Where you saw it
+        </label>
+        <input
+          id="benchmark-source"
+          type="text"
+          maxLength={255}
+          value={form.source}
+          onChange={(e) => form.setSource(e.target.value)}
+          placeholder="Power to Choose, 77021, 12-month fixed, 4★+"
+          className={UTILITY_PLAN_INPUT_CLASS}
+          data-testid="benchmark-source"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Include the filters you used — they are what makes the number checkable
+          later.
+        </p>
+      </div>
+
+      <div>
+        <label htmlFor="benchmark-observed-on" className="block text-sm font-medium mb-1">
+          Date observed
+        </label>
+        <input
+          id="benchmark-observed-on"
+          type="date"
+          value={form.observedOn}
+          max={form.maxObservedOn}
+          onChange={(e) => form.setObservedOn(e.target.value)}
+          className={UTILITY_PLAN_INPUT_CLASS}
+          data-testid="benchmark-observed-on"
+          required
+        />
+      </div>
+
+      <div>
+        <label htmlFor="benchmark-notes" className="block text-sm font-medium mb-1">
+          Notes
+        </label>
+        <textarea
+          id="benchmark-notes"
+          rows={2}
+          value={form.notes}
+          onChange={(e) => form.setNotes(e.target.value)}
+          className={UTILITY_PLAN_INPUT_CLASS}
+          data-testid="benchmark-notes"
+        />
+      </div>
+
+      {/* Removal sits apart from save/cancel: without it a rate recorded from
+          a source that turned out not to apply could only ever be overwritten,
+          never retracted, and every plan would keep being measured against it. */}
+      <div className="flex items-center justify-between gap-3">
+        {form.canRemove ? (
+          <button
+            type="button"
+            onClick={() => void form.handleRemove()}
+            disabled={!form.canRemove}
+            className="text-sm font-medium text-destructive hover:underline disabled:opacity-50"
+            data-testid="benchmark-remove-button"
+          >
+            {form.isRemoving ? "Removing..." : "Remove rate"}
+          </button>
+        ) : (
+          <span />
+        )}
+        <UtilityPlanFormActions
+          isSaving={form.isSaving}
+          saveLabel={existing ? "Update rate" : "Save rate"}
+          disabled={!form.canSubmit}
+          onCancel={onCancel}
+        />
+      </div>
+    </form>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/MarketRateBenchmarkSummary.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/MarketRateBenchmarkSummary.tsx
@@ -1,0 +1,103 @@
+import {
+  formatCents,
+  formatCentsPerKwh,
+  formatPlanDate,
+} from "@/shared/lib/utility-plan-format";
+import { useGetMarketRateBenchmarksQuery } from "@/shared/store/marketRateBenchmarksApi";
+import { UTILITY_SERVICE_TYPE_LABELS } from "@/shared/types/utility/utility-service-type";
+import type { MarketRateBenchmark } from "@/shared/types/utility/market-rate-benchmark";
+
+export interface MarketRateBenchmarkSummaryProps {
+  onEdit: () => void;
+}
+
+/**
+ * Read from the column the service type is priced in, not from whichever one
+ * happens to be populated — the comparison picks its figure the same way, and
+ * two sides disagreeing about the unit is how a monthly amount ends up being
+ * displayed as a per-kWh rate.
+ */
+function describeFigure(benchmark: MarketRateBenchmark): string {
+  if (benchmark.service_type === "internet") {
+    return benchmark.monthly_cents === null
+      ? "—"
+      : `${formatCents(benchmark.monthly_cents)}/mo`;
+  }
+  return formatCentsPerKwh(benchmark.rate_cents_per_kwh);
+}
+
+/**
+ * The market rates the plans on this page are measured against.
+ *
+ * Shown here rather than only in the dialog so the number driving the
+ * above-market badge is visible next to the plans it judges — a benchmark the
+ * operator cannot see is one they cannot tell has gone stale.
+ */
+export default function MarketRateBenchmarkSummary({
+  onEdit,
+}: MarketRateBenchmarkSummaryProps) {
+  const { data, isLoading } = useGetMarketRateBenchmarksQuery();
+
+  if (isLoading) {
+    return (
+      <div
+        className="h-9 bg-muted rounded animate-pulse"
+        aria-busy="true"
+        data-testid="market-rate-benchmark-summary-loading"
+      />
+    );
+  }
+
+  const benchmarks = data ?? [];
+
+  if (benchmarks.length === 0) {
+    return (
+      <p
+        className="text-sm text-muted-foreground"
+        data-testid="market-rate-benchmark-summary-empty"
+      >
+        No market rate recorded, so no plan is being checked for overpaying.{" "}
+        <button
+          type="button"
+          onClick={onEdit}
+          className="font-medium text-primary hover:underline"
+        >
+          Record one
+        </button>
+        .
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className="text-sm text-muted-foreground space-y-1"
+      data-testid="market-rate-benchmark-summary"
+    >
+      <p className="font-medium text-foreground">Comparing against</p>
+      <ul className="space-y-0.5">
+        {benchmarks.map((benchmark) => (
+          <li key={benchmark.id} data-testid={`market-rate-${benchmark.service_type}`}>
+            {UTILITY_SERVICE_TYPE_LABELS[benchmark.service_type]}:{" "}
+            {describeFigure(benchmark)}
+            {benchmark.source ? ` · ${benchmark.source}` : ""} · seen{" "}
+            {formatPlanDate(benchmark.observed_on)}
+            {benchmark.is_stale ? (
+              <span className="ml-1 text-amber-700 dark:text-amber-400">
+                (worth rechecking)
+              </span>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        onClick={onEdit}
+        className="font-medium text-primary hover:underline"
+        data-testid="market-rate-benchmark-summary-edit"
+      >
+        Update market rates
+      </button>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanComparisonCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanComparisonCard.tsx
@@ -1,0 +1,154 @@
+import { Link } from "react-router-dom";
+import AlertBox from "@/shared/components/ui/AlertBox";
+import Card from "@/shared/components/ui/Card";
+import {
+  useGetMarketRateBenchmarksQuery,
+  useGetUtilityPlanRateComparisonQuery,
+} from "@/shared/store/marketRateBenchmarksApi";
+import UtilityPlanComparisonRow from "./UtilityPlanComparisonRow";
+import UtilityPlanComparisonCardSkeleton from "./UtilityPlanComparisonCardSkeleton";
+import UtilityPlanNotComparedRow from "./UtilityPlanNotComparedRow";
+import { useHasAnyUtilityPlans } from "./useHasAnyUtilityPlans";
+import { useUtilityPlanComparisonCardMode } from "./useUtilityPlanComparisonCardMode";
+
+/**
+ * Dashboard card for plans priced materially above the recorded market rate.
+ *
+ * The sibling renewal card answers "is a term about to lapse?". This one
+ * answers the question that card cannot: a plan can be comfortably inside its
+ * term and still be the most expensive line in the portfolio, and nothing in
+ * the app would have said so.
+ *
+ * Every branch that reports good news also reports what that news rests on —
+ * the staleness caveat and the not-checked list render in the all-clear case
+ * too, because "no plan is above market" is only worth reading alongside how
+ * many plans were actually measured and how old the yardstick is.
+ */
+export default function UtilityPlanComparisonCard() {
+  const { data, isLoading, isError, refetch, isFetching } =
+    useGetUtilityPlanRateComparisonQuery();
+  const {
+    data: benchmarks,
+    isLoading: isBenchmarksLoading,
+    isError: isBenchmarksError,
+  } = useGetMarketRateBenchmarksQuery();
+  const {
+    hasAnyPlans,
+    isLoading: isPlansLoading,
+    isError: isPlansError,
+  } = useHasAnyUtilityPlans();
+
+  const mode = useUtilityPlanComparisonCardMode({
+    isLoading: isLoading || isPlansLoading || isBenchmarksLoading,
+    // A failed benchmarks or plans query must not read as "none recorded" or
+    // "none tracked" — both would render as a confident all-clear.
+    isError: isError || isBenchmarksError || isPlansError,
+    totalAboveMarket: data?.total_above_market,
+    hasAnyPlans,
+    hasAnyBenchmark: (benchmarks?.length ?? 0) > 0,
+  });
+
+  if (mode === "loading") return <UtilityPlanComparisonCardSkeleton />;
+  if (mode === "hidden") return null;
+
+  if (mode === "error") {
+    return (
+      <AlertBox variant="error" className="flex items-center justify-between gap-3">
+        <span>Couldn't compare your utility rates to the market.</span>
+        <button
+          type="button"
+          onClick={() => void refetch()}
+          className="text-sm font-medium hover:underline"
+        >
+          {isFetching ? "Retrying..." : "Retry"}
+        </button>
+      </AlertBox>
+    );
+  }
+
+  if (mode === "no-benchmark") {
+    return (
+      <Card title="Rate check" className="text-sm text-muted-foreground">
+        <p data-testid="utility-plan-comparison-card-no-benchmark">
+          No market rate recorded yet, so nothing is being checked against your
+          plans.{" "}
+          <Link to="/utility-plans" className="font-medium text-primary hover:underline">
+            Record one
+          </Link>{" "}
+          to find out whether you are overpaying.
+        </p>
+      </Card>
+    );
+  }
+
+  // Both remaining modes are reachable only once the comparison has resolved,
+  // so the threshold below is read from the payload that owns it rather than
+  // re-declared here with a fallback the UI would have no business choosing.
+  if (!data) return null;
+
+  const isClear = mode === "clear";
+
+  return (
+    <Card className="p-0 overflow-hidden">
+      <div
+        className="flex items-center justify-between gap-3 px-6 py-4 border-b"
+        data-testid="utility-plan-comparison-card"
+      >
+        <h2 className="text-base font-medium">
+          {isClear ? "Rate check" : `Paying above market (${data.total_above_market})`}
+        </h2>
+        <Link
+          to="/utility-plans"
+          className="text-sm font-medium text-primary hover:underline shrink-0"
+        >
+          View all
+        </Link>
+      </div>
+
+      <div className="px-6 py-2">
+        {isClear ? (
+          <p
+            className="text-sm text-muted-foreground py-2"
+            data-testid="utility-plan-comparison-card-clear"
+          >
+            No plan is priced more than {data.material_gap_pct}% above the market
+            rate you recorded.
+          </p>
+        ) : (
+          <ul className="divide-y" data-testid="utility-plan-comparison-above-list">
+            {data.above_market.map((row) => (
+              <UtilityPlanComparisonRow key={row.plan.id} row={row} />
+            ))}
+          </ul>
+        )}
+
+        {data.has_stale_benchmark ? (
+          <p
+            className="text-xs text-muted-foreground py-2"
+            data-testid="utility-plan-comparison-stale-notice"
+          >
+            {isClear
+              ? "This rests on a market rate recorded a while ago — worth checking again."
+              : "Some of these use a market rate recorded a while ago — worth checking again before acting on it."}
+          </p>
+        ) : null}
+
+        {data.not_compared.length > 0 ? (
+          <div
+            className="border-t pt-2 mt-1"
+            data-testid="utility-plan-comparison-not-compared"
+          >
+            <p className="text-xs font-medium text-muted-foreground py-1">
+              Not checked ({data.not_compared.length})
+            </p>
+            <ul className="divide-y">
+              {data.not_compared.map((row) => (
+                <UtilityPlanNotComparedRow key={row.plan.id} row={row} />
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanComparisonCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanComparisonCard.tsx
@@ -10,6 +10,7 @@ import UtilityPlanComparisonCardSkeleton from "./UtilityPlanComparisonCardSkelet
 import UtilityPlanNotComparedRow from "./UtilityPlanNotComparedRow";
 import { useHasAnyUtilityPlans } from "./useHasAnyUtilityPlans";
 import { useUtilityPlanComparisonCardMode } from "./useUtilityPlanComparisonCardMode";
+import { UTILITY_PLAN_COMPARISON_CARD_MODES } from "@/shared/types/utility/utility-plan-comparison-card-mode";
 
 /**
  * Dashboard card for plans priced materially above the recorded market rate.
@@ -48,10 +49,12 @@ export default function UtilityPlanComparisonCard() {
     hasAnyBenchmark: (benchmarks?.length ?? 0) > 0,
   });
 
-  if (mode === "loading") return <UtilityPlanComparisonCardSkeleton />;
-  if (mode === "hidden") return null;
+  if (mode === UTILITY_PLAN_COMPARISON_CARD_MODES.LOADING) {
+    return <UtilityPlanComparisonCardSkeleton />;
+  }
+  if (mode === UTILITY_PLAN_COMPARISON_CARD_MODES.HIDDEN) return null;
 
-  if (mode === "error") {
+  if (mode === UTILITY_PLAN_COMPARISON_CARD_MODES.ERROR) {
     return (
       <AlertBox variant="error" className="flex items-center justify-between gap-3">
         <span>Couldn't compare your utility rates to the market.</span>
@@ -66,7 +69,7 @@ export default function UtilityPlanComparisonCard() {
     );
   }
 
-  if (mode === "no-benchmark") {
+  if (mode === UTILITY_PLAN_COMPARISON_CARD_MODES.NO_BENCHMARK) {
     return (
       <Card title="Rate check" className="text-sm text-muted-foreground">
         <p data-testid="utility-plan-comparison-card-no-benchmark">
@@ -86,7 +89,7 @@ export default function UtilityPlanComparisonCard() {
   // re-declared here with a fallback the UI would have no business choosing.
   if (!data) return null;
 
-  const isClear = mode === "clear";
+  const isClear = mode === UTILITY_PLAN_COMPARISON_CARD_MODES.CLEAR;
 
   return (
     <Card className="p-0 overflow-hidden">

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanComparisonCardSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanComparisonCardSkeleton.tsx
@@ -1,0 +1,36 @@
+/**
+ * Loading placeholder for the dashboard rate-comparison card.
+ *
+ * Mirrors the loaded card's chrome exactly — ``p-0`` shell, a bordered header
+ * bar carrying the heading and the "View all" link, then two rows each with a
+ * two-line left block and a gap pill on the right. The dashboard's own skeleton
+ * renders this same component rather than re-describing it, so the two cannot
+ * drift apart and then both drift from the card they stand in for.
+ */
+export default function UtilityPlanComparisonCardSkeleton() {
+  return (
+    <div
+      className="bg-card border rounded-lg p-0 overflow-hidden animate-pulse"
+      aria-busy="true"
+      data-testid="utility-plan-comparison-card-loading"
+    >
+      <div className="flex items-center justify-between gap-3 px-6 py-4 border-b">
+        <div className="h-5 bg-muted rounded w-56" />
+        <div className="h-4 bg-muted rounded w-16 shrink-0" />
+      </div>
+      <div className="px-6 py-2">
+        <ul className="divide-y">
+          {[1, 2].map((i) => (
+            <li key={i} className="flex items-start justify-between gap-3 py-2">
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="h-4 bg-muted rounded w-1/2" />
+                <div className="h-3 bg-muted rounded w-2/3" />
+              </div>
+              <div className="h-5 w-28 bg-muted rounded-full shrink-0" />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanComparisonRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanComparisonRow.tsx
@@ -1,0 +1,50 @@
+import {
+  formatBenchmarkGap,
+  formatComparisonFigure,
+} from "@/shared/lib/utility-plan-format";
+import { UTILITY_SERVICE_TYPE_LABELS } from "@/shared/types/utility/utility-service-type";
+import type { UtilityPlanRateComparisonRow } from "@/shared/types/utility/utility-plan-rate-comparison-row";
+
+export interface UtilityPlanComparisonRowProps {
+  row: UtilityPlanRateComparisonRow;
+}
+
+export default function UtilityPlanComparisonRow({ row }: UtilityPlanComparisonRowProps) {
+  const { plan } = row;
+  return (
+    <li
+      className="flex items-start justify-between gap-3 py-2"
+      data-testid={`utility-plan-comparison-${plan.id}`}
+    >
+      <div className="min-w-0">
+        <p className="text-sm font-medium truncate">
+          {plan.property_name ?? "Unknown property"}
+          <span className="text-muted-foreground font-normal">
+            {" · "}
+            {UTILITY_SERVICE_TYPE_LABELS[plan.service_type]}
+          </span>
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5 truncate">
+          {plan.provider_name} · paying{" "}
+          {formatComparisonFigure(row.plan_figure, plan.service_type)} vs market{" "}
+          {formatComparisonFigure(row.benchmark_figure, plan.service_type)}
+          {/* Per-row rather than only card-level: with several services
+              benchmarked, the operator needs to know which of them is the
+              one resting on an old observation. */}
+          {row.benchmark_is_stale ? (
+            <span data-testid={`utility-plan-comparison-stale-${plan.id}`}>
+              {" "}
+              (recorded a while ago)
+            </span>
+          ) : null}
+        </p>
+      </div>
+      <span
+        className="shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200"
+        data-testid={`utility-plan-comparison-gap-${plan.id}`}
+      >
+        {formatBenchmarkGap(row.gap_pct)}
+      </span>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormActions.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanFormActions.tsx
@@ -3,6 +3,8 @@ import { Button, LoadingButton } from "@platform/ui";
 export interface UtilityPlanFormActionsProps {
   isSaving: boolean;
   saveLabel: string;
+  /** Blocks submit while the form is incomplete, alongside the saving state. */
+  disabled?: boolean;
   onCancel: () => void;
 }
 
@@ -10,6 +12,7 @@ export interface UtilityPlanFormActionsProps {
 export default function UtilityPlanFormActions({
   isSaving,
   saveLabel,
+  disabled = false,
   onCancel,
 }: UtilityPlanFormActionsProps) {
   return (
@@ -23,6 +26,7 @@ export default function UtilityPlanFormActions({
         size="md"
         isLoading={isSaving}
         loadingText="Saving..."
+        disabled={disabled || isSaving}
         data-testid="utility-plan-save-button"
       >
         {saveLabel}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanNotComparedRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanNotComparedRow.tsx
@@ -1,0 +1,41 @@
+import { UTILITY_PLAN_BENCHMARK_STATUS_LABELS } from "@/shared/types/utility/utility-plan-benchmark-status";
+import { UTILITY_SERVICE_TYPE_LABELS } from "@/shared/types/utility/utility-service-type";
+import type { UtilityPlanRateComparisonRow } from "@/shared/types/utility/utility-plan-rate-comparison-row";
+
+export interface UtilityPlanNotComparedRowProps {
+  row: UtilityPlanRateComparisonRow;
+}
+
+/**
+ * One plan the comparison could not measure, and why.
+ *
+ * Shown rather than dropped: "nothing was flagged" and "nothing was checked"
+ * look identical from the outside, and only one of them is good news.
+ */
+export default function UtilityPlanNotComparedRow({
+  row,
+}: UtilityPlanNotComparedRowProps) {
+  const { plan } = row;
+  return (
+    <li
+      className="flex items-start justify-between gap-3 py-2"
+      data-testid={`utility-plan-not-compared-${plan.id}`}
+    >
+      <div className="min-w-0">
+        <p className="text-sm truncate">
+          {plan.property_name ?? "Unknown property"}
+          <span className="text-muted-foreground">
+            {" · "}
+            {UTILITY_SERVICE_TYPE_LABELS[plan.service_type]}
+          </span>
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5 truncate">
+          {plan.provider_name}
+        </p>
+      </div>
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {UTILITY_PLAN_BENCHMARK_STATUS_LABELS[row.status]}
+      </span>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRenewalAlertCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanRenewalAlertCard.tsx
@@ -1,12 +1,10 @@
 import { Link } from "react-router-dom";
 import AlertBox from "@/shared/components/ui/AlertBox";
 import Card from "@/shared/components/ui/Card";
-import {
-  useGetUtilityPlanRenewalAlertsQuery,
-  useGetUtilityPlansQuery,
-} from "@/shared/store/utilityPlansApi";
+import { useGetUtilityPlanRenewalAlertsQuery } from "@/shared/store/utilityPlansApi";
 import UtilityPlanAlertRow from "./UtilityPlanAlertRow";
 import UtilityPlanAlertCardSkeleton from "./UtilityPlanAlertCardSkeleton";
+import { useHasAnyUtilityPlans } from "./useHasAnyUtilityPlans";
 import { useUtilityPlanAlertCardMode } from "./useUtilityPlanAlertCardMode";
 
 /**
@@ -20,15 +18,18 @@ import { useUtilityPlanAlertCardMode } from "./useUtilityPlanAlertCardMode";
 export default function UtilityPlanRenewalAlertCard() {
   const { data, isLoading, isError, refetch, isFetching } =
     useGetUtilityPlanRenewalAlertsQuery();
-  // One page is enough to answer "do they track any plans at all?", which is
-  // all this drives — the card hides itself for operators who track none.
-  const { data: plansPage, isLoading: isPlansLoading } = useGetUtilityPlansQuery({ limit: 1 });
+  // The card hides itself for operators who track no plans at all.
+  const {
+    hasAnyPlans,
+    isLoading: isPlansLoading,
+    isError: isPlansError,
+  } = useHasAnyUtilityPlans();
 
   const mode = useUtilityPlanAlertCardMode({
     isLoading: isLoading || isPlansLoading,
-    isError,
+    isError: isError || isPlansError,
     totalNeedingAttention: data?.total_needing_attention,
-    hasAnyPlans: (plansPage?.total ?? 0) > 0,
+    hasAnyPlans,
   });
 
   if (mode === "loading") return <UtilityPlanAlertCardSkeleton />;

--- a/apps/mybookkeeper/frontend/src/app/features/utility/useHasAnyUtilityPlans.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/useHasAnyUtilityPlans.ts
@@ -1,0 +1,25 @@
+import { useGetUtilityPlansQuery } from "@/shared/store/utilityPlansApi";
+
+export interface HasAnyUtilityPlansResult {
+  hasAnyPlans: boolean;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/**
+ * Whether the operator tracks any utility plans at all.
+ *
+ * Both dashboard utility cards hide themselves entirely for an operator who
+ * tracks none — an empty "paying above market" card is worse than no card. They
+ * ask the same question with the same arguments, so it lives here rather than
+ * being copy-pasted into each: one page is all it takes to answer, and RTK
+ * Query dedupes the identical request so the second caller costs nothing.
+ */
+export function useHasAnyUtilityPlans(): HasAnyUtilityPlansResult {
+  const { data, isLoading, isError } = useGetUtilityPlansQuery({ limit: 1 });
+  return {
+    hasAnyPlans: (data?.total ?? 0) > 0,
+    isLoading,
+    isError,
+  };
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/useMarketRateBenchmarkForm.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/useMarketRateBenchmarkForm.ts
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import { getApiErrorDetail } from "@/shared/lib/api-error-detail";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import {
+  useDeleteMarketRateBenchmarkMutation,
+  useUpsertMarketRateBenchmarkMutation,
+} from "@/shared/store/marketRateBenchmarksApi";
+import type { MarketRateBenchmark } from "@/shared/types/utility/market-rate-benchmark";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+interface UseMarketRateBenchmarkFormArgs {
+  serviceType: UtilityServiceType;
+  existing: MarketRateBenchmark | undefined;
+  onSaved: () => void;
+}
+
+/** Today as ``YYYY-MM-DD`` in local time — ``toISOString`` would shift the date. */
+function todayLocalIso(): string {
+  const now = new Date();
+  const month = `${now.getMonth() + 1}`.padStart(2, "0");
+  const day = `${now.getDate()}`.padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+/**
+ * Form state for recording one market rate.
+ *
+ * Which figure is asked for follows the service type rather than being a
+ * choice: internet is quoted per month, everything else per kWh. Letting the
+ * operator pick would only create a way to record a rate in the unit the
+ * comparison cannot use.
+ */
+export function useMarketRateBenchmarkForm({
+  serviceType,
+  existing,
+  onSaved,
+}: UseMarketRateBenchmarkFormArgs) {
+  const isFlat = serviceType === "internet";
+
+  const [figure, setFigure] = useState(() => {
+    if (!existing) return "";
+    if (isFlat) {
+      return existing.monthly_cents === null
+        ? ""
+        : (existing.monthly_cents / 100).toFixed(2);
+    }
+    return existing.rate_cents_per_kwh ?? "";
+  });
+  const [source, setSource] = useState(existing?.source ?? "");
+  const [observedOn, setObservedOn] = useState(existing?.observed_on ?? todayLocalIso());
+  const [notes, setNotes] = useState(existing?.notes ?? "");
+
+  const [upsert, { isLoading: isSaving }] = useUpsertMarketRateBenchmarkMutation();
+  const [remove, { isLoading: isRemoving }] = useDeleteMarketRateBenchmarkMutation();
+
+  const parsedFigure = Number(figure);
+  const isFigureValid = figure.trim() !== "" && Number.isFinite(parsedFigure) && parsedFigure > 0;
+  const isBusy = isSaving || isRemoving;
+  const canSubmit = isFigureValid && observedOn !== "" && !isBusy;
+  const canRemove = existing !== undefined && !isBusy;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    try {
+      await upsert({
+        serviceType,
+        data: {
+          // Exactly one shape — the other stays absent so the backend's
+          // "provide exactly one" rule is satisfied.
+          ...(isFlat
+            ? { monthly_cents: Math.round(parsedFigure * 100) }
+            : { rate_cents_per_kwh: figure.trim() }),
+          source: source.trim() === "" ? null : source.trim(),
+          observed_on: observedOn,
+          notes: notes.trim() === "" ? null : notes.trim(),
+        },
+      }).unwrap();
+      showSuccess("Market rate saved.");
+      onSaved();
+    } catch (err) {
+      // The backend says which rule the payload broke — "electricity is
+      // metered, provide rate_cents_per_kwh", "at most 4 decimal places". A
+      // generic "try again" would send the operator to retype a value that
+      // will be rejected identically.
+      showError(
+        getApiErrorDetail(err, "Couldn't save the market rate. Please try again."),
+      );
+    }
+  }
+
+  async function handleRemove() {
+    if (!canRemove) return;
+    try {
+      await remove(serviceType).unwrap();
+      showSuccess("Market rate removed.");
+      onSaved();
+    } catch (err) {
+      showError(
+        getApiErrorDetail(err, "Couldn't remove the market rate. Please try again."),
+      );
+    }
+  }
+
+  return {
+    isFlat,
+    figure,
+    setFigure,
+    source,
+    setSource,
+    observedOn,
+    setObservedOn,
+    notes,
+    setNotes,
+    isSaving,
+    isRemoving,
+    canSubmit,
+    canRemove,
+    maxObservedOn: todayLocalIso(),
+    handleSubmit,
+    handleRemove,
+  };
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlanComparisonCardMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlanComparisonCardMode.ts
@@ -1,0 +1,37 @@
+import type { UtilityPlanComparisonCardMode } from "@/shared/types/utility/utility-plan-comparison-card-mode";
+
+interface UseUtilityPlanComparisonCardModeArgs {
+  isLoading: boolean;
+  isError: boolean;
+  /** Undefined until the comparison query resolves. */
+  totalAboveMarket: number | undefined;
+  /** Whether the operator tracks any plans at all. */
+  hasAnyPlans: boolean;
+  /** Whether any market rate has been recorded to compare against. */
+  hasAnyBenchmark: boolean;
+}
+
+/**
+ * Resolves what the dashboard rate-comparison card should render.
+ *
+ * The ``no-benchmark`` case is the one that carries the design: without a
+ * recorded market rate the card must not fall through to "nothing to worry
+ * about". Silence there would read as an all-clear when the truth is that
+ * nothing was checked — which is exactly the failure this feature exists to
+ * fix, since a plan can sit comfortably inside its term and still be the most
+ * expensive line in the portfolio.
+ */
+export function useUtilityPlanComparisonCardMode({
+  isLoading,
+  isError,
+  totalAboveMarket,
+  hasAnyPlans,
+  hasAnyBenchmark,
+}: UseUtilityPlanComparisonCardModeArgs): UtilityPlanComparisonCardMode {
+  if (isLoading) return "loading";
+  if (isError) return "error";
+  if (!hasAnyPlans) return "hidden";
+  if (!hasAnyBenchmark) return "no-benchmark";
+  if ((totalAboveMarket ?? 0) === 0) return "clear";
+  return "above-market";
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlanComparisonCardMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/useUtilityPlanComparisonCardMode.ts
@@ -1,4 +1,7 @@
-import type { UtilityPlanComparisonCardMode } from "@/shared/types/utility/utility-plan-comparison-card-mode";
+import {
+  UTILITY_PLAN_COMPARISON_CARD_MODES,
+  type UtilityPlanComparisonCardMode,
+} from "@/shared/types/utility/utility-plan-comparison-card-mode";
 
 interface UseUtilityPlanComparisonCardModeArgs {
   isLoading: boolean;
@@ -14,7 +17,7 @@ interface UseUtilityPlanComparisonCardModeArgs {
 /**
  * Resolves what the dashboard rate-comparison card should render.
  *
- * The ``no-benchmark`` case is the one that carries the design: without a
+ * The ``NO_BENCHMARK`` case is the one that carries the design: without a
  * recorded market rate the card must not fall through to "nothing to worry
  * about". Silence there would read as an all-clear when the truth is that
  * nothing was checked — which is exactly the failure this feature exists to
@@ -28,10 +31,10 @@ export function useUtilityPlanComparisonCardMode({
   hasAnyPlans,
   hasAnyBenchmark,
 }: UseUtilityPlanComparisonCardModeArgs): UtilityPlanComparisonCardMode {
-  if (isLoading) return "loading";
-  if (isError) return "error";
-  if (!hasAnyPlans) return "hidden";
-  if (!hasAnyBenchmark) return "no-benchmark";
-  if ((totalAboveMarket ?? 0) === 0) return "clear";
-  return "above-market";
+  if (isLoading) return UTILITY_PLAN_COMPARISON_CARD_MODES.LOADING;
+  if (isError) return UTILITY_PLAN_COMPARISON_CARD_MODES.ERROR;
+  if (!hasAnyPlans) return UTILITY_PLAN_COMPARISON_CARD_MODES.HIDDEN;
+  if (!hasAnyBenchmark) return UTILITY_PLAN_COMPARISON_CARD_MODES.NO_BENCHMARK;
+  if ((totalAboveMarket ?? 0) === 0) return UTILITY_PLAN_COMPARISON_CARD_MODES.CLEAR;
+  return UTILITY_PLAN_COMPARISON_CARD_MODES.ABOVE_MARKET;
 }

--- a/apps/mybookkeeper/frontend/src/app/pages/Dashboard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Dashboard.tsx
@@ -28,6 +28,7 @@ import SectionHeader from "@/shared/components/ui/SectionHeader";
 import PropertyPnLGrid from "@/app/features/attribution/PropertyPnLGrid";
 import PnLDateRangeSelector from "@/app/features/attribution/PnLDateRangeSelector";
 import UtilityPlanRenewalAlertCard from "@/app/features/utility/UtilityPlanRenewalAlertCard";
+import UtilityPlanComparisonCard from "@/app/features/utility/UtilityPlanComparisonCard";
 
 function getThisMonthRange(): { since: string; until: string } {
   const now = new Date();
@@ -191,6 +192,11 @@ export default function Dashboard() {
           plan costs money whether or not any transactions have been imported
           yet, so it must not be hidden behind the no-data empty state. */}
       <UtilityPlanRenewalAlertCard />
+
+      {/* Directly below the renewal card, for the same reason: a plan can be
+          comfortably inside its term and still be the most expensive line in
+          the portfolio, which the renewal card cannot say. */}
+      <UtilityPlanComparisonCard />
 
       {!isEmpty && (filteredSummary?.by_month?.length ?? 0) > 0 && (
         <MonthlyAverageCard byMonth={filteredSummary?.by_month ?? []} />

--- a/apps/mybookkeeper/frontend/src/app/pages/UtilityPlans.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/UtilityPlans.tsx
@@ -8,6 +8,8 @@ import {
   useGetUtilityPlansQuery,
 } from "@/shared/store/utilityPlansApi";
 import AddUtilityPlanDialog from "@/app/features/utility/AddUtilityPlanDialog";
+import MarketRateBenchmarkDialog from "@/app/features/utility/MarketRateBenchmarkDialog";
+import MarketRateBenchmarkSummary from "@/app/features/utility/MarketRateBenchmarkSummary";
 import EditUtilityPlanDialog from "@/app/features/utility/EditUtilityPlanDialog";
 import UtilityPlansListBody from "@/app/features/utility/UtilityPlansListBody";
 import { useUtilityPlansListMode } from "@/app/features/utility/useUtilityPlansListMode";
@@ -22,6 +24,7 @@ import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-sum
 export default function UtilityPlans() {
   const [showExpiringOnly, setShowExpiringOnly] = useState(false);
   const [showAddDialog, setShowAddDialog] = useState(false);
+  const [showBenchmarkDialog, setShowBenchmarkDialog] = useState(false);
   const [editingPlanId, setEditingPlanId] = useState<string | null>(null);
   const [deletingPlanId, setDeletingPlanId] = useState<string | null>(null);
   const [planPendingDelete, setPlanPendingDelete] = useState<UtilityPlanSummary | null>(null);
@@ -63,17 +66,28 @@ export default function UtilityPlans() {
     <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
       <SectionHeader
         title="Utility Plans"
-        subtitle="Track what each property pays for power and gas, and get warned before a fixed rate lapses."
+        subtitle="Track what each property pays for power and gas, get warned before a fixed rate lapses, and see which plans are priced above the market."
         actions={
-          <Button
-            type="button"
-            variant="primary"
-            size="md"
-            onClick={() => setShowAddDialog(true)}
-            data-testid="add-utility-plan-button"
-          >
-            Add plan
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={() => setShowBenchmarkDialog(true)}
+              data-testid="record-market-rate-button"
+            >
+              Market rate
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              size="md"
+              onClick={() => setShowAddDialog(true)}
+              data-testid="add-utility-plan-button"
+            >
+              Add plan
+            </Button>
+          </div>
         }
       />
 
@@ -89,6 +103,8 @@ export default function UtilityPlans() {
           </button>
         </AlertBox>
       ) : null}
+
+      <MarketRateBenchmarkSummary onEdit={() => setShowBenchmarkDialog(true)} />
 
       <div className="flex items-center gap-3">
         <label className="flex items-center gap-2 text-sm cursor-pointer">
@@ -114,6 +130,10 @@ export default function UtilityPlans() {
 
       {showAddDialog ? (
         <AddUtilityPlanDialog onClose={() => setShowAddDialog(false)} />
+      ) : null}
+
+      {showBenchmarkDialog ? (
+        <MarketRateBenchmarkDialog onClose={() => setShowBenchmarkDialog(false)} />
       ) : null}
 
       {editingPlanId ? (

--- a/apps/mybookkeeper/frontend/src/shared/lib/api-error-detail.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/api-error-detail.ts
@@ -1,0 +1,13 @@
+import type { ApiErrorDetailShape } from "@/shared/types/api/api-error-detail-shape";
+
+/**
+ * The backend's own explanation of a failure, or ``fallback`` when there is none.
+ *
+ * FastAPI validation errors put a list of per-field objects in `detail` rather
+ * than a string; those are for developers, not operators, so only a plain
+ * string is surfaced and anything else falls back.
+ */
+export function getApiErrorDetail(error: unknown, fallback: string): string {
+  const detail = (error as ApiErrorDetailShape | undefined)?.data?.detail;
+  return typeof detail === "string" && detail.trim() !== "" ? detail : fallback;
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-format.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-format.ts
@@ -1,4 +1,5 @@
 import { formatCurrency } from "@/shared/utils/currency";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
 
 /**
  * Display helpers for utility-plan figures.
@@ -55,4 +56,44 @@ export function formatPlanDate(value: string | null): string {
     day: "numeric",
     year: "numeric",
   });
+}
+
+/**
+ * Signed gap → ``"+38% above market"`` / ``"12% below market"``.
+ *
+ * The sign is spelled out in words because a bare ``-12%`` reads as bad news
+ * when it is the opposite — the plan is beating the market.
+ */
+export function formatBenchmarkGap(value: string | null): string {
+  if (value === null || value.trim() === "") return "—";
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return "—";
+  // Round first, then decide the wording. Testing the raw value would render
+  // -0.04 as "0% below market" — a direction claimed on a difference the
+  // display has already rounded away.
+  const rounded = Math.round(parsed * 10) / 10;
+  if (rounded === 0) return "level with market";
+  const magnitude = Math.abs(rounded).toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  });
+  return rounded > 0 ? `${magnitude}% above market` : `${magnitude}% below market`;
+}
+
+/**
+ * A comparison figure in the unit its service type is priced in.
+ *
+ * Metered service is quoted per kWh; internet is a flat monthly amount. Both
+ * arrive as Decimal strings, so the flat one is parsed back to integer cents
+ * before ``formatCents`` sees it.
+ */
+export function formatComparisonFigure(
+  value: string | null,
+  serviceType: UtilityServiceType,
+): string {
+  if (serviceType !== "internet") return formatCentsPerKwh(value);
+  if (value === null || value.trim() === "") return "—";
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return "—";
+  return `${formatCents(Math.round(parsed))}/mo`;
 }

--- a/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
@@ -4,6 +4,6 @@ import { axiosBaseQuery } from "./baseQuery";
 export const baseApi = createApi({
   reducerPath: "api",
   baseQuery: axiosBaseQuery,
-  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "BookingStatement", "Reconciliation", "TaxReturn", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor", "Screening", "Channel", "ChannelListing", "Calendar", "BlackoutAttachments", "LeaseTemplate", "SignedLease", "ReviewQueue", "InsurancePolicy", "AttributionQueue", "WelcomeManual", "WelcomeManualSend", "UtilityPlan"],
+  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "BookingStatement", "Reconciliation", "TaxReturn", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor", "Screening", "Channel", "ChannelListing", "Calendar", "BlackoutAttachments", "LeaseTemplate", "SignedLease", "ReviewQueue", "InsurancePolicy", "AttributionQueue", "WelcomeManual", "WelcomeManualSend", "UtilityPlan", "MarketRateBenchmark"],
   endpoints: () => ({}),
 });

--- a/apps/mybookkeeper/frontend/src/shared/store/marketRateBenchmarksApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/marketRateBenchmarksApi.ts
@@ -1,0 +1,71 @@
+import { baseApi } from "./baseApi";
+import type { MarketRateBenchmark } from "@/shared/types/utility/market-rate-benchmark";
+import type { MarketRateBenchmarkUpsertRequest } from "@/shared/types/utility/market-rate-benchmark-upsert-request";
+import type { UtilityPlanRateComparison } from "@/shared/types/utility/utility-plan-rate-comparison";
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+/**
+ * RTK Query slice for market rate benchmarks and the comparison they drive.
+ *
+ * The comparison is tagged ``UtilityPlan:COMPARISON`` rather than under this
+ * slice's own tag because it is derived from *both* sides — editing a plan's
+ * rate must refresh it just as recording a new benchmark does. Benchmark
+ * mutations invalidate both tags for that reason.
+ */
+const marketRateBenchmarksApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getMarketRateBenchmarks: builder.query<MarketRateBenchmark[], void>({
+      query: () => ({ url: "/market-rate-benchmarks" }),
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.map((b) => ({
+                type: "MarketRateBenchmark" as const,
+                id: b.service_type,
+              })),
+              { type: "MarketRateBenchmark" as const, id: "LIST" },
+            ]
+          : [{ type: "MarketRateBenchmark" as const, id: "LIST" }],
+    }),
+
+    getUtilityPlanRateComparison: builder.query<UtilityPlanRateComparison, void>({
+      query: () => ({ url: "/utility-plans/rate-comparison" }),
+      providesTags: [{ type: "UtilityPlan", id: "COMPARISON" }],
+    }),
+
+    upsertMarketRateBenchmark: builder.mutation<
+      MarketRateBenchmark,
+      { serviceType: UtilityServiceType; data: MarketRateBenchmarkUpsertRequest }
+    >({
+      query: ({ serviceType, data }) => ({
+        url: `/market-rate-benchmarks/${serviceType}`,
+        method: "PUT",
+        data,
+      }),
+      invalidatesTags: (_r, _e, { serviceType }) => [
+        { type: "MarketRateBenchmark", id: serviceType },
+        { type: "MarketRateBenchmark", id: "LIST" },
+        { type: "UtilityPlan", id: "COMPARISON" },
+      ],
+    }),
+
+    deleteMarketRateBenchmark: builder.mutation<void, UtilityServiceType>({
+      query: (serviceType) => ({
+        url: `/market-rate-benchmarks/${serviceType}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (_r, _e, serviceType) => [
+        { type: "MarketRateBenchmark", id: serviceType },
+        { type: "MarketRateBenchmark", id: "LIST" },
+        { type: "UtilityPlan", id: "COMPARISON" },
+      ],
+    }),
+  }),
+});
+
+export const {
+  useGetMarketRateBenchmarksQuery,
+  useGetUtilityPlanRateComparisonQuery,
+  useUpsertMarketRateBenchmarkMutation,
+  useDeleteMarketRateBenchmarkMutation,
+} = marketRateBenchmarksApi;

--- a/apps/mybookkeeper/frontend/src/shared/store/utilityPlansApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/utilityPlansApi.ts
@@ -20,9 +20,11 @@ export interface UtilityPlanListArgs {
  *
  * Tag strategy mirrors insurancePoliciesApi: per-id ``UtilityPlan:{id}`` plus
  * a shared ``UtilityPlan:LIST``. Every mutation also invalidates
- * ``UtilityPlan:ALERTS`` — the dashboard card is derived from the same rows,
- * so editing a term end date must refresh it or the operator keeps seeing an
- * alert they already dealt with.
+ * ``UtilityPlan:ALERTS`` and ``UtilityPlan:COMPARISON`` — both dashboard cards
+ * are derived from the same rows, so editing a term end date or a rate must
+ * refresh them or the operator keeps seeing a warning they already dealt with.
+ * ``COMPARISON`` is served by ``marketRateBenchmarksApi`` but tagged here
+ * because it is invalidated from both sides.
  */
 const utilityPlansApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -80,6 +82,7 @@ const utilityPlansApi = baseApi.injectEndpoints({
       invalidatesTags: [
         { type: "UtilityPlan", id: "LIST" },
         { type: "UtilityPlan", id: "ALERTS" },
+        { type: "UtilityPlan", id: "COMPARISON" },
       ],
     }),
 
@@ -96,6 +99,7 @@ const utilityPlansApi = baseApi.injectEndpoints({
         { type: "UtilityPlan", id: planId },
         { type: "UtilityPlan", id: "LIST" },
         { type: "UtilityPlan", id: "ALERTS" },
+        { type: "UtilityPlan", id: "COMPARISON" },
       ],
     }),
 
@@ -116,6 +120,7 @@ const utilityPlansApi = baseApi.injectEndpoints({
       invalidatesTags: [
         { type: "UtilityPlan", id: "LIST" },
         { type: "UtilityPlan", id: "ALERTS" },
+        { type: "UtilityPlan", id: "COMPARISON" },
       ],
     }),
   }),

--- a/apps/mybookkeeper/frontend/src/shared/types/api/api-error-detail-shape.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/api/api-error-detail-shape.ts
@@ -1,0 +1,13 @@
+/**
+ * Shape of an RTK Query / axios error whose body carries FastAPI's `detail`.
+ *
+ * The backend answers a rejected write with a sentence explaining what was
+ * wrong with it. Discarding that in favour of a generic "please try again"
+ * tells the operator to retry a request that will fail identically every time.
+ */
+export interface ApiErrorDetailShape {
+  data?: {
+    detail?: unknown;
+  };
+  status?: number;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/market-rate-benchmark-upsert-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/market-rate-benchmark-upsert-request.ts
@@ -1,0 +1,14 @@
+/**
+ * Body for ``PUT /market-rate-benchmarks/{service_type}``.
+ *
+ * Mirrors ``schemas/properties/market_rate_benchmark_upsert_request.py``.
+ * Exactly one of the two figures must be sent; the backend rejects both or
+ * neither with a 422.
+ */
+export interface MarketRateBenchmarkUpsertRequest {
+  rate_cents_per_kwh?: string | null;
+  monthly_cents?: number | null;
+  source?: string | null;
+  observed_on: string;
+  notes?: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/market-rate-benchmark.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/market-rate-benchmark.ts
@@ -1,0 +1,26 @@
+import type { UtilityServiceType } from "@/shared/types/utility/utility-service-type";
+
+/**
+ * One recorded market observation.
+ *
+ * Mirrors ``schemas/properties/market_rate_benchmark_response.py``. Exactly one
+ * of ``rate_cents_per_kwh`` (metered service) and ``monthly_cents`` (flat
+ * service) is set — the database enforces that, so the UI can branch on which
+ * is non-null rather than on the service type.
+ *
+ * Decimal fields arrive as strings: JSON numbers are IEEE doubles, and a rate
+ * carrying four decimals should not be rounded in transit.
+ */
+export interface MarketRateBenchmark {
+  id: string;
+  service_type: UtilityServiceType;
+  rate_cents_per_kwh: string | null;
+  monthly_cents: number | null;
+  source: string | null;
+  observed_on: string;
+  notes: string | null;
+  /** Derived server-side from ``observed_on`` — never stored. */
+  is_stale: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-benchmark-status.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-benchmark-status.ts
@@ -1,0 +1,22 @@
+/**
+ * How a plan's price compares to the recorded market benchmark.
+ *
+ * Mirrors ``BENCHMARK_STATUSES`` in
+ * ``backend/app/core/market_benchmark_constants.py``. A value added there MUST
+ * be added here in the same PR.
+ */
+export type UtilityPlanBenchmarkStatus =
+  | "no_benchmark"
+  | "not_comparable"
+  | "at_or_below_market"
+  | "above_market";
+
+export const UTILITY_PLAN_BENCHMARK_STATUS_LABELS: Record<
+  UtilityPlanBenchmarkStatus,
+  string
+> = {
+  no_benchmark: "No market rate recorded",
+  not_comparable: "Not comparable",
+  at_or_below_market: "At or below market",
+  above_market: "Above market",
+};

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-comparison-card-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-comparison-card-mode.ts
@@ -1,15 +1,19 @@
 /**
  * What the dashboard rate-comparison card should render.
  *
- * ``no-benchmark`` is distinct from ``clear``: with nothing to compare against
+ * ``NO_BENCHMARK`` is distinct from ``CLEAR``: with nothing to compare against
  * the card cannot claim the plans are priced well, so it prompts the operator
  * to record a market rate instead of implying an all-clear it has not earned.
- * ``hidden`` covers the operator who tracks no plans at all.
+ * ``HIDDEN`` covers the operator who tracks no plans at all.
  */
+export const UTILITY_PLAN_COMPARISON_CARD_MODES = {
+  LOADING: "loading",
+  ERROR: "error",
+  HIDDEN: "hidden",
+  NO_BENCHMARK: "no-benchmark",
+  CLEAR: "clear",
+  ABOVE_MARKET: "above-market",
+} as const;
+
 export type UtilityPlanComparisonCardMode =
-  | "loading"
-  | "error"
-  | "hidden"
-  | "no-benchmark"
-  | "clear"
-  | "above-market";
+  (typeof UTILITY_PLAN_COMPARISON_CARD_MODES)[keyof typeof UTILITY_PLAN_COMPARISON_CARD_MODES];

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-comparison-card-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-comparison-card-mode.ts
@@ -1,0 +1,15 @@
+/**
+ * What the dashboard rate-comparison card should render.
+ *
+ * ``no-benchmark`` is distinct from ``clear``: with nothing to compare against
+ * the card cannot claim the plans are priced well, so it prompts the operator
+ * to record a market rate instead of implying an all-clear it has not earned.
+ * ``hidden`` covers the operator who tracks no plans at all.
+ */
+export type UtilityPlanComparisonCardMode =
+  | "loading"
+  | "error"
+  | "hidden"
+  | "no-benchmark"
+  | "clear"
+  | "above-market";

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-rate-comparison-row.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-rate-comparison-row.ts
@@ -1,0 +1,19 @@
+import type { UtilityPlanBenchmarkStatus } from "@/shared/types/utility/utility-plan-benchmark-status";
+import type { UtilityPlanSummary } from "@/shared/types/utility/utility-plan-summary";
+
+/**
+ * One plan measured against the market benchmark for its service type.
+ *
+ * Mirrors ``schemas/properties/utility_plan_rate_comparison_row.py``.
+ * ``plan_figure`` and ``benchmark_figure`` share a unit that depends on the
+ * plan's service type: ¢/kWh for metered service, cents per month for flat.
+ */
+export interface UtilityPlanRateComparisonRow {
+  plan: UtilityPlanSummary;
+  status: UtilityPlanBenchmarkStatus;
+  plan_figure: string | null;
+  benchmark_figure: string | null;
+  /** Signed — negative means the plan beats the market. */
+  gap_pct: string | null;
+  benchmark_is_stale: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-rate-comparison.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-plan-rate-comparison.ts
@@ -1,0 +1,16 @@
+import type { UtilityPlanRateComparisonRow } from "@/shared/types/utility/utility-plan-rate-comparison-row";
+
+/**
+ * Dashboard payload for plans priced above the market.
+ *
+ * Mirrors ``schemas/properties/utility_plan_rate_comparison_response.py``.
+ * ``material_gap_pct`` comes from the backend so the UI can say "more than N%
+ * above" without hardcoding a threshold it does not own.
+ */
+export interface UtilityPlanRateComparison {
+  material_gap_pct: number;
+  above_market: UtilityPlanRateComparisonRow[];
+  not_compared: UtilityPlanRateComparisonRow[];
+  total_above_market: number;
+  has_stale_benchmark: boolean;
+}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -658,7 +658,21 @@
         "frontend/src/shared/store/utilityPlansApi.ts",
         "frontend/src/shared/lib/utility-plan-format.ts",
         "frontend/src/shared/lib/utility-plan-form.ts",
-        "frontend/src/shared/lib/utility-plan-draft.ts"
+        "frontend/src/shared/lib/utility-plan-draft.ts",
+        "backend/app/models/properties/market_rate_benchmark.py",
+        "backend/app/repositories/properties/market_rate_benchmark_repo.py",
+        "backend/app/schemas/properties/market_rate_benchmark_response.py",
+        "backend/app/schemas/properties/market_rate_benchmark_upsert_request.py",
+        "backend/app/schemas/properties/utility_plan_rate_comparison_row.py",
+        "backend/app/schemas/properties/utility_plan_rate_comparison_response.py",
+        "backend/app/services/properties/market_rate_benchmark_service.py",
+        "backend/app/services/properties/_market_benchmark_compare.py",
+        "backend/app/api/market_rate_benchmarks.py",
+        "backend/app/core/market_benchmark_constants.py",
+        "backend/alembic/versions/mktbench260811_market_rate_benchmarks.py",
+        "frontend/src/shared/store/marketRateBenchmarksApi.ts",
+        "frontend/src/shared/lib/api-error-detail.ts",
+        "frontend/src/shared/types/api/"
       ],
       "backend_tests": [
         "test_utility_plan_service.py",
@@ -666,7 +680,11 @@
         "test_utility_plans_api.py",
         "test_utility_plan_extraction.py",
         "test_utility_plan_scheduler.py",
-        "test_utility_plan_seed.py"
+        "test_utility_plan_seed.py",
+        "test_market_benchmark_compare.py",
+        "test_market_rate_benchmark_repo.py",
+        "test_market_rate_benchmark_service.py",
+        "test_market_rate_benchmarks_api.py"
       ],
       "frontend_tests": [
         "UtilityPlans.test.tsx",
@@ -676,12 +694,16 @@
         "utility-plan-format.test.ts",
         "utility-plan-form.test.ts",
         "utility-plan-draft.test.ts",
-        "Dashboard.test.tsx"
+        "Dashboard.test.tsx",
+        "UtilityPlanComparisonCard.test.tsx",
+        "MarketRateBenchmarkDialog.test.tsx"
       ],
       "e2e_specs": [
         "utility-plans.spec.ts",
         "utility-plans-layout.spec.ts",
-        "dashboard.spec.ts"
+        "dashboard.spec.ts",
+        "utility-plan-rate-benchmark.spec.ts",
+        "utility-plan-comparison-layout.spec.ts"
       ]
     },
     "welcome_manuals": {


### PR DESCRIPTION
Records a market rate per service type and flags any plan priced materially above it (>10%), so an overpriced plan surfaces on the dashboard instead of waiting to be noticed at renewal.

The trigger needs only two numbers — what you pay and what the market charges. Early-termination fees, bill credits and exact kWh belong to the *decision* of whether to switch, not to the *question* of whether you're overpaying, so none of them gate the flag.

## Backend

- **`market_rate_benchmarks`**, one row per `(organization, service_type)`. Deliberately **org-scoped** rather than user-scoped like its siblings — the unique index is on the organization, so a per-user scope would let one member's read miss another member's row. `recorded_by_user_id` keeps provenance without implying ownership.
- **One shape per service type** — internet per month, everything else per kWh. Enforced in three places: two DB `CHECK` constraints, a service-layer assertion that produces a readable 422 instead of an `IntegrityError` 500, and a form whose unit follows the service type rather than being a choice.
- Both sides of the comparison derive their figure from the service type through **one shared predicate**, so they cannot disagree about units.
- The upsert is race-safe via `SAVEPOINT` + `IntegrityError` recovery rather than dialect-specific `ON CONFLICT`, keeping the repository portable to the SQLite test session.
- `observed_on` allows **one day of slack** — the browser sends its own local date, which can lead the server's, and a user east of the server shouldn't get a 422 for picking today.

## Frontend

- Dashboard card lists above-market plans with the gap and, when nothing is flagged, says explicitly **which plans were not checked and why** — "all clear" is never mistaken for "nothing was measured".
- Benchmark-fetch and plan-fetch failures fold into the card's error mode; a failed request must not read as "no market rate recorded".
- Stale benchmarks (>90 days) are marked on the card and per row.
- A recorded rate can be **removed**, not only overwritten — a rate from a source that turned out not to apply would otherwise keep judging every plan forever.
- Save/remove surface the backend's own reason instead of a generic "try again" the operator can't act on.

## Operational migration

None. Purely additive — new table, new routes, no new env vars. Existing deploys keep working without any VPS change.

## Verification

| Suite | Result |
|---|---|
| Backend — utility domain (10 files) | 254 passed |
| Frontend unit — comparison card, dialog, dashboard, formatters | 47 passed |
| E2E — benchmark, comparison-layout, plans, plans-layout | 11 passed |
| ESLint | 0 errors |
| `tsc --noEmit` | clean |

`dashboard.spec.ts` has 5 failures that reproduce identically on `main` (verified by stashing only the dashboard files) — pre-existing, untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgX4F6Unf2PbXHwHAX2fVb