### PR TITLE
fix(mbk): fill the utility-plan form as soon as a document is picked

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/utility-plan-document-upload.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-plan-document-upload.spec.ts
@@ -12,6 +12,7 @@
  *
  * Verifies:
  *   - A file picked on the device is read without leaving the dialog
+ *   - Picking is the whole interaction — the fields fill with nothing else pressed
  *   - An empty library shows no picker rather than an empty one
  *   - The read prefills the form the operator then saves
  *   - The upload posts to the reference-only route, not /documents/upload
@@ -177,9 +178,6 @@ test.describe("Adding a utility plan from a document on the phone", () => {
 
     await openDialog(page);
 
-    const read = page.getByTestId("utility-plan-read-document-button");
-    await expect(read).toBeDisabled();
-
     await page
       .getByTestId("utility-plan-file-input")
       .setInputFiles(EFL_FILE);
@@ -187,8 +185,10 @@ test.describe("Adding a utility plan from a document on the phone", () => {
     await expect(page.getByTestId("utility-plan-chosen-document")).toContainText(
       "rhythm-efl.pdf",
     );
-    await expect(read).toBeEnabled();
-    await read.click();
+    // Picking is the whole interaction — nothing else to press.
+    await expect(
+      page.getByTestId("utility-plan-read-document-button"),
+    ).toHaveCount(0);
 
     // The read is only worth anything if it lands in the form the operator saves.
     await expect(page.getByTestId("utility-plan-provider-input")).toHaveValue("Rhythm");
@@ -220,7 +220,6 @@ test.describe("Adding a utility plan from a document on the phone", () => {
     await page
       .getByTestId("utility-plan-document-select")
       .selectOption(DOCUMENT_ID);
-    await page.getByTestId("utility-plan-read-document-button").click();
 
     await expect(page.getByTestId("utility-plan-provider-input")).toHaveValue("Rhythm");
   });
@@ -237,7 +236,6 @@ test.describe("Adding a utility plan from a document on the phone", () => {
 
     for (const testId of [
       "utility-plan-choose-file-button",
-      "utility-plan-read-document-button",
       "utility-plan-property-select",
     ]) {
       const box = await page.getByTestId(testId).boundingBox();

--- a/apps/mybookkeeper/frontend/src/__tests__/AddUtilityPlanDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/AddUtilityPlanDialog.test.tsx
@@ -84,13 +84,13 @@ function renderDialog() {
 }
 
 async function readTheDocument(user: ReturnType<typeof userEvent.setup>) {
-  // The library picker is collapsed now that uploading is the primary path.
+  // The library picker is collapsed now that uploading is the primary path,
+  // and picking is what starts the read — there is no confirm step.
   await user.click(screen.getByText(/already uploaded/));
   await user.selectOptions(
     screen.getByTestId("utility-plan-document-select"),
     "doc-1",
   );
-  await user.click(screen.getByTestId("utility-plan-read-document-button"));
 }
 
 beforeEach(() => {
@@ -301,11 +301,9 @@ describe("AddUtilityPlanDialog — reading from a document", () => {
   });
 
   it("does not call the model until a document is chosen", async () => {
-    const user = userEvent.setup();
     renderDialog();
 
-    await user.click(screen.getByTestId("utility-plan-read-document-button"));
-
     expect(mockExtract).not.toHaveBeenCalled();
+    expect(mockExtractUpload).not.toHaveBeenCalled();
   });
 });

--- a/apps/mybookkeeper/frontend/src/__tests__/UtilityPlanDocumentReader.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/UtilityPlanDocumentReader.test.tsx
@@ -9,9 +9,10 @@
  *
  * Verifies:
  * - A file picked on the device is read without visiting the Documents page
- * - Nothing is uploaded until the read is actually asked for
+ * - Picking reads immediately — no second button to press
  * - An empty library hides the picker rather than showing an empty one
- * - Each way a read can fail says something the operator can act on
+ * - Each way a read can fail says something the operator can act on, and the
+ *   failed document can be retried without being picked again
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -26,12 +27,12 @@ const mockExtract = vi.fn();
 const mockExtractUpload = vi.fn();
 const mockUseGetDocuments = vi.fn();
 
+/** Mutable so a test can hold the read open and inspect the in-flight state. */
+const uploadState = vi.hoisted(() => ({ isLoading: false }));
+
 vi.mock("@/shared/store/utilityPlansApi", () => ({
   useExtractUtilityPlanMutation: vi.fn(() => [mockExtract, { isLoading: false }]),
-  useExtractUtilityPlanFromUploadMutation: vi.fn(() => [
-    mockExtractUpload,
-    { isLoading: false },
-  ]),
+  useExtractUtilityPlanFromUploadMutation: vi.fn(() => [mockExtractUpload, uploadState]),
 }));
 
 vi.mock("@/shared/store/documentsApi", () => ({
@@ -64,6 +65,7 @@ async function pickFile(user: ReturnType<typeof userEvent.setup>, file = EFL) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  uploadState.isLoading = false;
   withLibrary([{ id: "doc-1", file_name: "constellation-efl.pdf" }]);
   mockExtract.mockReturnValue({ unwrap: vi.fn().mockResolvedValue(DRAFT) });
   mockExtractUpload.mockReturnValue({ unwrap: vi.fn().mockResolvedValue(DRAFT) });
@@ -75,14 +77,27 @@ describe("UtilityPlanDocumentReader — reading a file off the device", () => {
     const onRead = renderReader();
 
     await pickFile(user);
-    await user.click(screen.getByTestId("utility-plan-read-document-button"));
 
     await waitFor(() => expect(onRead).toHaveBeenCalledWith(DRAFT));
     expect(mockExtractUpload).toHaveBeenCalledWith(EFL);
     expect(mockExtract).not.toHaveBeenCalled();
   });
 
-  it("shows which file it is about to read", async () => {
+  it("reads on pick rather than waiting to be asked a second time", async () => {
+    // Picking a document had exactly one sensible next step, so pressing a
+    // button to confirm it was a step that never carried a decision.
+    const user = userEvent.setup();
+    renderReader();
+
+    await pickFile(user);
+
+    await waitFor(() => expect(mockExtractUpload).toHaveBeenCalled());
+    expect(
+      screen.queryByTestId("utility-plan-read-document-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows which file it is reading", async () => {
     const user = userEvent.setup();
     renderReader();
 
@@ -93,18 +108,23 @@ describe("UtilityPlanDocumentReader — reading a file off the device", () => {
     );
   });
 
-  it("uploads nothing until the read is asked for", async () => {
-    // Picking a file and then abandoning the dialog must not leave a document
-    // behind — the upload happens inside the read, not on selection.
+  it("says it is reading while the read is in flight", async () => {
     const user = userEvent.setup();
+    uploadState.isLoading = true;
+    mockExtractUpload.mockReturnValue({ unwrap: vi.fn(() => new Promise(() => {})) });
     renderReader();
 
     await pickFile(user);
 
-    expect(mockExtractUpload).not.toHaveBeenCalled();
+    expect(screen.getByTestId("utility-plan-reading-indicator")).toBeInTheDocument();
+    // Swapping the document out mid-read would race the response about to
+    // fill the form, so the way to do that is gone until it settles.
+    expect(
+      screen.queryByTestId("utility-plan-clear-document-button"),
+    ).not.toBeInTheDocument();
   });
 
-  it("lets the operator swap the file back out", async () => {
+  it("lets the operator swap the file back out once the read has settled", async () => {
     const user = userEvent.setup();
     renderReader();
 
@@ -113,17 +133,16 @@ describe("UtilityPlanDocumentReader — reading a file off the device", () => {
 
     expect(screen.queryByTestId("utility-plan-chosen-document")).not.toBeInTheDocument();
     expect(screen.getByTestId("utility-plan-file-dropzone")).toBeInTheDocument();
-    expect(screen.getByTestId("utility-plan-read-document-button")).toBeDisabled();
   });
 
-  it("does not read anything until something is chosen", async () => {
-    const user = userEvent.setup();
+  it("reads nothing on its own before anything is picked", async () => {
     renderReader();
-
-    await user.click(screen.getByTestId("utility-plan-read-document-button"));
 
     expect(mockExtractUpload).not.toHaveBeenCalled();
     expect(mockExtract).not.toHaveBeenCalled();
+    expect(
+      screen.queryByTestId("utility-plan-read-document-button"),
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -146,7 +165,6 @@ describe("UtilityPlanDocumentReader — the document library", () => {
       screen.getByTestId("utility-plan-document-select"),
       "doc-1",
     );
-    await user.click(screen.getByTestId("utility-plan-read-document-button"));
 
     await waitFor(() => expect(onRead).toHaveBeenCalledWith(DRAFT));
     expect(mockExtract).toHaveBeenCalledWith({ document_id: "doc-1" });
@@ -182,13 +200,33 @@ describe("UtilityPlanDocumentReader — when a read fails", () => {
     renderReader();
 
     await pickFile(user);
-    await user.click(screen.getByTestId("utility-plan-read-document-button"));
 
     await waitFor(() => expect(showError).toHaveBeenCalled());
     expect(vi.mocked(showError).mock.calls[0][0]).toContain(expected);
   });
 
-  it("keeps the chosen file so a retry does not start from scratch", async () => {
+  it("offers to retry the same document rather than making it be picked again", async () => {
+    const user = userEvent.setup();
+    mockExtractUpload.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ status: 500 }),
+    });
+    const onRead = renderReader();
+
+    await pickFile(user);
+    await waitFor(() => expect(showError).toHaveBeenCalled());
+
+    expect(screen.getByTestId("utility-plan-chosen-document")).toHaveTextContent(
+      "rhythm-efl.pdf",
+    );
+
+    mockExtractUpload.mockReturnValue({ unwrap: vi.fn().mockResolvedValue(DRAFT) });
+    await user.click(screen.getByTestId("utility-plan-read-document-button"));
+
+    await waitFor(() => expect(onRead).toHaveBeenCalledWith(DRAFT));
+    expect(mockExtractUpload).toHaveBeenCalledTimes(2);
+  });
+
+  it("takes the retry button away again once the read succeeds", async () => {
     const user = userEvent.setup();
     mockExtractUpload.mockReturnValue({
       unwrap: vi.fn().mockRejectedValue({ status: 500 }),
@@ -196,11 +234,17 @@ describe("UtilityPlanDocumentReader — when a read fails", () => {
     renderReader();
 
     await pickFile(user);
+    await waitFor(() =>
+      expect(screen.getByTestId("utility-plan-read-document-button")).toBeInTheDocument(),
+    );
+
+    mockExtractUpload.mockReturnValue({ unwrap: vi.fn().mockResolvedValue(DRAFT) });
     await user.click(screen.getByTestId("utility-plan-read-document-button"));
 
-    await waitFor(() => expect(showError).toHaveBeenCalled());
-    expect(screen.getByTestId("utility-plan-chosen-document")).toHaveTextContent(
-      "rhythm-efl.pdf",
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("utility-plan-read-document-button"),
+      ).not.toBeInTheDocument(),
     );
   });
 });

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanChosenDocument.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanChosenDocument.tsx
@@ -1,21 +1,28 @@
-import { FileText, X } from "lucide-react";
+import { FileText, Loader2, X } from "lucide-react";
 import type { UtilityPlanDocumentSource } from "@/shared/types/utility/utility-plan-document-source";
 
 export interface UtilityPlanChosenDocumentProps {
   source: UtilityPlanDocumentSource;
   onClear: () => void;
-  disabled?: boolean;
+  isReading?: boolean;
 }
 
 function nameOf(source: UtilityPlanDocumentSource): string {
   return source.kind === "file" ? source.file.name : source.name;
 }
 
-/** What is about to be read, and a way to change your mind about it. */
+/**
+ * What is being read, and a way to change your mind about it.
+ *
+ * Reading starts as soon as something is picked, so this doubles as the
+ * progress surface — swapping the file out mid-read would race the response
+ * it is about to fill the form with, which is why the clear button goes away
+ * until the read settles.
+ */
 export default function UtilityPlanChosenDocument({
   source,
   onClear,
-  disabled = false,
+  isReading = false,
 }: UtilityPlanChosenDocumentProps) {
   return (
     <div
@@ -27,16 +34,25 @@ export default function UtilityPlanChosenDocument({
         <FileText size={16} className="shrink-0 text-muted-foreground" />
         <span className="truncate">{nameOf(source)}</span>
       </span>
-      <button
-        type="button"
-        onClick={onClear}
-        disabled={disabled}
-        aria-label="Choose a different document"
-        className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-50"
-        data-testid="utility-plan-clear-document-button"
-      >
-        <X size={16} />
-      </button>
+      {isReading ? (
+        <span
+          className="shrink-0 flex items-center gap-2 text-muted-foreground"
+          data-testid="utility-plan-reading-indicator"
+        >
+          <Loader2 size={16} className="animate-spin" />
+          Reading...
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={onClear}
+          aria-label="Choose a different document"
+          className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center text-muted-foreground hover:text-foreground"
+          data-testid="utility-plan-clear-document-button"
+        >
+          <X size={16} />
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDocumentReader.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDocumentReader.tsx
@@ -26,10 +26,15 @@ export interface UtilityPlanDocumentReaderProps {
  * stores the file as reference material instead, so it lands in the library
  * — the saved plan cites it — without ever being mistaken for a payment.
  *
- * A picked file is held until "Read the terms" is pressed rather than uploaded
- * on sight, so abandoning the dialog leaves nothing behind and the read is a
- * single request either way. That matters on a phone, which is where this is
- * mostly used.
+ * Picking a document reads it. There is no confirm step: the card exists to
+ * fill the form, so a picked document the operator then has to press a second
+ * button to act on is a step that only ever had one sensible answer. The file
+ * is uploaded as part of that read rather than on sight, so abandoning the
+ * dialog before picking leaves nothing behind and the read is a single request
+ * either way. That matters on a phone, which is where this is mostly used.
+ *
+ * The button only comes back when a read fails, as a way to retry the same
+ * document without re-picking it.
  */
 export default function UtilityPlanDocumentReader({
   onRead,
@@ -39,20 +44,28 @@ export default function UtilityPlanDocumentReader({
   const [extractUpload, { isLoading: isReadingUpload }] =
     useExtractUtilityPlanFromUploadMutation();
   const [source, setSource] = useState<UtilityPlanDocumentSource | null>(null);
+  const [hasFailed, setHasFailed] = useState(false);
 
   const isReading = isReadingLibrary || isReadingUpload;
 
-  async function handleRead() {
-    if (!source) return;
+  async function read(target: UtilityPlanDocumentSource) {
+    setHasFailed(false);
     try {
       onRead(
-        source.kind === "file"
-          ? await extractUpload(source.file).unwrap()
-          : await extractPlan({ document_id: source.documentId }).unwrap(),
+        target.kind === "file"
+          ? await extractUpload(target.file).unwrap()
+          : await extractPlan({ document_id: target.documentId }).unwrap(),
       );
     } catch (e: unknown) {
+      setHasFailed(true);
       showError(readDocumentErrorMessage((e as { status?: number }).status));
     }
+  }
+
+  /** Picking is the whole interaction — take the document and read it. */
+  function pick(target: UtilityPlanDocumentSource) {
+    setSource(target);
+    void read(target);
   }
 
   return (
@@ -68,39 +81,42 @@ export default function UtilityPlanDocumentReader({
       {source ? (
         <UtilityPlanChosenDocument
           source={source}
-          onClear={() => setSource(null)}
-          disabled={isReading}
+          onClear={() => {
+            setSource(null);
+            setHasFailed(false);
+          }}
+          isReading={isReading}
         />
       ) : (
         <>
           <UtilityPlanFileDropzone
-            onFile={(file) => setSource({ kind: "file", file })}
+            onFile={(file) => pick({ kind: "file", file })}
             disabled={isReading}
           />
           {documents.length > 0 && (
             <UtilityPlanLibraryPicker
               documents={documents}
-              onPick={(documentId, name) =>
-                setSource({ kind: "library", documentId, name })
-              }
+              onPick={(documentId, name) => pick({ kind: "library", documentId, name })}
               disabled={isReading}
             />
           )}
         </>
       )}
 
-      <LoadingButton
-        type="button"
-        variant="secondary"
-        size="md"
-        isLoading={isReading}
-        loadingText="Reading..."
-        disabled={isReading || !source}
-        onClick={() => void handleRead()}
-        data-testid="utility-plan-read-document-button"
-      >
-        Read the terms
-      </LoadingButton>
+      {hasFailed && source && (
+        <LoadingButton
+          type="button"
+          variant="secondary"
+          size="md"
+          isLoading={isReading}
+          loadingText="Reading..."
+          disabled={isReading}
+          onClick={() => void read(source)}
+          data-testid="utility-plan-read-document-button"
+        >
+          Try reading it again
+        </LoadingButton>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Follow-up to #1068.

## The problem

After #1068 you could pick a document from inside the dialog, but picking it only showed you a filename and enabled a "Read the terms" button. Filling the form is the entire reason the card exists, so that button was a confirm step for a decision with one possible answer.

On a phone it's worse than redundant: the file picker has just closed, you're looking at a filename, and nothing appears to have happened until you find and tap a second control.

## The change

Picking a document reads it. Both paths — a file off the device and a document from the library — start the read on selection.

- The chosen-document row doubles as the progress surface: it shows a spinner and "Reading..." while the read is in flight.
- Its clear button is withheld during the read. Swapping the document out mid-flight would race the response that is about to fill the form.
- The button comes back only after a failure, as "Try reading it again", so a transient error can be retried without re-picking the file. It disappears again on success.

## Tests

`UtilityPlanDocumentReader.test.tsx` grew to 15: reading fires on pick with no button present, the in-flight state shows the indicator and hides the clear button, a failed read offers the retry and a second attempt succeeds, and the retry button goes away again afterwards. The dialog and E2E specs drop their button clicks — the E2E now asserts the button is *absent* after picking, which is what pins the behaviour.

43 unit tests passed across the three touched specs; all 4 E2E passed at 390x844. Lint 0 errors. No backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgX4F6Unf2PbXHwHAX2fVb