### PR TITLE
feat(mbk): find better electricity plans from the live Power to Choose feed

### DIFF
--- a/.github/workflows/ci-mybookkeeper.yml
+++ b/.github/workflows/ci-mybookkeeper.yml
@@ -182,7 +182,8 @@ jobs:
             e2e/document-viewer-failure-modes.spec.ts \
             e2e/document-re-extract.spec.ts \
             e2e/caddy-headers-blob-iframe.spec.ts \
-            e2e/welcome-manuals-layout-mock.spec.ts
+            e2e/welcome-manuals-layout-mock.spec.ts \
+            e2e/utility-better-plans.spec.ts
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/apps/mybookkeeper/backend/app/api/utility_plans.py
+++ b/apps/mybookkeeper/backend/app/api/utility_plans.py
@@ -12,9 +12,16 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
 from app.core.context import RequestContext
 from app.core.permissions import current_org_member, require_write_access
-from app.core.rate_limit import utility_plan_extract_limiter
+from app.core.power_to_choose_constants import DEFAULT_MIN_TERM_MONTHS
+from app.core.rate_limit import (
+    utility_offer_search_limiter,
+    utility_plan_extract_limiter,
+)
 from app.core.utility_plan_constants import EXPIRING_SOON_DAYS
 from app.schemas.properties.utility_plan_create_request import UtilityPlanCreateRequest
+from app.schemas.properties.utility_offer_search_response import (
+    UtilityOfferSearchResponse,
+)
 from app.schemas.properties.utility_plan_draft import UtilityPlanDraft
 from app.schemas.properties.utility_plan_extract_request import UtilityPlanExtractRequest
 from app.schemas.properties.utility_plan_list_response import UtilityPlanListResponse
@@ -28,6 +35,7 @@ from app.schemas.properties.utility_plan_response import UtilityPlanResponse
 from app.schemas.properties.utility_plan_update_request import UtilityPlanUpdateRequest
 from app.services.properties import (
     market_rate_benchmark_service,
+    utility_offer_service,
     utility_plan_extraction_service,
     utility_plan_service,
 )
@@ -129,6 +137,24 @@ async def get_rate_comparison(
     return await market_rate_benchmark_service.get_rate_comparison(
         user_id=ctx.user_id,
         organization_id=ctx.organization_id,
+    )
+
+
+@router.get("/offers", response_model=UtilityOfferSearchResponse)
+async def find_better_plans(
+    min_term_months: int = Query(DEFAULT_MIN_TERM_MONTHS, ge=1, le=60),
+    ctx: RequestContext = Depends(current_org_member),
+) -> UtilityOfferSearchResponse:
+    """Live market offers ranked against each property's current electricity plan.
+
+    Reads the Power to Choose feed; persists nothing. Declared before
+    ``/{plan_id}`` so the literal path is not swallowed by the UUID route.
+    """
+    utility_offer_search_limiter.check(f"utility-offer-search:{ctx.user_id}")
+    return await utility_offer_service.find_better_plans(
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
+        min_term_months=min_term_months,
     )
 
 

--- a/apps/mybookkeeper/backend/app/core/power_to_choose_constants.py
+++ b/apps/mybookkeeper/backend/app/core/power_to_choose_constants.py
@@ -1,0 +1,74 @@
+"""Constants for the Power to Choose offer feed.
+
+Power to Choose (powertochoose.org) is the electricity marketplace the Public
+Utility Commission of Texas runs. Every REP selling to residential customers in
+the deregulated market is required to list its offers there, so the feed is the
+closest thing to a complete, neutral view of what a Texas address can actually
+buy. It is public, unauthenticated, and free.
+
+Only *electricity* is shoppable. Houston natural gas is a regulated CenterPoint
+monopoly and water is municipal — there is no competing supplier to switch to,
+which is why ``REGULATED_TX_GAS_PROVIDERS`` exists in
+``utility_plan_constants``. Asking this feed about gas would return nothing.
+"""
+
+# Undocumented but long-stable JSON endpoint behind the public site. Plain HTTP
+# is what the host serves; it carries no credentials and no personal data — the
+# only thing sent is a ZIP code.
+POWER_TO_CHOOSE_PLANS_URL = "http://api.powertochoose.org/api/PowerToChoose/plans"
+
+# The feed returns ~175 offers for a Houston ZIP in well under a second. 15s is
+# generous enough to absorb a slow day without holding a request open.
+OFFER_FETCH_TIMEOUT_SECONDS: float = 15.0
+
+# Offers are re-published in daily batches, so a short in-process cache spares
+# the PUCT host a request per page view without ever showing a stale price.
+OFFER_CACHE_TTL_SECONDS: int = 900
+
+# ``rate_type`` values the feed emits. Only ``Fixed`` has a price that holds for
+# the term; ``Variable`` is the holdover product a lapsed plan already fell
+# into, so offering it as an upgrade would be nonsense.
+FEED_RATE_TYPE_FIXED = "Fixed"
+
+# Shortest term worth switching for. Anything under a year re-exposes the
+# operator to the same renewal cliff before the switch has paid for itself.
+DEFAULT_MIN_TERM_MONTHS = 12
+
+# Reference annual consumption for the savings estimate, in kWh. Texas EFLs
+# quote price at 500 / 1000 / 2000 kWh per month, and 1000 is the disclosure
+# point every plan must publish — so 12,000 kWh/yr is the only basis on which
+# two arbitrary plans can be compared without per-property usage history.
+# Savings computed from it are explicitly a "at this reference usage" figure,
+# never a promise about a specific bill.
+REFERENCE_ANNUAL_KWH = 12_000
+
+# A plan is teaser-priced when its headline 1000 kWh figure is far below what
+# the same plan charges at 500 and 2000 kWh. That shape is the signature of a
+# bill credit that pays out only inside a narrow usage band: land one kWh
+# outside it and the effective rate can double. As of this writing 9 of the 174
+# Houston offers do this, and they occupy the entire top of a naive
+# sort-by-price-at-1000 — which is exactly why this threshold exists.
+TEASER_PRICE_RATIO = 0.85
+
+# Gap below which a switch is not worth the paperwork, in ¢/kWh. Under a cent
+# the annual difference is inside the noise of a usage swing.
+MIN_MEANINGFUL_SAVING_CENTS = 1.0
+
+# Lowest Power to Choose customer rating (1-5) an offer may carry and still be
+# recommended. The cheapest honest Houston offers are 1-star providers, and a
+# rock-bottom rate from a REP with a billing-dispute reputation is a false
+# saving — the switch costs more in hours than it returns in dollars. Gating at
+# 3 costs 0.20¢/kWh against the ungated cheapest, which is a trade worth making
+# by default.
+MIN_PROVIDER_RATING = 3
+
+# The feed writes -1 (and occasionally 0) for "no rating on file" rather than
+# omitting the field. Unrated is not the same as badly rated, but it is equally
+# not a basis for a recommendation, so unrated offers are held back too — and
+# counted, so the UI can say how many were withheld rather than silently
+# shrinking the list.
+UNRATED_SENTINELS: frozenset[int] = frozenset({-1, 0})
+
+# Cap on offers returned per property. The ranked list is long and repetitive
+# past the first handful — every REP fields near-identical 12-month products.
+MAX_OFFERS_PER_PROPERTY = 8

--- a/apps/mybookkeeper/backend/app/core/rate_limit.py
+++ b/apps/mybookkeeper/backend/app/core/rate_limit.py
@@ -49,6 +49,7 @@ __all__ = [
     "password_reset_limiter",
     "export_limiter",
     "utility_plan_extract_limiter",
+    "utility_offer_search_limiter",
     "frontend_error_limiter",
     "require_turnstile",
     "check_login_rate_limit",
@@ -73,6 +74,10 @@ export_limiter = RateLimiter(max_attempts=20, window_seconds=3600)
 # The daily upload cap bounds how many distinct documents exist but not how
 # many times one is re-read, so this bounds the re-reads.
 utility_plan_extract_limiter = RateLimiter(max_attempts=30, window_seconds=3600)
+# Each search fans out to one Power to Choose request per distinct property ZIP.
+# The client's 15-minute cache absorbs ordinary page views, so this only bounds
+# a caller deliberately hammering the PUCT host through us.
+utility_offer_search_limiter = RateLimiter(max_attempts=60, window_seconds=3600)
 frontend_error_limiter = RateLimiter(max_attempts=50, window_seconds=3600)
 
 

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_offer.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_offer.py
@@ -1,0 +1,41 @@
+"""A single electricity offer available at a ZIP code, as ranked for the operator."""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class UtilityOffer(BaseModel):
+    # Power to Choose's own plan id. Not a local row — nothing about an offer is
+    # persisted until the operator actually signs up and records the new plan.
+    external_plan_id: int
+    provider_name: str
+    plan_name: str
+    term_months: int
+    # All three published disclosure points, because the shape across them is
+    # what separates a real price from a bill-credit teaser. The client shows
+    # all three rather than making the operator trust a single number.
+    price_cents_per_kwh_at_500: Decimal
+    price_cents_per_kwh_at_1000: Decimal
+    price_cents_per_kwh_at_2000: Decimal
+    renewable_pct: int | None = None
+    # Power to Choose customer rating, 1-5. None when the feed has none on file
+    # — which the UI must render as "unrated", never as a zero-star score.
+    provider_rating: int | None = None
+    # J.D. Power residential satisfaction score, 1-5, where published. Only a
+    # minority of REPs carry one, so it is a bonus signal and never a gate.
+    jd_power_rating: int | None = None
+    # None means the feed stated no dollar figure — distinct from a stated $0.
+    cancellation_fee_cents: int | None = None
+    cancellation_fee_is_per_remaining_month: bool = False
+    # True when the 1000 kWh headline is far below this plan's own price at 500
+    # and 2000 kWh. Ranked below honest plans and badged in the UI.
+    is_teaser_priced: bool = False
+    # Signed cents per year at the reference usage, against the plan currently
+    # held for this property. Negative means the offer is worse.
+    annual_saving_cents: int | None = None
+    # The provider's Electricity Facts Label — the legally binding terms. Always
+    # surfaced, because a ranking is a starting point and not a recommendation.
+    fact_sheet_url: str | None = None
+    enroll_url: str | None = None

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_offer_group.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_offer_group.py
@@ -1,0 +1,32 @@
+"""Offers for one property, measured against the plan it holds today."""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+from app.schemas.properties.utility_offer import UtilityOffer
+
+
+class UtilityOfferGroup(BaseModel):
+    property_id: uuid.UUID
+    property_name: str | None = None
+    # Derived from the property's address, not stored — see
+    # ``_address_zip.derive_zip_code``. None when the address carries no ZIP,
+    # in which case ``offers`` is empty and ``unavailable_reason`` says why.
+    zip_code: str | None = None
+    current_provider_name: str | None = None
+    current_price_cents_per_kwh_at_1000: Decimal | None = None
+    # What it costs to leave the current plan early. None when unknown — an
+    # unknown exit cost must never render as free.
+    switch_cost_cents: int | None = None
+    offers: list[UtilityOffer] = []
+    # Cheaper offers held back for failing the provider-rating bar (or having no
+    # rating on file). Reported rather than silently dropped so the list never
+    # reads as "this is everything" when it is not.
+    withheld_low_rated_count: int = 0
+    # Set when no ranking could be produced: no ZIP in the address, no current
+    # electricity plan to compare against, or the feed was unreachable. The UI
+    # shows this instead of an empty list, so a gap never reads as "no savings".
+    unavailable_reason: str | None = None

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_offer_search_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_offer_search_response.py
@@ -1,0 +1,15 @@
+"""Response for the better-plan search across every property."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from app.schemas.properties.utility_offer_group import UtilityOfferGroup
+
+
+class UtilityOfferSearchResponse(BaseModel):
+    groups: list[UtilityOfferGroup] = []
+    # Reference consumption the savings figures were computed at, so the client
+    # can label them honestly rather than implying a bill-specific promise.
+    reference_annual_kwh: int
+    # True when at least one group came back with offers.
+    has_any_offers: bool = False

--- a/apps/mybookkeeper/backend/app/services/properties/_address_zip.py
+++ b/apps/mybookkeeper/backend/app/services/properties/_address_zip.py
@@ -1,0 +1,22 @@
+"""Derive a US ZIP code from a free-text property address.
+
+The ZIP lives inside ``properties.address`` already. Copying it into its own
+column would store the same fact twice and let the two drift, so it is read
+back out on demand instead.
+"""
+from __future__ import annotations
+
+import re
+
+# Anchored to the end of the string because a US address puts the ZIP last.
+# ZIP+4 is accepted and truncated — the offer feed keys on the 5-digit form.
+# Searching anywhere in the string would happily match a house number.
+_TRAILING_ZIP_RE = re.compile(r"\b(\d{5})(?:-\d{4})?\s*$")
+
+
+def derive_zip_code(address: str | None) -> str | None:
+    """Return the 5-digit ZIP at the end of ``address``, or None."""
+    if not address:
+        return None
+    match = _TRAILING_ZIP_RE.search(address.strip())
+    return match.group(1) if match else None

--- a/apps/mybookkeeper/backend/app/services/properties/_offer_ranking.py
+++ b/apps/mybookkeeper/backend/app/services/properties/_offer_ranking.py
@@ -1,0 +1,122 @@
+"""Pure scoring helpers for Power to Choose offers.
+
+No network, no DB — every function here is deterministic on its arguments so
+the ranking rules can be tested against the real shapes the feed emits.
+"""
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+from app.core.power_to_choose_constants import (
+    MIN_PROVIDER_RATING,
+    REFERENCE_ANNUAL_KWH,
+    TEASER_PRICE_RATIO,
+    UNRATED_SENTINELS,
+)
+
+# Matches the dollar amount in a ``pricing_details`` string. The feed writes the
+# fee 37 different ways across 174 Houston offers ("$150.00", "$100", "$20 /
+# remaining month", "$20.00 per month left in term"), so the amount and the
+# per-month qualifier are detected separately rather than by enumerating forms.
+_FEE_AMOUNT_RE = re.compile(r"\$\s*([\d,]+(?:\.\d{1,2})?)")
+
+# Any phrasing that makes the fee recur per month left in the term rather than
+# being charged once.
+_PER_MONTH_RE = re.compile(
+    r"(?:per|/)\s*(?:remaining\s+)?month|month\s+(?:left|remaining)",
+    re.IGNORECASE,
+)
+
+
+def parse_cancellation_fee_cents(pricing_details: str | None) -> tuple[int | None, bool]:
+    """Pull the early-termination fee out of a feed ``pricing_details`` string.
+
+    Returns ``(amount_cents, is_per_remaining_month)``. The amount is ``None``
+    when no dollar figure is present at all — which is different from a stated
+    ``$0.00`` fee, and the caller must not conflate the two: "no fee" is a
+    selling point, "unknown fee" is a reason to read the EFL.
+    """
+    if not pricing_details:
+        return None, False
+
+    match = _FEE_AMOUNT_RE.search(pricing_details)
+    if match is None:
+        return None, False
+
+    dollars = Decimal(match.group(1).replace(",", ""))
+    cents = int((dollars * 100).to_integral_value())
+    return cents, _PER_MONTH_RE.search(pricing_details) is not None
+
+
+def is_teaser_priced(
+    price_500: Decimal, price_1000: Decimal, price_2000: Decimal,
+) -> bool:
+    """True when the headline 1000 kWh price is propped up by a bill credit.
+
+    A genuinely cheap plan is cheap across the whole usage curve. A plan that is
+    dramatically cheaper at exactly 1000 kWh than at 500 or 2000 is pricing a
+    credit that pays out only inside that band, and a household landing outside
+    it pays the un-discounted rate. Ranking on the headline alone puts these at
+    the top of the list, which is worse than useless.
+    """
+    edge = min(price_500, price_2000)
+    if edge <= 0:
+        return False
+    return price_1000 < edge * Decimal(str(TEASER_PRICE_RATIO))
+
+
+def normalize_rating(raw: object) -> int | None:
+    """Turn a feed rating into a 1-5 score, or None when there is none on file.
+
+    The feed writes -1 (occasionally 0) rather than omitting the field, and a
+    caller that treats those as numbers would rank an unrated provider below a
+    genuinely 1-star one.
+    """
+    if not isinstance(raw, int) or isinstance(raw, bool):
+        return None
+    if raw in UNRATED_SENTINELS:
+        return None
+    return raw if 1 <= raw <= 5 else None
+
+
+def meets_rating_bar(rating: int | None) -> bool:
+    """True when a provider is well-enough regarded to be worth recommending.
+
+    Unrated fails. It is not the same as badly rated, but it is equally not a
+    basis for telling someone to move their account.
+    """
+    return rating is not None and rating >= MIN_PROVIDER_RATING
+
+
+def annual_saving_cents(
+    current_price_1000: Decimal, offer_price_1000: Decimal,
+) -> int:
+    """Yearly difference in cents at the reference usage.
+
+    Signed — a negative result means the offer is worse than what is held today,
+    which the caller may still want to display rather than silently drop.
+    """
+    delta_cents_per_kwh = current_price_1000 - offer_price_1000
+    return int((delta_cents_per_kwh * REFERENCE_ANNUAL_KWH).to_integral_value())
+
+
+def switch_cost_cents(
+    cancellation_fee_cents: int | None,
+    *,
+    is_per_remaining_month: bool,
+    months_remaining: int | None,
+) -> int | None:
+    """What leaving the current plan early actually costs.
+
+    ``None`` when the fee is unknown, or when a per-month fee has no remaining
+    term to multiply by — an unknown cost must stay visibly unknown rather than
+    defaulting to zero and making the switch look free.
+    """
+    if cancellation_fee_cents is None:
+        return None
+    if not is_per_remaining_month:
+        return cancellation_fee_cents
+    if months_remaining is None:
+        return None
+    return cancellation_fee_cents * max(months_remaining, 0)

--- a/apps/mybookkeeper/backend/app/services/properties/power_to_choose_client.py
+++ b/apps/mybookkeeper/backend/app/services/properties/power_to_choose_client.py
@@ -35,6 +35,18 @@ class OfferFeedUnavailableError(RuntimeError):
     """The feed could not be reached or returned something unusable."""
 
 
+def _log_zip(zip_code: str) -> str:
+    """A ZIP coarse enough to log.
+
+    Application logs ship to Sentry, and a full ZIP tied to an organization is
+    household-level location data about the operator's properties. The first
+    three digits name the market — which is the whole diagnostic value here,
+    since a feed failure is regional, never per-address — and are the geographic
+    precision HIPAA Safe Harbor treats as de-identified.
+    """
+    return f"{zip_code[:3]}xx" if len(zip_code) >= 3 else "xxxxx"
+
+
 # ZIP -> (fetched_at_monotonic, offers). The feed republishes in daily batches,
 # so within the TTL every caller for a ZIP can share one fetch. Process-local by
 # design: it holds nothing user-specific and needs no invalidation story.
@@ -130,17 +142,17 @@ async def fetch_offers(zip_code: str) -> list[UtilityOffer]:
         logger.warning(
             "Power to Choose returned HTTP %s for zip=%s",
             exc.response.status_code,
-            zip_code,
+            _log_zip(zip_code),
         )
         raise OfferFeedUnavailableError("offer feed returned an error") from exc
     except (httpx.HTTPError, ValueError) as exc:
-        logger.warning("Power to Choose unreachable for zip=%s: %s", zip_code, exc)
+        logger.warning("Power to Choose unreachable for zip=%s: %s", _log_zip(zip_code), exc)
         raise OfferFeedUnavailableError("offer feed is unreachable") from exc
 
     if not isinstance(payload, dict) or not payload.get("success"):
         logger.warning(
             "Power to Choose reported failure for zip=%s: %s",
-            zip_code,
+            _log_zip(zip_code),
             (payload or {}).get("message") if isinstance(payload, dict) else None,
         )
         raise OfferFeedUnavailableError("offer feed reported a failure")

--- a/apps/mybookkeeper/backend/app/services/properties/power_to_choose_client.py
+++ b/apps/mybookkeeper/backend/app/services/properties/power_to_choose_client.py
@@ -35,16 +35,13 @@ class OfferFeedUnavailableError(RuntimeError):
     """The feed could not be reached or returned something unusable."""
 
 
-def _log_zip(zip_code: str) -> str:
-    """A ZIP coarse enough to log.
-
-    Application logs ship to Sentry, and a full ZIP tied to an organization is
-    household-level location data about the operator's properties. The first
-    three digits name the market — which is the whole diagnostic value here,
-    since a feed failure is regional, never per-address — and are the geographic
-    precision HIPAA Safe Harbor treats as de-identified.
-    """
-    return f"{zip_code[:3]}xx" if len(zip_code) >= 3 else "xxxxx"
+# The ZIP is deliberately absent from every log line below. Application logs
+# ship to Sentry, and a ZIP tied to an organization is location data about the
+# operator's properties — while adding nothing to a diagnosis, because a feed
+# failure is regional and the operator already sees which property couldn't be
+# priced: ``utility_offer_service`` turns the raised error into a per-group
+# reason on the page. What the logs carry instead is what the third-party
+# response actually said.
 
 
 # ZIP -> (fetched_at_monotonic, offers). The feed republishes in daily batches,
@@ -140,19 +137,18 @@ async def fetch_offers(zip_code: str) -> list[UtilityOffer]:
             payload = response.json()
     except httpx.HTTPStatusError as exc:
         logger.warning(
-            "Power to Choose returned HTTP %s for zip=%s",
+            "Power to Choose returned HTTP %s: %s",
             exc.response.status_code,
-            _log_zip(zip_code),
+            exc.response.text[:200],
         )
         raise OfferFeedUnavailableError("offer feed returned an error") from exc
     except (httpx.HTTPError, ValueError) as exc:
-        logger.warning("Power to Choose unreachable for zip=%s: %s", _log_zip(zip_code), exc)
+        logger.warning("Power to Choose unreachable: %s", exc)
         raise OfferFeedUnavailableError("offer feed is unreachable") from exc
 
     if not isinstance(payload, dict) or not payload.get("success"):
         logger.warning(
-            "Power to Choose reported failure for zip=%s: %s",
-            _log_zip(zip_code),
+            "Power to Choose reported failure: %s",
             (payload or {}).get("message") if isinstance(payload, dict) else None,
         )
         raise OfferFeedUnavailableError("offer feed reported a failure")

--- a/apps/mybookkeeper/backend/app/services/properties/power_to_choose_client.py
+++ b/apps/mybookkeeper/backend/app/services/properties/power_to_choose_client.py
@@ -1,0 +1,158 @@
+"""Fetch residential electricity offers from the Power to Choose feed.
+
+Network boundary only: this module talks to the PUCT host and turns the raw
+payload into ``UtilityOffer`` rows. Which offers are worth showing, and how they
+compare to what a property already pays, is decided in
+``utility_offer_service`` — nothing here reads the database.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from decimal import Decimal
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+from app.core.power_to_choose_constants import (
+    FEED_RATE_TYPE_FIXED,
+    OFFER_CACHE_TTL_SECONDS,
+    OFFER_FETCH_TIMEOUT_SECONDS,
+    POWER_TO_CHOOSE_PLANS_URL,
+)
+from app.schemas.properties.utility_offer import UtilityOffer
+from app.services.properties._offer_ranking import (
+    is_teaser_priced,
+    normalize_rating,
+    parse_cancellation_fee_cents,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OfferFeedUnavailableError(RuntimeError):
+    """The feed could not be reached or returned something unusable."""
+
+
+# ZIP -> (fetched_at_monotonic, offers). The feed republishes in daily batches,
+# so within the TTL every caller for a ZIP can share one fetch. Process-local by
+# design: it holds nothing user-specific and needs no invalidation story.
+_cache: dict[str, tuple[float, list[UtilityOffer]]] = {}
+
+
+def _user_agent() -> str:
+    base = settings.app_url or "https://mybookkeeper.app"
+    return f"MyBookkeeper-UtilityOffers/1.0 ({base})"
+
+
+def _decimal(raw: Any) -> Decimal | None:
+    if raw is None:
+        return None
+    try:
+        return Decimal(str(raw))
+    except (ArithmeticError, ValueError):
+        return None
+
+
+def _to_offer(row: dict[str, Any]) -> UtilityOffer | None:
+    """Map one feed row, or None when it is unusable.
+
+    Only ``Fixed`` offers survive: a variable-rate offer is the holdover product
+    a lapsed plan already fell into, so presenting it as an upgrade would be
+    incoherent. Prepaid and time-of-use products are dropped for the same
+    reason — their headline ¢/kWh is not comparable to a standard fixed rate.
+    """
+    if row.get("rate_type") != FEED_RATE_TYPE_FIXED:
+        return None
+    if row.get("prepaid") or row.get("timeofuse"):
+        return None
+
+    price_500 = _decimal(row.get("price_kwh500"))
+    price_1000 = _decimal(row.get("price_kwh1000"))
+    price_2000 = _decimal(row.get("price_kwh2000"))
+    if price_500 is None or price_1000 is None or price_2000 is None:
+        return None
+    if price_1000 <= 0:
+        return None
+
+    plan_id = row.get("plan_id")
+    term = row.get("term_value")
+    if not isinstance(plan_id, int) or not isinstance(term, int):
+        return None
+
+    fee_cents, fee_per_month = parse_cancellation_fee_cents(row.get("pricing_details"))
+
+    return UtilityOffer(
+        external_plan_id=plan_id,
+        provider_name=str(row.get("company_name") or "").strip() or "Unknown provider",
+        plan_name=str(row.get("plan_name") or "").strip() or "Unnamed plan",
+        term_months=term,
+        price_cents_per_kwh_at_500=price_500,
+        price_cents_per_kwh_at_1000=price_1000,
+        price_cents_per_kwh_at_2000=price_2000,
+        renewable_pct=row.get("renewable_energy_id")
+        if isinstance(row.get("renewable_energy_id"), int)
+        else None,
+        provider_rating=normalize_rating(row.get("rating_total")),
+        jd_power_rating=normalize_rating(row.get("jdp_rating")),
+        cancellation_fee_cents=fee_cents,
+        cancellation_fee_is_per_remaining_month=fee_per_month,
+        is_teaser_priced=is_teaser_priced(price_500, price_1000, price_2000),
+        fact_sheet_url=str(row.get("fact_sheet") or "") or None,
+        enroll_url=str(row.get("go_to_plan") or "") or None,
+    )
+
+
+async def fetch_offers(zip_code: str) -> list[UtilityOffer]:
+    """Every usable fixed-rate offer published for ``zip_code``.
+
+    Raises ``OfferFeedUnavailableError`` rather than returning an empty list on
+    failure: "the feed is down" and "there are no offers here" lead to different
+    words on screen, and collapsing them would quietly tell the operator they
+    have nothing to switch to.
+    """
+    cached = _cache.get(zip_code)
+    if cached is not None and (time.monotonic() - cached[0]) < OFFER_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    try:
+        async with httpx.AsyncClient(timeout=OFFER_FETCH_TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                POWER_TO_CHOOSE_PLANS_URL,
+                params={"zip_code": zip_code},
+                headers={"User-Agent": _user_agent(), "Accept": "application/json"},
+                follow_redirects=True,
+            )
+            response.raise_for_status()
+            payload = response.json()
+    except httpx.HTTPStatusError as exc:
+        logger.warning(
+            "Power to Choose returned HTTP %s for zip=%s",
+            exc.response.status_code,
+            zip_code,
+        )
+        raise OfferFeedUnavailableError("offer feed returned an error") from exc
+    except (httpx.HTTPError, ValueError) as exc:
+        logger.warning("Power to Choose unreachable for zip=%s: %s", zip_code, exc)
+        raise OfferFeedUnavailableError("offer feed is unreachable") from exc
+
+    if not isinstance(payload, dict) or not payload.get("success"):
+        logger.warning(
+            "Power to Choose reported failure for zip=%s: %s",
+            zip_code,
+            (payload or {}).get("message") if isinstance(payload, dict) else None,
+        )
+        raise OfferFeedUnavailableError("offer feed reported a failure")
+
+    rows = payload.get("data")
+    if not isinstance(rows, list):
+        raise OfferFeedUnavailableError("offer feed returned an unexpected shape")
+
+    offers = [
+        offer
+        for offer in (_to_offer(row) for row in rows if isinstance(row, dict))
+        if offer is not None
+    ]
+    _cache[zip_code] = (time.monotonic(), offers)
+    return offers

--- a/apps/mybookkeeper/backend/app/services/properties/utility_offer_service.py
+++ b/apps/mybookkeeper/backend/app/services/properties/utility_offer_service.py
@@ -1,0 +1,204 @@
+"""Find better electricity plans than the ones each property currently holds.
+
+Orchestration only: loads the current plans and their properties, asks
+``power_to_choose_client`` what is on offer at each ZIP, and applies the ranking
+rules in ``_offer_ranking``. Nothing is persisted — an offer becomes a row only
+when the operator signs up and records the new plan through the normal add flow.
+
+Ranking order is deliberate and quality-first:
+
+1. Drop anything the operator cannot sensibly switch to — wrong term, no saving.
+2. **Gate on provider rating.** The cheapest honest offers in Houston are 1-star
+   REPs, and a rock-bottom rate from a provider with a billing-dispute
+   reputation is a false saving. Withheld offers are counted, never hidden.
+3. Sink teaser-priced offers below honest ones.
+4. Only then sort by price, breaking ties toward the better-rated provider.
+"""
+from __future__ import annotations
+
+import math
+import uuid
+from decimal import Decimal
+
+from app.core.power_to_choose_constants import (
+    DEFAULT_MIN_TERM_MONTHS,
+    MAX_OFFERS_PER_PROPERTY,
+    MIN_MEANINGFUL_SAVING_CENTS,
+    REFERENCE_ANNUAL_KWH,
+)
+from app.core.utility_plan_constants import (
+    RATE_TYPE_REGULATED,
+    SERVICE_TYPE_ELECTRICITY,
+)
+from app.db.session import unit_of_work
+from app.repositories.properties import property_repo, utility_plan_repo
+from app.schemas.properties.utility_offer import UtilityOffer
+from app.schemas.properties.utility_offer_group import UtilityOfferGroup
+from app.schemas.properties.utility_offer_search_response import (
+    UtilityOfferSearchResponse,
+)
+from app.services.properties._address_zip import derive_zip_code
+from app.services.properties._offer_ranking import (
+    annual_saving_cents,
+    meets_rating_bar,
+    switch_cost_cents,
+)
+from app.services.properties._utility_plan_helpers import (
+    current_plan_ids,
+    days_until_term_end,
+)
+from app.services.properties.power_to_choose_client import (
+    OfferFeedUnavailableError,
+    fetch_offers,
+)
+
+_NO_ZIP_REASON = (
+    "Add a ZIP code to this property's address so we can look up what's "
+    "available there."
+)
+_NO_PLAN_REASON = (
+    "Record this property's current electricity plan first — there's nothing "
+    "to measure an offer against yet."
+)
+_REGULATED_REASON = (
+    "This plan is a regulated tariff, so there's no competing supplier to "
+    "switch to."
+)
+_FEED_DOWN_REASON = (
+    "Power to Choose isn't responding right now. Nothing is wrong with your "
+    "plan — try again shortly."
+)
+_NO_BETTER_REASON = (
+    "Nothing on the market beats this plan by enough to be worth switching."
+)
+
+
+def _months_remaining(term_end_date: object) -> int | None:
+    """Whole months left on a term, rounded up. None when there is no end date."""
+    days = days_until_term_end(term_end_date)  # type: ignore[arg-type]
+    if days is None:
+        return None
+    return max(math.ceil(days / 30), 0)
+
+
+def _rank(
+    offers: list[UtilityOffer],
+    *,
+    current_price: Decimal,
+    min_term_months: int,
+) -> tuple[list[UtilityOffer], int]:
+    """Ranked offers worth showing, plus how many were withheld on rating."""
+    withheld = 0
+    kept: list[UtilityOffer] = []
+
+    for offer in offers:
+        if offer.term_months < min_term_months:
+            continue
+
+        saving = current_price - offer.price_cents_per_kwh_at_1000
+        if saving < Decimal(str(MIN_MEANINGFUL_SAVING_CENTS)):
+            continue
+
+        # Quality gate comes after the saving check on purpose: a low-rated
+        # offer that is not even cheaper is not a withheld opportunity, and
+        # counting it would inflate the "hidden" number into noise.
+        if not meets_rating_bar(offer.provider_rating):
+            withheld += 1
+            continue
+
+        kept.append(
+            offer.model_copy(
+                update={
+                    "annual_saving_cents": annual_saving_cents(
+                        current_price, offer.price_cents_per_kwh_at_1000,
+                    ),
+                },
+            ),
+        )
+
+    kept.sort(
+        key=lambda o: (
+            o.is_teaser_priced,
+            o.price_cents_per_kwh_at_1000,
+            -(o.provider_rating or 0),
+        ),
+    )
+    return kept[:MAX_OFFERS_PER_PROPERTY], withheld
+
+
+async def find_better_plans(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    min_term_months: int = DEFAULT_MIN_TERM_MONTHS,
+) -> UtilityOfferSearchResponse:
+    """Rank live market offers against every property's current electricity plan."""
+    async with unit_of_work() as db:
+        plans = await utility_plan_repo.list_all_active_for_org(
+            db, user_id=user_id, organization_id=organization_id,
+        )
+        properties = await property_repo.list_by_org(db, organization_id)
+
+    addresses = {prop.id: prop.address for prop in properties}
+    names = {prop.id: prop.name for prop in properties}
+    current_ids = current_plan_ids(list(plans))
+
+    current_electricity = [
+        plan
+        for plan in plans
+        if plan.service_type == SERVICE_TYPE_ELECTRICITY and plan.id in current_ids
+    ]
+
+    groups: list[UtilityOfferGroup] = []
+    for plan in current_electricity:
+        group = UtilityOfferGroup(
+            property_id=plan.property_id,
+            property_name=names.get(plan.property_id),
+            zip_code=derive_zip_code(addresses.get(plan.property_id)),
+            current_provider_name=plan.provider_name,
+            current_price_cents_per_kwh_at_1000=plan.avg_price_cents_per_kwh_at_1000,
+            switch_cost_cents=switch_cost_cents(
+                plan.early_termination_fee_cents,
+                # A stored fee is the total the EFL states, not a monthly rate —
+                # per-month fees are normalised when the plan is recorded.
+                is_per_remaining_month=False,
+                months_remaining=_months_remaining(plan.term_end_date),
+            ),
+        )
+
+        if plan.rate_type == RATE_TYPE_REGULATED:
+            group.unavailable_reason = _REGULATED_REASON
+            groups.append(group)
+            continue
+        if group.zip_code is None:
+            group.unavailable_reason = _NO_ZIP_REASON
+            groups.append(group)
+            continue
+        if plan.avg_price_cents_per_kwh_at_1000 is None:
+            group.unavailable_reason = _NO_PLAN_REASON
+            groups.append(group)
+            continue
+
+        try:
+            available = await fetch_offers(group.zip_code)
+        except OfferFeedUnavailableError:
+            group.unavailable_reason = _FEED_DOWN_REASON
+            groups.append(group)
+            continue
+
+        ranked, withheld = _rank(
+            available,
+            current_price=plan.avg_price_cents_per_kwh_at_1000,
+            min_term_months=min_term_months,
+        )
+        group.offers = ranked
+        group.withheld_low_rated_count = withheld
+        if not ranked:
+            group.unavailable_reason = _NO_BETTER_REASON
+        groups.append(group)
+
+    return UtilityOfferSearchResponse(
+        groups=groups,
+        reference_annual_kwh=REFERENCE_ANNUAL_KWH,
+        has_any_offers=any(group.offers for group in groups),
+    )

--- a/apps/mybookkeeper/backend/tests/test_offer_ranking.py
+++ b/apps/mybookkeeper/backend/tests/test_offer_ranking.py
@@ -1,0 +1,153 @@
+"""Unit tests for the pure offer-scoring helpers.
+
+No network — the fixtures are the literal shapes the Power to Choose feed
+returned for ZIP 77021, so a change in the parsing rules is measured against
+real data rather than invented data.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.properties._address_zip import derive_zip_code
+from app.services.properties._offer_ranking import (
+    annual_saving_cents,
+    is_teaser_priced,
+    meets_rating_bar,
+    normalize_rating,
+    parse_cancellation_fee_cents,
+    switch_cost_cents,
+)
+
+
+class TestParseCancellationFee:
+    """The feed writes the fee 37 different ways across 174 Houston offers."""
+
+    @pytest.mark.parametrize(
+        ("raw", "cents"),
+        [
+            ("Cancellation Fee: $150.00", 15000),
+            ("Cancellation Fee: $175.00", 17500),
+            ("Cancellation Fee: $0.00", 0),
+            ("Cancellation Fee: $100", 10000),
+            ("Cancellation Fee: $295.00", 29500),
+            ("Cancellation Fee: $1,200.00", 120000),
+        ],
+    )
+    def test_reads_a_flat_fee(self, raw: str, cents: int) -> None:
+        assert parse_cancellation_fee_cents(raw) == (cents, False)
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "Cancellation Fee: $20 / remaining month",
+            "Cancellation Fee: $20/remaining month.",
+            "Cancellation Fee: $20.00 per month left in term",
+            "Cancellation Fee: $20 per month remaining",
+            "Cancellation Fee: $20.00 per remaining month",
+        ],
+    )
+    def test_recognises_a_per_remaining_month_fee(self, raw: str) -> None:
+        """All five phrasings mean the same thing and must not read as flat."""
+        assert parse_cancellation_fee_cents(raw) == (2000, True)
+
+    def test_absent_fee_is_none_not_zero(self) -> None:
+        """"No figure stated" and "$0.00 stated" are different facts.
+
+        Collapsing them would render an unknown exit cost as free.
+        """
+        assert parse_cancellation_fee_cents("Cancellation Fee: see EFL") == (None, False)
+        assert parse_cancellation_fee_cents(None) == (None, False)
+        assert parse_cancellation_fee_cents("Cancellation Fee: $0.00") == (0, False)
+
+
+class TestTeaserPricing:
+    def test_the_ap_gas_shape_is_flagged(self) -> None:
+        """AP Gas SimpleSaver 12 — the cheapest headline in Houston, and a trap.
+
+        6.20¢ at 1000 kWh against 19.2¢ at 500 and 12.2¢ at 2000: a bill credit
+        that pays out only inside a narrow band. It tops a naive
+        sort-by-price-at-1000, which is exactly why this check exists.
+        """
+        assert is_teaser_priced(Decimal("19.2"), Decimal("6.2"), Decimal("12.2"))
+
+    def test_a_flat_curve_is_honest(self) -> None:
+        """True Value 12 — 10.8 / 10.3 / 10.1, cheap all the way across."""
+        assert not is_teaser_priced(Decimal("10.8"), Decimal("10.3"), Decimal("10.1"))
+
+    def test_a_plan_dearer_at_1000_is_not_a_teaser(self) -> None:
+        assert not is_teaser_priced(Decimal("10.5"), Decimal("10.5"), Decimal("10.6"))
+
+
+class TestProviderRating:
+    def test_feed_sentinels_read_as_unrated(self) -> None:
+        """-1 and 0 mean "none on file", not "worst possible score"."""
+        assert normalize_rating(-1) is None
+        assert normalize_rating(0) is None
+
+    @pytest.mark.parametrize("score", [1, 2, 3, 4, 5])
+    def test_real_scores_pass_through(self, score: int) -> None:
+        assert normalize_rating(score) == score
+
+    def test_junk_reads_as_unrated(self) -> None:
+        assert normalize_rating("4") is None
+        assert normalize_rating(None) is None
+        assert normalize_rating(9) is None
+
+    def test_one_and_two_star_providers_fail_the_bar(self) -> None:
+        """The operator does not want the cheapest plan from a 1-star REP."""
+        assert not meets_rating_bar(1)
+        assert not meets_rating_bar(2)
+
+    def test_three_stars_and_up_pass(self) -> None:
+        assert meets_rating_bar(3)
+        assert meets_rating_bar(5)
+
+    def test_unrated_fails_the_bar(self) -> None:
+        """Unrated is not badly rated, but it is not a basis to move an account."""
+        assert not meets_rating_bar(None)
+
+
+class TestSavingsAndSwitchCost:
+    def test_saving_is_computed_at_the_reference_usage(self) -> None:
+        """15.66¢ -> 10.50¢ over 12,000 kWh/yr is $619.20."""
+        assert annual_saving_cents(Decimal("15.66"), Decimal("10.50")) == 61920
+
+    def test_a_worse_offer_yields_a_negative_saving(self) -> None:
+        assert annual_saving_cents(Decimal("10.0"), Decimal("12.0")) == -24000
+
+    def test_a_flat_fee_is_the_whole_cost(self) -> None:
+        assert switch_cost_cents(
+            15000, is_per_remaining_month=False, months_remaining=6,
+        ) == 15000
+
+    def test_a_per_month_fee_multiplies_by_the_term_left(self) -> None:
+        assert switch_cost_cents(
+            2000, is_per_remaining_month=True, months_remaining=6,
+        ) == 12000
+
+    def test_unknown_cost_stays_unknown(self) -> None:
+        """A per-month fee with no term left to multiply must not read as free."""
+        assert switch_cost_cents(
+            2000, is_per_remaining_month=True, months_remaining=None,
+        ) is None
+        assert switch_cost_cents(
+            None, is_per_remaining_month=False, months_remaining=6,
+        ) is None
+
+
+class TestDeriveZipCode:
+    def test_reads_the_trailing_zip(self) -> None:
+        assert derive_zip_code("6734 Peerless St, Houston, TX 77021") == "77021"
+
+    def test_accepts_zip_plus_four(self) -> None:
+        assert derive_zip_code("6734 Peerless St, Houston, TX 77021-1234") == "77021"
+
+    def test_a_house_number_is_not_a_zip(self) -> None:
+        """Anchoring to the end is what stops "67341 Main St" matching."""
+        assert derive_zip_code("67341 Main St, Houston, TX") is None
+
+    def test_missing_address_is_none(self) -> None:
+        assert derive_zip_code(None) is None
+        assert derive_zip_code("") is None

--- a/apps/mybookkeeper/backend/tests/test_offer_ranking.py
+++ b/apps/mybookkeeper/backend/tests/test_offer_ranking.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 import pytest
 
 from app.services.properties._address_zip import derive_zip_code
+from app.services.properties.power_to_choose_client import _log_zip
 from app.services.properties._offer_ranking import (
     annual_saving_cents,
     is_teaser_priced,
@@ -151,3 +152,20 @@ class TestDeriveZipCode:
     def test_missing_address_is_none(self) -> None:
         assert derive_zip_code(None) is None
         assert derive_zip_code("") is None
+
+
+class TestLogZip:
+    """Application logs ship to Sentry — a full ZIP must never reach them."""
+
+    def test_keeps_only_the_market_prefix(self) -> None:
+        assert _log_zip("77021") == "770xx"
+
+    @pytest.mark.parametrize("zip_code", ["77021", "75201", "78701", "77021-1234"])
+    def test_the_house_level_digits_are_dropped(self, zip_code: str) -> None:
+        masked = _log_zip(zip_code)
+        assert masked == f"{zip_code[:3]}xx"
+        assert zip_code not in masked
+
+    def test_a_too_short_value_is_fully_masked(self) -> None:
+        assert _log_zip("77") == "xxxxx"
+        assert _log_zip("") == "xxxxx"

--- a/apps/mybookkeeper/backend/tests/test_offer_ranking.py
+++ b/apps/mybookkeeper/backend/tests/test_offer_ranking.py
@@ -6,12 +6,14 @@ real data rather than invented data.
 """
 from __future__ import annotations
 
+import ast
+import inspect
 from decimal import Decimal
 
 import pytest
 
+from app.services.properties import power_to_choose_client
 from app.services.properties._address_zip import derive_zip_code
-from app.services.properties.power_to_choose_client import _log_zip
 from app.services.properties._offer_ranking import (
     annual_saving_cents,
     is_teaser_priced,
@@ -154,18 +156,29 @@ class TestDeriveZipCode:
         assert derive_zip_code("") is None
 
 
-class TestLogZip:
-    """Application logs ship to Sentry — a full ZIP must never reach them."""
+class TestFeedLoggingCarriesNoZip:
+    """Application logs ship to Sentry — a property ZIP must never reach them.
 
-    def test_keeps_only_the_market_prefix(self) -> None:
-        assert _log_zip("77021") == "770xx"
+    Checked against the module's AST rather than a captured record: the three
+    warnings sit on separate failure branches that each need a differently
+    broken feed to reach, and the property worth protecting is simply that no
+    branch passes the ZIP to a logger.
+    """
 
-    @pytest.mark.parametrize("zip_code", ["77021", "75201", "78701", "77021-1234"])
-    def test_the_house_level_digits_are_dropped(self, zip_code: str) -> None:
-        masked = _log_zip(zip_code)
-        assert masked == f"{zip_code[:3]}xx"
-        assert zip_code not in masked
+    def test_no_logger_call_takes_the_zip_as_an_argument(self) -> None:
+        tree = ast.parse(inspect.getsource(power_to_choose_client))
+        logger_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "logger"
+        ]
+        assert logger_calls, "no logger calls found — this test would pass vacuously"
 
-    def test_a_too_short_value_is_fully_masked(self) -> None:
-        assert _log_zip("77") == "xxxxx"
-        assert _log_zip("") == "xxxxx"
+        for call in logger_calls:
+            names = {
+                sub.id for sub in ast.walk(call) if isinstance(sub, ast.Name)
+            }
+            assert "zip_code" not in names, ast.unparse(call)

--- a/apps/mybookkeeper/backend/tests/test_utility_offer_ranking.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_offer_ranking.py
@@ -1,0 +1,145 @@
+"""Tests for how offers are ordered and which ones are withheld.
+
+The fixtures mirror the real Houston 77021 board: the two cheapest honest offers
+are 1-star providers, the cheapest headline overall is a bill-credit teaser, and
+the best recommendable plan sits 0.20¢ above the ungated cheapest.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.core.power_to_choose_constants import MAX_OFFERS_PER_PROPERTY
+from app.schemas.properties.utility_offer import UtilityOffer
+from app.services.properties.utility_offer_service import _rank
+
+CURRENT_PRICE = Decimal("15.66")
+
+
+def _offer(
+    *,
+    name: str,
+    price: str,
+    rating: int | None,
+    term: int = 12,
+    teaser: bool = False,
+    plan_id: int = 1,
+) -> UtilityOffer:
+    value = Decimal(price)
+    return UtilityOffer(
+        external_plan_id=plan_id,
+        provider_name=name,
+        plan_name=f"{name} {term}",
+        term_months=term,
+        price_cents_per_kwh_at_500=value,
+        price_cents_per_kwh_at_1000=value,
+        price_cents_per_kwh_at_2000=value,
+        provider_rating=rating,
+        is_teaser_priced=teaser,
+    )
+
+
+class TestRatingGate:
+    def test_a_cheaper_one_star_offer_is_withheld(self) -> None:
+        """True Power at 10.30¢ is the cheapest honest plan — and 1-star.
+
+        The operator has said twice they do not want it. Veteran Energy at
+        10.50¢ with 3 stars is the answer, 0.20¢ dearer.
+        """
+        ranked, withheld = _rank(
+            [
+                _offer(name="True Power", price="10.30", rating=1, plan_id=1),
+                _offer(name="Budget Power", price="10.40", rating=1, plan_id=2),
+                _offer(name="Veteran Energy", price="10.50", rating=3, plan_id=3),
+            ],
+            current_price=CURRENT_PRICE,
+            min_term_months=12,
+        )
+
+        assert [o.provider_name for o in ranked] == ["Veteran Energy"]
+        assert withheld == 2
+
+    def test_an_unrated_provider_is_withheld_too(self) -> None:
+        ranked, withheld = _rank(
+            [
+                _offer(name="Mystery REP", price="10.00", rating=None, plan_id=1),
+                _offer(name="Octopus Energy", price="10.50", rating=3, plan_id=2),
+            ],
+            current_price=CURRENT_PRICE,
+            min_term_months=12,
+        )
+
+        assert [o.provider_name for o in ranked] == ["Octopus Energy"]
+        assert withheld == 1
+
+    def test_a_low_rated_offer_that_is_not_cheaper_is_not_counted(self) -> None:
+        """Withholding is about missed savings, not a census of bad providers."""
+        _, withheld = _rank(
+            [_offer(name="Dear And Bad", price="20.00", rating=1)],
+            current_price=CURRENT_PRICE,
+            min_term_months=12,
+        )
+        assert withheld == 0
+
+
+class TestOrdering:
+    def test_teasers_sink_below_honest_offers(self) -> None:
+        """A teaser may be numerically cheapest and must still not lead."""
+        ranked, _ = _rank(
+            [
+                _offer(
+                    name="AP Gas", price="6.20", rating=3, teaser=True, plan_id=1,
+                ),
+                _offer(name="True Value", price="10.30", rating=3, plan_id=2),
+            ],
+            current_price=CURRENT_PRICE,
+            min_term_months=12,
+        )
+        assert [o.provider_name for o in ranked] == ["True Value", "AP Gas"]
+
+    def test_equal_prices_break_toward_the_better_rated_provider(self) -> None:
+        ranked, _ = _rank(
+            [
+                _offer(name="Three Star", price="10.50", rating=3, plan_id=1),
+                _offer(name="Five Star", price="10.50", rating=5, plan_id=2),
+            ],
+            current_price=CURRENT_PRICE,
+            min_term_months=12,
+        )
+        assert [o.provider_name for o in ranked] == ["Five Star", "Three Star"]
+
+    def test_the_list_is_capped(self) -> None:
+        offers = [
+            _offer(name=f"REP {i}", price="11.00", rating=4, plan_id=i)
+            for i in range(MAX_OFFERS_PER_PROPERTY + 5)
+        ]
+        ranked, _ = _rank(
+            offers, current_price=CURRENT_PRICE, min_term_months=12,
+        )
+        assert len(ranked) == MAX_OFFERS_PER_PROPERTY
+
+
+class TestFiltering:
+    def test_a_shorter_term_than_asked_for_is_dropped(self) -> None:
+        ranked, _ = _rank(
+            [_offer(name="Six Month", price="9.00", rating=5, term=6)],
+            current_price=CURRENT_PRICE,
+            min_term_months=12,
+        )
+        assert ranked == []
+
+    def test_a_saving_too_small_to_act_on_is_dropped(self) -> None:
+        """15.66 -> 15.00 is 0.66¢, inside the noise of a usage swing."""
+        ranked, _ = _rank(
+            [_offer(name="Barely Better", price="15.00", rating=5)],
+            current_price=CURRENT_PRICE,
+            min_term_months=12,
+        )
+        assert ranked == []
+
+    def test_the_saving_is_attached_to_each_kept_offer(self) -> None:
+        ranked, _ = _rank(
+            [_offer(name="Veteran Energy", price="10.50", rating=3)],
+            current_price=CURRENT_PRICE,
+            min_term_months=12,
+        )
+        assert ranked[0].annual_saving_cents == 61920

--- a/apps/mybookkeeper/backend/tests/test_utility_plans_api.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_plans_api.py
@@ -28,6 +28,9 @@ from app.core.utility_plan_constants import (
 )
 from app.main import app
 from app.models.organization.organization_member import OrgRole
+from app.schemas.properties.utility_offer_search_response import (
+    UtilityOfferSearchResponse,
+)
 from app.schemas.properties.utility_plan_draft import UtilityPlanDraft
 from app.schemas.properties.utility_plan_list_response import UtilityPlanListResponse
 from app.schemas.properties.utility_plan_renewal_alert_response import (
@@ -51,6 +54,7 @@ PLAN_ID = uuid.uuid4()
 
 _SERVICE = "app.api.utility_plans.utility_plan_service"
 _EXTRACTION = "app.api.utility_plans.utility_plan_extraction_service"
+_OFFERS = "app.api.utility_plans.utility_offer_service"
 
 
 def _ctx(role: OrgRole = OrgRole.OWNER) -> RequestContext:
@@ -667,3 +671,60 @@ class TestPermissions:
         client = TestClient(app)
         assert client.get("/utility-plans").status_code == 401
         assert client.get("/utility-plans/renewal-alerts").status_code == 401
+        assert client.get("/utility-plans/offers").status_code == 401
+
+
+class TestFindBetterPlans:
+    def test_offers_is_not_swallowed_by_the_uuid_route(
+        self, client: TestClient,
+    ) -> None:
+        """``/offers`` is declared before ``/{plan_id}``; this pins that order.
+
+        Reversing them would send this to ``get_plan``, which rejects "offers"
+        as a malformed UUID — a 422 that reads like a payload problem and
+        nothing like the routing bug it would actually be.
+        """
+        with patch(f"{_SERVICE}.get_plan", new_callable=AsyncMock) as mock_get:
+            with patch(
+                f"{_OFFERS}.find_better_plans",
+                new_callable=AsyncMock,
+                return_value=UtilityOfferSearchResponse(
+                    groups=[], reference_annual_kwh=12_000,
+                ),
+            ):
+                response = client.get("/utility-plans/offers")
+
+        assert response.status_code == 200
+        mock_get.assert_not_called()
+
+    def test_the_minimum_term_is_passed_through(self, client: TestClient) -> None:
+        with patch(
+            f"{_OFFERS}.find_better_plans",
+            new_callable=AsyncMock,
+            return_value=UtilityOfferSearchResponse(
+                groups=[], reference_annual_kwh=12_000,
+            ),
+        ) as mock_find:
+            response = client.get("/utility-plans/offers?min_term_months=24")
+
+        assert response.status_code == 200
+        assert mock_find.await_args.kwargs["min_term_months"] == 24
+
+    def test_an_absurd_term_is_rejected(self, client: TestClient) -> None:
+        assert client.get("/utility-plans/offers?min_term_months=0").status_code == 422
+        assert client.get("/utility-plans/offers?min_term_months=99").status_code == 422
+
+    def test_a_read_only_member_may_search(self) -> None:
+        """Searching the market changes nothing, so a viewer may do it."""
+        app.dependency_overrides[current_org_member] = lambda: _ctx(OrgRole.VIEWER)
+        try:
+            with patch(
+                f"{_OFFERS}.find_better_plans",
+                new_callable=AsyncMock,
+                return_value=UtilityOfferSearchResponse(
+                    groups=[], reference_annual_kwh=12_000,
+                ),
+            ):
+                assert TestClient(app).get("/utility-plans/offers").status_code == 200
+        finally:
+            app.dependency_overrides.clear()

--- a/apps/mybookkeeper/frontend/e2e/utility-better-plans.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-better-plans.spec.ts
@@ -1,0 +1,202 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "./fixtures/auth";
+
+/**
+ * E2E for the "Find a better plan" section.
+ *
+ * The offer feed is Power to Choose — a live public service outside this
+ * repo's control. The endpoint response is stubbed so the assertions are about
+ * *our* behaviour (search is explicit, the gate is visible, a teaser is
+ * labelled) rather than about whatever the market happens to be offering the
+ * morning the suite runs. The stub is applied at the backend route, so
+ * everything from RTK Query down through the rendered rows is real.
+ */
+
+const PROPERTY_ID = "c0ffee00-0000-4000-8000-000000000001";
+
+/** Matches ``BetterPlansSkeleton``: two cards, three rows each. */
+const SKELETON_GROUP_COUNT = 2;
+const SKELETON_ROWS_PER_GROUP = 3;
+
+const OFFERS_RESPONSE = {
+  groups: [
+    {
+      property_id: PROPERTY_ID,
+      property_name: "E2E Peerless",
+      zip_code: "77021",
+      current_provider_name: "Constellation",
+      current_price_cents_per_kwh_at_1000: "15.6600",
+      switch_cost_cents: 15000,
+      offers: [
+        {
+          external_plan_id: 501,
+          provider_name: "Veteran Energy",
+          plan_name: "Basic 12",
+          term_months: 12,
+          price_cents_per_kwh_at_500: "11.1000",
+          price_cents_per_kwh_at_1000: "10.5000",
+          price_cents_per_kwh_at_2000: "10.2000",
+          renewable_pct: 24,
+          provider_rating: 3,
+          jd_power_rating: null,
+          cancellation_fee_cents: 15000,
+          cancellation_fee_is_per_remaining_month: false,
+          is_teaser_priced: false,
+          annual_saving_cents: 61920,
+          fact_sheet_url: "https://example.test/efl.pdf",
+          enroll_url: "https://example.test/enroll",
+        },
+        {
+          external_plan_id: 502,
+          provider_name: "AP Gas & Electric",
+          plan_name: "Credit 12",
+          term_months: 12,
+          price_cents_per_kwh_at_500: "19.2000",
+          price_cents_per_kwh_at_1000: "6.2000",
+          price_cents_per_kwh_at_2000: "12.2000",
+          renewable_pct: null,
+          provider_rating: 3,
+          jd_power_rating: null,
+          cancellation_fee_cents: 2000,
+          cancellation_fee_is_per_remaining_month: true,
+          is_teaser_priced: true,
+          annual_saving_cents: 113520,
+          fact_sheet_url: null,
+          enroll_url: null,
+        },
+      ],
+      withheld_low_rated_count: 33,
+      unavailable_reason: null,
+    },
+  ],
+  reference_annual_kwh: 12000,
+  has_any_offers: true,
+};
+
+async function stubOffers(page: Page, delayMs = 0): Promise<void> {
+  await page.route("**/api/utility-plans/offers*", async (route) => {
+    if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(OFFERS_RESPONSE),
+    });
+  });
+}
+
+async function hasHorizontalOverflow(page: Page): Promise<boolean> {
+  return page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+  );
+}
+
+test.describe("Find a better plan", () => {
+  test("searches only when asked, then shows the market with its caveats", async ({
+    authedPage: page,
+  }) => {
+    let offerRequests = 0;
+    await page.route("**/api/utility-plans/offers*", async (route) => {
+      offerRequests += 1;
+      // Held long enough for the skeleton to be observable on the one click.
+      await new Promise((r) => setTimeout(r, 1200));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(OFFERS_RESPONSE),
+      });
+    });
+
+    await page.goto("/utility-plans");
+
+    // Loading the page must not reach an external marketplace on its own.
+    await expect(page.getByTestId("better-plans-idle")).toBeVisible({ timeout: 15000 });
+    expect(offerRequests, "feed was hit before the operator asked").toBe(0);
+
+    await page.getByTestId("find-better-plans-button").click();
+
+    const skeleton = page.getByTestId("better-plans-loading");
+    await expect(skeleton).toBeVisible({ timeout: 5000 });
+    await expect(skeleton.locator("section")).toHaveCount(SKELETON_GROUP_COUNT);
+    await expect(skeleton.locator("li")).toHaveCount(
+      SKELETON_GROUP_COUNT * SKELETON_ROWS_PER_GROUP,
+    );
+
+    const results = page.getByTestId("better-plans-results");
+    await expect(results).toBeVisible({ timeout: 15000 });
+    expect(offerRequests).toBe(1);
+
+    // The recommendation itself: rate, rating, and the saving against today.
+    const topOffer = page.getByTestId("better-plan-501");
+    await expect(topOffer).toContainText("Veteran Energy");
+    await expect(topOffer).toContainText("10.50¢/kWh");
+    await expect(topOffer).toContainText("3/5");
+    await expect(page.getByTestId("better-plan-saving-501")).toContainText("$619/yr");
+
+    // A cheaper headline that only holds in one usage band says so.
+    await expect(page.getByTestId("better-plan-teaser-502")).toContainText(
+      "only holds near 1,000 kWh",
+    );
+
+    // The rating gate is stated, not silently applied.
+    await expect(page.getByTestId(`better-plans-withheld-${PROPERTY_ID}`)).toContainText(
+      "33 cheaper offers hidden",
+    );
+
+    // A saving is arithmetic at a stated usage, not a bill promise.
+    await expect(results).toContainText("12,000 kWh per year");
+  });
+
+  test("the section fits every viewport and keeps a 44px touch target", async ({
+    authedPage: page,
+  }) => {
+    await stubOffers(page);
+
+    for (const size of [
+      { width: 375, height: 800 },
+      { width: 768, height: 900 },
+      { width: 1440, height: 900 },
+    ]) {
+      await page.setViewportSize(size);
+      await page.goto("/utility-plans");
+
+      const button = page.getByTestId("find-better-plans-button");
+      await expect(button).toBeVisible({ timeout: 15000 });
+      await button.click();
+      await expect(page.getByTestId("better-plans-results")).toBeVisible({
+        timeout: 15000,
+      });
+
+      expect(
+        await hasHorizontalOverflow(page),
+        `horizontal overflow at ${size.width}px`,
+      ).toBe(false);
+    }
+
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto("/utility-plans");
+    const button = page.getByTestId("find-better-plans-button");
+    await expect(button).toBeVisible({ timeout: 15000 });
+    const box = await button.boundingBox();
+    expect(box, "search button has no box").not.toBeNull();
+    expect(box!.height, "search button height").toBeGreaterThanOrEqual(44);
+  });
+
+  test("a feed outage reads as a feed outage, not as a bad rate", async ({
+    authedPage: page,
+  }) => {
+    await page.route("**/api/utility-plans/offers*", (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "offer_feed_unavailable" }),
+      }),
+    );
+
+    await page.goto("/utility-plans");
+    await page.getByTestId("find-better-plans-button").click();
+
+    await expect(page.getByTestId("better-plans-error")).toContainText(
+      "Nothing is wrong with your plans",
+    );
+  });
+});

--- a/apps/mybookkeeper/frontend/e2e/utility-better-plans.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-better-plans.spec.ts
@@ -1,22 +1,102 @@
-import type { Page } from "@playwright/test";
-import { test, expect } from "./fixtures/auth";
-
 /**
- * E2E for the "Find a better plan" section.
+ * No-backend E2E for the "Find a better plan" section.
  *
- * The offer feed is Power to Choose — a live public service outside this
- * repo's control. The endpoint response is stubbed so the assertions are about
- * *our* behaviour (search is explicit, the gate is visible, a teaser is
- * labelled) rather than about whatever the market happens to be offering the
- * morning the suite runs. The stub is applied at the backend route, so
- * everything from RTK Query down through the rendered rows is real.
+ * Fully mocks the API surface via page.route() so it runs under
+ * playwright.layout.config.ts in the `frontend-layout-e2e` CI job (no backend,
+ * no globalSetup) — the same shape welcome-manuals-layout-mock.spec.ts uses.
+ *
+ * Mocking is not a compromise here: the upstream source is Power to Choose, a
+ * live public marketplace outside this repo's control. Asserting against
+ * whatever it happens to be offering the morning the suite runs would test the
+ * Texas electricity market, not this code. What is exercised is ours —
+ * the search is explicit, the skeleton matches the loaded shape, the rating
+ * gate is visible, a teaser is labelled, and a feed outage reads as an outage.
+ *
+ * Verifies:
+ *   - Loading the page does not call the external feed; only a click does.
+ *   - Skeleton group/row counts mirror the loaded section (no layout shift).
+ *   - The withheld-for-poor-rating count is stated, not silently applied.
+ *   - A bill-credit teaser carries its caveat.
+ *   - No horizontal scroll across mobile / tablet / desktop; 44px touch target.
+ *   - A 503 from the feed renders "nothing is wrong with your plans".
  */
+import { test, expect, type Page } from "@playwright/test";
 
-const PROPERTY_ID = "c0ffee00-0000-4000-8000-000000000001";
+const ORG_ID = "00000000-0000-0000-0000-000000000010";
+const PROPERTY_ID = "00000000-0000-0000-0000-0000000000c1";
 
 /** Matches ``BetterPlansSkeleton``: two cards, three rows each. */
 const SKELETON_GROUP_COUNT = 2;
 const SKELETON_ROWS_PER_GROUP = 3;
+
+function plantAuth(page: Page): Promise<void> {
+  return page.addInitScript(
+    ([orgId]) => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+      const payload = btoa(JSON.stringify({ sub: "test-user", exp: futureExp }));
+      window.localStorage.setItem("token", `${header}.${payload}.fake-signature`);
+      window.localStorage.setItem("v1_activeOrgId", orgId);
+    },
+    [ORG_ID],
+  );
+}
+
+function json(body: unknown) {
+  return { status: 200, contentType: "application/json", body: JSON.stringify(body) };
+}
+
+async function stubShell(page: Page): Promise<void> {
+  await page.route("**/api/users/me", (route) =>
+    route.fulfill(
+      json({
+        id: "00000000-0000-0000-0000-000000000001",
+        email: "test@example.com",
+        name: "Test User",
+        is_active: true,
+        is_superuser: false,
+        is_verified: true,
+        role: "owner",
+      }),
+    ),
+  );
+  await page.route("**/api/organizations", (route) =>
+    route.fulfill(json([{ id: ORG_ID, name: "Test Workspace", role: "owner" }])),
+  );
+  await page.route("**/api/version", (route) => route.fulfill(json({ version: "test" })));
+  await page.route("**/api/tax-profile", (route) =>
+    route.fulfill(
+      json({
+        onboarding_completed: true,
+        tax_situations: [],
+        filing_status: null,
+        dependents_count: 0,
+      }),
+    ),
+  );
+  await page.route("**/api/properties", (route) => route.fulfill(json([])));
+}
+
+/**
+ * The rest of the Utility Plans page. Routed before the offers stub would be
+ * wrong — `**\/api/utility-plans*` stops at the next `/`, so it never swallows
+ * `/utility-plans/offers`, but the two sibling literal routes below would.
+ */
+async function stubUtilityPage(page: Page): Promise<void> {
+  await page.route("**/api/utility-plans/renewal-alerts*", (route) =>
+    route.fulfill(json({ expiring_count: 0, expired_count: 0, plans: [] })),
+  );
+  await page.route("**/api/utility-plans/rate-comparison*", (route) =>
+    route.fulfill(json({ rows: [], benchmarks: [] })),
+  );
+  await page.route("**/api/market-rate-benchmarks*", (route) => route.fulfill(json([])));
+  await page.route("**/api/utility-plans?*", (route) =>
+    route.fulfill(json({ items: [], total: 0, has_more: false })),
+  );
+  await page.route("**/api/utility-plans", (route) =>
+    route.fulfill(json({ items: [], total: 0, has_more: false })),
+  );
+}
 
 const OFFERS_RESPONSE = {
   groups: [
@@ -73,37 +153,28 @@ const OFFERS_RESPONSE = {
   has_any_offers: true,
 };
 
-async function stubOffers(page: Page, delayMs = 0): Promise<void> {
-  await page.route("**/api/utility-plans/offers*", async (route) => {
-    if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(OFFERS_RESPONSE),
-    });
-  });
-}
-
 async function hasHorizontalOverflow(page: Page): Promise<boolean> {
   return page.evaluate(
     () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
   );
 }
 
+test.beforeEach(async ({ page }) => {
+  await plantAuth(page);
+  await stubShell(page);
+  await stubUtilityPage(page);
+});
+
 test.describe("Find a better plan", () => {
   test("searches only when asked, then shows the market with its caveats", async ({
-    authedPage: page,
+    page,
   }) => {
     let offerRequests = 0;
     await page.route("**/api/utility-plans/offers*", async (route) => {
       offerRequests += 1;
       // Held long enough for the skeleton to be observable on the one click.
       await new Promise((r) => setTimeout(r, 1200));
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(OFFERS_RESPONSE),
-      });
+      await route.fulfill(json(OFFERS_RESPONSE));
     });
 
     await page.goto("/utility-plans");
@@ -147,9 +218,11 @@ test.describe("Find a better plan", () => {
   });
 
   test("the section fits every viewport and keeps a 44px touch target", async ({
-    authedPage: page,
+    page,
   }) => {
-    await stubOffers(page);
+    await page.route("**/api/utility-plans/offers*", (route) =>
+      route.fulfill(json(OFFERS_RESPONSE)),
+    );
 
     for (const size of [
       { width: 375, height: 800 },
@@ -181,9 +254,7 @@ test.describe("Find a better plan", () => {
     expect(box!.height, "search button height").toBeGreaterThanOrEqual(44);
   });
 
-  test("a feed outage reads as a feed outage, not as a bad rate", async ({
-    authedPage: page,
-  }) => {
+  test("a feed outage reads as a feed outage, not as a bad rate", async ({ page }) => {
     await page.route("**/api/utility-plans/offers*", (route) =>
       route.fulfill({
         status: 503,

--- a/apps/mybookkeeper/frontend/src/__tests__/BetterPlansSection.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/BetterPlansSection.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for the "Find a better plan" section.
+ *
+ * Two behaviours matter most and both are about honesty of the list:
+ *
+ * 1. Offers withheld for a poor provider rating are *named*. A silently shorter
+ *    list reads as "this is the whole market", and the operator has twice said
+ *    they do not want the cheapest plan from a 1-star REP — so the gate must be
+ *    visible, not just applied.
+ * 2. A teaser-priced offer is labelled. Its headline rate is genuinely the
+ *    lowest number on screen, and without the caveat that is what gets picked.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { store } from "@/shared/store";
+import BetterPlansSection from "@/app/features/utility/BetterPlansSection";
+import type { UtilityOffer } from "@/shared/types/utility/utility-offer";
+import type { UtilityOfferGroup } from "@/shared/types/utility/utility-offer-group";
+import type { UtilityOfferSearchResponse } from "@/shared/types/utility/utility-offer-search-response";
+
+const mockSearch = vi.fn();
+let mockData: UtilityOfferSearchResponse | undefined;
+let mockFetching = false;
+let mockError = false;
+let mockUninitialized = true;
+
+vi.mock("@/shared/store/utilityOffersApi", () => ({
+  useLazyFindBetterUtilityPlansQuery: () => [
+    mockSearch,
+    {
+      data: mockData,
+      isFetching: mockFetching,
+      isError: mockError,
+      isUninitialized: mockUninitialized,
+    },
+  ],
+}));
+
+function offer(overrides: Partial<UtilityOffer> = {}): UtilityOffer {
+  return {
+    external_plan_id: 1,
+    provider_name: "Veteran Energy",
+    plan_name: "Basic 12",
+    term_months: 12,
+    price_cents_per_kwh_at_500: "11.0",
+    price_cents_per_kwh_at_1000: "10.5",
+    price_cents_per_kwh_at_2000: "10.3",
+    renewable_pct: null,
+    provider_rating: 3,
+    jd_power_rating: null,
+    cancellation_fee_cents: 15000,
+    cancellation_fee_is_per_remaining_month: false,
+    is_teaser_priced: false,
+    annual_saving_cents: 61920,
+    fact_sheet_url: "https://example.test/efl.pdf",
+    enroll_url: "https://example.test/enroll",
+    ...overrides,
+  };
+}
+
+function group(overrides: Partial<UtilityOfferGroup> = {}): UtilityOfferGroup {
+  return {
+    property_id: "11111111-1111-1111-1111-111111111111",
+    property_name: "6734 Peerless",
+    zip_code: "77021",
+    current_provider_name: "Constellation",
+    current_price_cents_per_kwh_at_1000: "15.66",
+    switch_cost_cents: 15000,
+    offers: [offer()],
+    withheld_low_rated_count: 0,
+    unavailable_reason: null,
+    ...overrides,
+  };
+}
+
+function renderSection() {
+  return render(
+    <Provider store={store}>
+      <BetterPlansSection />
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  mockSearch.mockClear();
+  mockData = undefined;
+  mockFetching = false;
+  mockError = false;
+  mockUninitialized = true;
+});
+
+describe("BetterPlansSection", () => {
+  it("does not hit the feed until asked", () => {
+    renderSection();
+    expect(screen.getByTestId("better-plans-idle")).toBeInTheDocument();
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it("runs the search when the button is clicked", async () => {
+    renderSection();
+    await userEvent.click(screen.getByTestId("find-better-plans-button"));
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a skeleton while the feed is being read", () => {
+    mockFetching = true;
+    renderSection();
+    expect(screen.getByTestId("better-plans-loading")).toBeInTheDocument();
+  });
+
+  it("names how many cheaper offers were withheld for a poor rating", () => {
+    mockUninitialized = false;
+    mockData = {
+      groups: [group({ withheld_low_rated_count: 33 })],
+      reference_annual_kwh: 12000,
+      has_any_offers: true,
+    };
+    renderSection();
+
+    const withheld = screen.getByTestId(
+      "better-plans-withheld-11111111-1111-1111-1111-111111111111",
+    );
+    expect(withheld).toHaveTextContent("33 cheaper offers hidden");
+    expect(withheld).toHaveTextContent("poorly rated or unrated");
+  });
+
+  it("labels a teaser-priced offer", () => {
+    mockUninitialized = false;
+    mockData = {
+      groups: [
+        group({
+          offers: [
+            offer({
+              external_plan_id: 99,
+              provider_name: "AP Gas",
+              price_cents_per_kwh_at_500: "19.2",
+              price_cents_per_kwh_at_1000: "6.2",
+              price_cents_per_kwh_at_2000: "12.2",
+              is_teaser_priced: true,
+            }),
+          ],
+        }),
+      ],
+      reference_annual_kwh: 12000,
+      has_any_offers: true,
+    };
+    renderSection();
+
+    expect(screen.getByTestId("better-plan-teaser-99")).toHaveTextContent(
+      "only holds near 1,000 kWh",
+    );
+  });
+
+  it("shows the saving and the rate against the current plan", () => {
+    mockUninitialized = false;
+    mockData = {
+      groups: [group()],
+      reference_annual_kwh: 12000,
+      has_any_offers: true,
+    };
+    renderSection();
+
+    expect(screen.getByTestId("better-plan-saving-1")).toHaveTextContent("$619/yr");
+    expect(screen.getByTestId("better-plan-1")).toHaveTextContent("10.50¢/kWh");
+    expect(screen.getByTestId("better-plan-1")).toHaveTextContent("3/5");
+  });
+
+  it("says why a property has nothing to show instead of showing nothing", () => {
+    mockUninitialized = false;
+    mockData = {
+      groups: [
+        group({
+          offers: [],
+          zip_code: null,
+          unavailable_reason: "Add a ZIP code to this property's address.",
+        }),
+      ],
+      reference_annual_kwh: 12000,
+      has_any_offers: false,
+    };
+    renderSection();
+
+    expect(
+      screen.getByTestId(
+        "better-plans-unavailable-11111111-1111-1111-1111-111111111111",
+      ),
+    ).toHaveTextContent("Add a ZIP code");
+  });
+
+  it("distinguishes a feed outage from a bad rate", () => {
+    mockUninitialized = false;
+    mockError = true;
+    renderSection();
+    expect(screen.getByTestId("better-plans-error")).toHaveTextContent(
+      "Nothing is wrong with your plans",
+    );
+  });
+
+  it("labels the usage basis so a saving is not read as a bill promise", () => {
+    mockUninitialized = false;
+    mockData = {
+      groups: [group()],
+      reference_annual_kwh: 12000,
+      has_any_offers: true,
+    };
+    renderSection();
+    expect(screen.getByTestId("better-plans-results")).toHaveTextContent(
+      "12,000 kWh per year",
+    );
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlanRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlanRow.tsx
@@ -1,0 +1,85 @@
+import {
+  formatAnnualSaving,
+  formatCancellationFee,
+  formatOfferRate,
+  formatProviderRating,
+  formatTerm,
+} from "@/shared/lib/utility-offer-format";
+import type { UtilityOffer } from "@/shared/types/utility/utility-offer";
+
+export interface BetterPlanRowProps {
+  offer: UtilityOffer;
+}
+
+export default function BetterPlanRow({ offer }: BetterPlanRowProps) {
+  return (
+    <li
+      className="flex items-start justify-between gap-3 py-3 border-b border-border last:border-0"
+      data-testid={`better-plan-${offer.external_plan_id}`}
+    >
+      <div className="min-w-0">
+        <p className="text-sm font-medium truncate">
+          {offer.provider_name}
+          <span className="text-muted-foreground font-normal">
+            {" · "}
+            {offer.plan_name}
+          </span>
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {formatOfferRate(offer.price_cents_per_kwh_at_1000)}/kWh ·{" "}
+          {formatTerm(offer.term_months)} ·{" "}
+          {formatProviderRating(offer.provider_rating)} ·{" "}
+          {formatCancellationFee(
+            offer.cancellation_fee_cents,
+            offer.cancellation_fee_is_per_remaining_month,
+          )}
+        </p>
+        {/* All three disclosure points, because a single headline number is
+            exactly what a bill-credit plan is designed to game. */}
+        <p className="text-xs text-muted-foreground mt-0.5">
+          At 500 / 1000 / 2000 kWh:{" "}
+          {formatOfferRate(offer.price_cents_per_kwh_at_500)} /{" "}
+          {formatOfferRate(offer.price_cents_per_kwh_at_1000)} /{" "}
+          {formatOfferRate(offer.price_cents_per_kwh_at_2000)}
+        </p>
+        {offer.is_teaser_priced ? (
+          <p
+            className="text-xs mt-1 text-amber-700 dark:text-amber-300"
+            data-testid={`better-plan-teaser-${offer.external_plan_id}`}
+          >
+            The low rate here only holds near 1,000 kWh — a bill credit props it
+            up, and usage either side of that band costs more.
+          </p>
+        ) : null}
+        <p className="text-xs mt-1 flex gap-3">
+          {offer.fact_sheet_url ? (
+            <a
+              href={offer.fact_sheet_url}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-primary hover:underline"
+            >
+              Facts label
+            </a>
+          ) : null}
+          {offer.enroll_url ? (
+            <a
+              href={offer.enroll_url}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-primary hover:underline"
+            >
+              Sign up
+            </a>
+          ) : null}
+        </p>
+      </div>
+      <span
+        className="shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200"
+        data-testid={`better-plan-saving-${offer.external_plan_id}`}
+      >
+        {formatAnnualSaving(offer.annual_saving_cents)}
+      </span>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlansBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlansBody.tsx
@@ -1,0 +1,61 @@
+import BetterPlansGroup from "@/app/features/utility/BetterPlansGroup";
+import BetterPlansSkeleton from "@/app/features/utility/BetterPlansSkeleton";
+import type { BetterPlansMode } from "@/shared/types/utility/better-plans-mode";
+import type { UtilityOfferGroup } from "@/shared/types/utility/utility-offer-group";
+
+export interface BetterPlansBodyProps {
+  mode: BetterPlansMode;
+  groups: UtilityOfferGroup[];
+  referenceAnnualKwh: number;
+}
+
+export default function BetterPlansBody({
+  mode,
+  groups,
+  referenceAnnualKwh,
+}: BetterPlansBodyProps) {
+  switch (mode) {
+    case "loading":
+      return <BetterPlansSkeleton />;
+
+    case "idle":
+      return (
+        <p className="text-sm text-muted-foreground" data-testid="better-plans-idle">
+          Checks every offer currently listed on Power to Choose against what
+          each property pays today.
+        </p>
+      );
+
+    case "error":
+      return (
+        <p className="text-sm text-muted-foreground" data-testid="better-plans-error">
+          Couldn't reach the offer feed. Nothing is wrong with your plans — try
+          again shortly.
+        </p>
+      );
+
+    case "empty":
+      return (
+        <p className="text-sm text-muted-foreground" data-testid="better-plans-empty">
+          No electricity plans on file yet. Add one and we'll have something to
+          compare the market against.
+        </p>
+      );
+
+    case "results":
+      return (
+        <div className="space-y-4" data-testid="better-plans-results">
+          {groups.map((group) => (
+            <BetterPlansGroup key={group.property_id} group={group} />
+          ))}
+          {/* Stated once, at the bottom: every saving above is arithmetic at
+              this usage, not a forecast of a specific bill. */}
+          <p className="text-xs text-muted-foreground">
+            Savings are calculated at {referenceAnnualKwh.toLocaleString()} kWh
+            per year, the disclosure basis every Texas plan publishes. Your
+            actual bill depends on what you use.
+          </p>
+        </div>
+      );
+  }
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlansGroup.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlansGroup.tsx
@@ -1,0 +1,67 @@
+import BetterPlanRow from "@/app/features/utility/BetterPlanRow";
+import { formatCents } from "@/shared/lib/utility-plan-format";
+import { formatOfferRate } from "@/shared/lib/utility-offer-format";
+import type { UtilityOfferGroup } from "@/shared/types/utility/utility-offer-group";
+
+export interface BetterPlansGroupProps {
+  group: UtilityOfferGroup;
+}
+
+function CurrentPlanLine({ group }: BetterPlansGroupProps) {
+  if (group.current_price_cents_per_kwh_at_1000 === null) return null;
+  return (
+    <p className="text-xs text-muted-foreground mt-0.5">
+      Currently {group.current_provider_name} at{" "}
+      {formatOfferRate(group.current_price_cents_per_kwh_at_1000)}/kWh
+      {group.switch_cost_cents === null
+        ? " · exit fee unknown"
+        : ` · ${formatCents(group.switch_cost_cents)} to leave early`}
+    </p>
+  );
+}
+
+export default function BetterPlansGroup({ group }: BetterPlansGroupProps) {
+  return (
+    <section
+      className="rounded-lg border border-border p-4"
+      data-testid={`better-plans-group-${group.property_id}`}
+    >
+      <header>
+        <h3 className="text-sm font-semibold">
+          {group.property_name ?? "Unknown property"}
+        </h3>
+        <CurrentPlanLine group={group} />
+      </header>
+
+      {group.unavailable_reason ? (
+        <p
+          className="text-sm text-muted-foreground mt-3"
+          data-testid={`better-plans-unavailable-${group.property_id}`}
+        >
+          {group.unavailable_reason}
+        </p>
+      ) : null}
+
+      {group.offers.length > 0 ? (
+        <ul className="mt-2">
+          {group.offers.map((offer) => (
+            <BetterPlanRow key={offer.external_plan_id} offer={offer} />
+          ))}
+        </ul>
+      ) : null}
+
+      {/* Named rather than silent: a shorter list with no explanation reads as
+          "this is the whole market", which it is not. */}
+      {group.withheld_low_rated_count > 0 ? (
+        <p
+          className="text-xs text-muted-foreground mt-3"
+          data-testid={`better-plans-withheld-${group.property_id}`}
+        >
+          {group.withheld_low_rated_count} cheaper{" "}
+          {group.withheld_low_rated_count === 1 ? "offer" : "offers"} hidden —
+          poorly rated or unrated providers.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlansSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlansSection.tsx
@@ -1,0 +1,52 @@
+import { LoadingButton } from "@platform/ui";
+import BetterPlansBody from "@/app/features/utility/BetterPlansBody";
+import { useBetterPlansMode } from "@/app/features/utility/useBetterPlansMode";
+import { useLazyFindBetterUtilityPlansQuery } from "@/shared/store/utilityOffersApi";
+
+/**
+ * "Find a better plan" — the market side of the utility feature.
+ *
+ * The search is explicit rather than automatic: it fans out to the Power to
+ * Choose feed once per distinct property ZIP, and a page view is not a reason
+ * to hit an external service.
+ */
+export default function BetterPlansSection() {
+  const [search, { data, isFetching, isError, isUninitialized }] =
+    useLazyFindBetterUtilityPlansQuery();
+
+  const groups = data?.groups ?? [];
+  const mode = useBetterPlansMode({
+    hasSearched: !isUninitialized,
+    isFetching,
+    isError,
+    groupCount: groups.length,
+  });
+
+  return (
+    <section className="space-y-3" data-testid="better-plans-section">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold">Find a better plan</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Live offers from Power to Choose, the marketplace the Public Utility
+            Commission of Texas runs.
+          </p>
+        </div>
+        <LoadingButton
+          isLoading={isFetching}
+          loadingText="Checking the market..."
+          onClick={() => void search({})}
+          data-testid="find-better-plans-button"
+        >
+          Check the market
+        </LoadingButton>
+      </div>
+
+      <BetterPlansBody
+        mode={mode}
+        groups={groups}
+        referenceAnnualKwh={data?.reference_annual_kwh ?? 0}
+      />
+    </section>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlansSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlansSkeleton.tsx
@@ -1,0 +1,39 @@
+/**
+ * Loading placeholder for the better-plans search.
+ *
+ * Mirrors the loaded section: two bordered property cards, each with a heading,
+ * a current-plan line, and three offer rows carrying a three-line left block
+ * and a saving pill on the right. Same shape means no layout shift when the
+ * feed answers.
+ */
+export default function BetterPlansSkeleton() {
+  return (
+    <div
+      className="space-y-4 animate-pulse"
+      aria-busy="true"
+      data-testid="better-plans-loading"
+    >
+      {[1, 2].map((group) => (
+        <section key={group} className="rounded-lg border border-border p-4">
+          <div className="h-4 bg-muted rounded w-40" />
+          <div className="h-3 bg-muted rounded w-64 mt-2" />
+          <ul className="mt-2">
+            {[1, 2, 3].map((row) => (
+              <li
+                key={row}
+                className="flex items-start justify-between gap-3 py-3 border-b border-border last:border-0"
+              >
+                <div className="min-w-0 flex-1 space-y-2">
+                  <div className="h-4 bg-muted rounded w-1/2" />
+                  <div className="h-3 bg-muted rounded w-3/4" />
+                  <div className="h-3 bg-muted rounded w-2/3" />
+                </div>
+                <div className="h-5 w-20 bg-muted rounded-full shrink-0" />
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/useBetterPlansMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/useBetterPlansMode.ts
@@ -1,0 +1,28 @@
+import type { BetterPlansMode } from "@/shared/types/utility/better-plans-mode";
+
+export interface UseBetterPlansModeArgs {
+  hasSearched: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  groupCount: number;
+}
+
+/**
+ * Resolves the better-plans render mode.
+ *
+ * Single source of truth so the body is a flat switch rather than a ternary
+ * chain, and so the skeleton and the results can never disagree about which
+ * state is showing.
+ */
+export function useBetterPlansMode({
+  hasSearched,
+  isFetching,
+  isError,
+  groupCount,
+}: UseBetterPlansModeArgs): BetterPlansMode {
+  if (isFetching) return "loading";
+  if (!hasSearched) return "idle";
+  if (isError) return "error";
+  if (groupCount === 0) return "empty";
+  return "results";
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/UtilityPlans.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/UtilityPlans.tsx
@@ -8,6 +8,7 @@ import {
   useGetUtilityPlansQuery,
 } from "@/shared/store/utilityPlansApi";
 import AddUtilityPlanDialog from "@/app/features/utility/AddUtilityPlanDialog";
+import BetterPlansSection from "@/app/features/utility/BetterPlansSection";
 import MarketRateBenchmarkDialog from "@/app/features/utility/MarketRateBenchmarkDialog";
 import MarketRateBenchmarkSummary from "@/app/features/utility/MarketRateBenchmarkSummary";
 import EditUtilityPlanDialog from "@/app/features/utility/EditUtilityPlanDialog";
@@ -66,7 +67,7 @@ export default function UtilityPlans() {
     <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
       <SectionHeader
         title="Utility Plans"
-        subtitle="Track what each property pays for power and gas, get warned before a fixed rate lapses, and see which plans are priced above the market."
+        subtitle="Track what each property pays for power and gas, get warned before a fixed rate lapses, and check the live market for a better rate."
         actions={
           <div className="flex gap-2">
             <Button
@@ -105,6 +106,8 @@ export default function UtilityPlans() {
       ) : null}
 
       <MarketRateBenchmarkSummary onEdit={() => setShowBenchmarkDialog(true)} />
+
+      <BetterPlansSection />
 
       <div className="flex items-center gap-3">
         <label className="flex items-center gap-2 text-sm cursor-pointer">

--- a/apps/mybookkeeper/frontend/src/shared/lib/utility-offer-format.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/utility-offer-format.ts
@@ -1,0 +1,47 @@
+/**
+ * Display formatting for market offers.
+ *
+ * Kept apart from `utility-plan-format` because these describe an offer the
+ * operator does not hold yet — the vocabulary is "would save", not "is paying".
+ */
+
+/** "$619/yr" — whole dollars, because the cents are false precision here. */
+export function formatAnnualSaving(cents: number | null): string {
+  if (cents === null) return "—";
+  return `$${Math.round(cents / 100).toLocaleString()}/yr`;
+}
+
+/** "10.50¢" — the offer's price at the 1,000 kWh disclosure point. */
+export function formatOfferRate(value: string): string {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) return "—";
+  return `${parsed.toFixed(2)}¢`;
+}
+
+/**
+ * The exit fee in words.
+ *
+ * An unpublished fee reads as "not published", never as "$0" — those are
+ * different facts and only one of them is good news.
+ */
+export function formatCancellationFee(
+  cents: number | null,
+  isPerRemainingMonth: boolean,
+): string {
+  if (cents === null) return "Exit fee not published";
+  if (cents === 0) return "No exit fee";
+  const dollars = `$${Math.round(cents / 100).toLocaleString()}`;
+  if (isPerRemainingMonth) return `${dollars} per month left`;
+  return `${dollars} exit fee`;
+}
+
+/** "3/5" — or "Unrated" when the feed has nothing on file. */
+export function formatProviderRating(rating: number | null): string {
+  if (rating === null) return "Unrated";
+  return `${rating}/5`;
+}
+
+/** "12 months" / "1 month". */
+export function formatTerm(months: number): string {
+  return months === 1 ? "1 month" : `${months} months`;
+}

--- a/apps/mybookkeeper/frontend/src/shared/store/utilityOffersApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/utilityOffersApi.ts
@@ -1,0 +1,33 @@
+import { baseApi } from "./baseApi";
+import type { UtilityOfferSearchResponse } from "@/shared/types/utility/utility-offer-search-response";
+
+/**
+ * RTK Query slice for the live market-offer search.
+ *
+ * Tagged under `UtilityPlan:OFFERS` because the ranking is measured against the
+ * plans currently on file — editing a plan's rate changes which offers beat it,
+ * so plan mutations must be able to invalidate this.
+ *
+ * The query is lazy: it fans out to the Power to Choose feed once per distinct
+ * property ZIP, so it runs when the operator asks for it rather than on every
+ * page load.
+ */
+const utilityOffersApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    findBetterUtilityPlans: builder.query<
+      UtilityOfferSearchResponse,
+      { minTermMonths?: number } | void
+    >({
+      query: (args) => ({
+        url: "/utility-plans/offers",
+        params: args?.minTermMonths ? { min_term_months: args.minTermMonths } : undefined,
+      }),
+      providesTags: [{ type: "UtilityPlan", id: "OFFERS" }],
+    }),
+  }),
+});
+
+export const {
+  useFindBetterUtilityPlansQuery,
+  useLazyFindBetterUtilityPlansQuery,
+} = utilityOffersApi;

--- a/apps/mybookkeeper/frontend/src/shared/store/utilityPlansApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/utilityPlansApi.ts
@@ -83,6 +83,9 @@ const utilityPlansApi = baseApi.injectEndpoints({
         { type: "UtilityPlan", id: "LIST" },
         { type: "UtilityPlan", id: "ALERTS" },
         { type: "UtilityPlan", id: "COMPARISON" },
+        // The market ranking is measured against the plan's own rate, so
+        // changing that rate changes which offers beat it.
+        { type: "UtilityPlan", id: "OFFERS" },
       ],
     }),
 
@@ -100,6 +103,9 @@ const utilityPlansApi = baseApi.injectEndpoints({
         { type: "UtilityPlan", id: "LIST" },
         { type: "UtilityPlan", id: "ALERTS" },
         { type: "UtilityPlan", id: "COMPARISON" },
+        // The market ranking is measured against the plan's own rate, so
+        // changing that rate changes which offers beat it.
+        { type: "UtilityPlan", id: "OFFERS" },
       ],
     }),
 
@@ -121,6 +127,9 @@ const utilityPlansApi = baseApi.injectEndpoints({
         { type: "UtilityPlan", id: "LIST" },
         { type: "UtilityPlan", id: "ALERTS" },
         { type: "UtilityPlan", id: "COMPARISON" },
+        // The market ranking is measured against the plan's own rate, so
+        // changing that rate changes which offers beat it.
+        { type: "UtilityPlan", id: "OFFERS" },
       ],
     }),
   }),

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/better-plans-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/better-plans-mode.ts
@@ -1,0 +1,12 @@
+/**
+ * What the better-plans section is currently showing.
+ *
+ * `idle` is the pre-search state — the search fans out to an external feed, so
+ * it runs when asked rather than on page load.
+ */
+export type BetterPlansMode =
+  | "idle"
+  | "loading"
+  | "error"
+  | "empty"
+  | "results";

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-offer-group.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-offer-group.ts
@@ -1,0 +1,21 @@
+import type { UtilityOffer } from "@/shared/types/utility/utility-offer";
+
+/**
+ * Offers for one property, measured against the plan it holds today.
+ *
+ * Mirrors `backend/app/schemas/properties/utility_offer_group.py`.
+ */
+export interface UtilityOfferGroup {
+  property_id: string;
+  property_name: string | null;
+  zip_code: string | null;
+  current_provider_name: string | null;
+  current_price_cents_per_kwh_at_1000: string | null;
+  /** `null` means the exit cost is unknown — must never render as free. */
+  switch_cost_cents: number | null;
+  offers: UtilityOffer[];
+  /** Cheaper offers held back for failing the provider-rating bar. */
+  withheld_low_rated_count: number;
+  /** Why there is nothing to show. Rendered instead of an empty list. */
+  unavailable_reason: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-offer-search-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-offer-search-response.ts
@@ -1,0 +1,14 @@
+import type { UtilityOfferGroup } from "@/shared/types/utility/utility-offer-group";
+
+/**
+ * Mirrors `backend/app/schemas/properties/utility_offer_search_response.py`.
+ */
+export interface UtilityOfferSearchResponse {
+  groups: UtilityOfferGroup[];
+  /**
+   * Usage the savings figures were computed at. Shown to the operator so a
+   * saving reads as "at this reference usage", not as a promise about a bill.
+   */
+  reference_annual_kwh: number;
+  has_any_offers: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-offer.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-offer.ts
@@ -1,0 +1,29 @@
+/**
+ * One electricity offer available at a property's ZIP, as ranked by the API.
+ *
+ * Nothing here is a local row — an offer becomes a `UtilityPlan` only if the
+ * operator signs up and records it through the normal add flow.
+ *
+ * Mirrors `backend/app/schemas/properties/utility_offer.py`.
+ */
+export interface UtilityOffer {
+  external_plan_id: number;
+  provider_name: string;
+  plan_name: string;
+  term_months: number;
+  /** Decimals arrive as strings so no precision is lost in JSON. */
+  price_cents_per_kwh_at_500: string;
+  price_cents_per_kwh_at_1000: string;
+  price_cents_per_kwh_at_2000: string;
+  renewable_pct: number | null;
+  /** 1-5. `null` means unrated — never render that as zero stars. */
+  provider_rating: number | null;
+  jd_power_rating: number | null;
+  /** `null` means no figure was published — distinct from a stated $0. */
+  cancellation_fee_cents: number | null;
+  cancellation_fee_is_per_remaining_month: boolean;
+  is_teaser_priced: boolean;
+  annual_saving_cents: number | null;
+  fact_sheet_url: string | null;
+  enroll_url: string | null;
+}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -672,7 +672,17 @@
         "backend/alembic/versions/mktbench260811_market_rate_benchmarks.py",
         "frontend/src/shared/store/marketRateBenchmarksApi.ts",
         "frontend/src/shared/lib/api-error-detail.ts",
-        "frontend/src/shared/types/api/"
+        "frontend/src/shared/types/api/",
+        "backend/app/core/power_to_choose_constants.py",
+        "backend/app/schemas/properties/utility_offer.py",
+        "backend/app/schemas/properties/utility_offer_group.py",
+        "backend/app/schemas/properties/utility_offer_search_response.py",
+        "backend/app/services/properties/_address_zip.py",
+        "backend/app/services/properties/_offer_ranking.py",
+        "backend/app/services/properties/power_to_choose_client.py",
+        "backend/app/services/properties/utility_offer_service.py",
+        "frontend/src/shared/store/utilityOffersApi.ts",
+        "frontend/src/shared/lib/utility-offer-format.ts"
       ],
       "backend_tests": [
         "test_utility_plan_service.py",
@@ -684,7 +694,9 @@
         "test_market_benchmark_compare.py",
         "test_market_rate_benchmark_repo.py",
         "test_market_rate_benchmark_service.py",
-        "test_market_rate_benchmarks_api.py"
+        "test_market_rate_benchmarks_api.py",
+        "test_offer_ranking.py",
+        "test_utility_offer_ranking.py"
       ],
       "frontend_tests": [
         "UtilityPlans.test.tsx",
@@ -696,14 +708,16 @@
         "utility-plan-draft.test.ts",
         "Dashboard.test.tsx",
         "UtilityPlanComparisonCard.test.tsx",
-        "MarketRateBenchmarkDialog.test.tsx"
+        "MarketRateBenchmarkDialog.test.tsx",
+        "BetterPlansSection.test.tsx"
       ],
       "e2e_specs": [
         "utility-plans.spec.ts",
         "utility-plans-layout.spec.ts",
         "dashboard.spec.ts",
         "utility-plan-rate-benchmark.spec.ts",
-        "utility-plan-comparison-layout.spec.ts"
+        "utility-plan-comparison-layout.spec.ts",
+        "utility-better-plans.spec.ts"
       ]
     },
     "welcome_manuals": {


### PR DESCRIPTION
## What this is

The Utility Plans page could record what each property pays and compare it against a rate typed in by hand. It could not answer the actual question: **which plan should I move to.** This adds that.

"Find a better plan" reads the live [Power to Choose](http://powertochoose.org) feed — the marketplace the Public Utility Commission of Texas runs — once per distinct property ZIP, and ranks what it finds against the rate each property is actually on.

## Ranking

In order, in `services/properties/_offer_ranking.py` (pure functions, unit-tested directly):

1. **Drop what can't be acted on** — variable/indexed rates, prepaid, time-of-use, terms shorter than requested, anything not actually cheaper than the current plan.
2. **Gate on provider rating.** `MIN_PROVIDER_RATING = 3`, and an **unrated** provider fails the gate rather than passing it — Power to Choose uses `-1` and `0` as "no rating" sentinels, and treating those as neutral is exactly how an unrated REP outranks a good one. Against the real 77021 feed this withholds 32–37 offers per property, several of which are the cheapest on the board. **The count is surfaced in the UI, not hidden** — a silently shorter list reads as "this is the whole market", which it isn't.
3. **Sink teaser pricing.** A plan whose 1,000 kWh headline is >15% below both its 500 and 2,000 kWh prices is propped up by a bill credit that only pays out in that band. Every one of the five cheapest offers in the live feed is one of these. They still appear — last, and labelled.
4. **Sort on price, tie-break on rating.**

## Honesty of the numbers

- Savings are computed at **12,000 kWh/year**, the disclosure basis every Texas plan publishes, and the UI says so. It's arithmetic at a stated usage, not a forecast of a bill.
- All three disclosure price points (500 / 1,000 / 2,000 kWh) are shown per offer, because a single headline number is precisely what a bill-credit plan is designed to game.
- The early-exit fee is parsed out of the plan's pricing details, including the per-remaining-month form, and shown against the current plan's switch cost.

## Design notes

- **ZIP comes from `properties.address`**, not a new column. The address already holds it; a second copy is a second thing to keep true. No migration.
- **The search is explicit.** A page view is not a reason to call an external service, so nothing is fetched until the operator clicks. Requests are rate-limited to 60/hour/user; ZIP responses are cached 15 minutes.
- **A feed outage raises rather than returning `[]`**, so "the market is down" never renders as "no plan beats yours" — the two states have separate copy.
- All tunables live in `core/power_to_choose_constants.py`; nothing magic is inline.

## Verification against the live feed

Three Peerless properties, ZIP 77021 — 145 usable fixed offers parsed.

| Property | Current rate | Best qualifying offer | Saving/yr |
|---|---|---|---|
| 6732 Peerless | 15.06¢ | 10.50¢ (3★) | ~$547 |
| 6734 Peerless | 15.66¢ | 10.50¢ (3★) | ~$619 |
| 6738 Peerless | 16.27¢ | 10.50¢ (3★) | ~$692 |

~$1,860/yr across the three, against a $150-per-account exit fee. This falsifies the earlier "switching is marginal" read, which was based on a stale ~12.3¢ market figure.

## Tests

- Backend full suite: **3569 passed, 5 skipped**
- Frontend unit: 24 passed (`BetterPlansSection.test.tsx` 9 + existing 15); `tsc --noEmit` clean; eslint clean
- New E2E `utility-better-plans.spec.ts` — explicit-search behaviour, skeleton/loaded shape parity, teaser label, withheld-count visibility, viewport fit + 44px touch target, feed-outage copy
- `scripts/test-map.json` updated with the new sources and specs

## Operational migration

None. No new env vars, no migration, no new required config. The Power to Choose API is unauthenticated and free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgX4F6Unf2PbXHwHAX2fVb
