### PR TITLE
perf(mbk): stop rebuilding the DB schema for every backend test (10m15s to 1m43s)

### DIFF
--- a/.github/workflows/ci-mybookkeeper.yml
+++ b/.github/workflows/ci-mybookkeeper.yml
@@ -80,7 +80,8 @@ jobs:
         working-directory: apps/mybookkeeper/backend
         # Test deps are not pinned in pyproject.toml; install into the uv venv.
         # Mirrors the standalone repo's CI pattern (pytest + pytest-asyncio + aiosqlite).
-        run: uv pip install pytest pytest-asyncio aiosqlite
+        # pytest-xdist runs the suite across cores — see the -n flag below.
+        run: uv pip install pytest pytest-asyncio aiosqlite pytest-xdist
 
       - name: Install shared-backend package
         # platform_shared lives at packages/shared-backend and is imported by
@@ -100,7 +101,10 @@ jobs:
           ANTHROPIC_API_KEY: sk-ant-placeholder-not-real
           GOOGLE_CLIENT_ID: placeholder-not-real-google-client
           GOOGLE_CLIENT_SECRET: placeholder-not-real-google-secret
-        run: uv run pytest -q -m "not integration"
+        # -n auto spreads the ~3.6k tests across the runner's cores. Each
+        # xdist worker is its own process, so the session-scoped in-memory
+        # database in tests/conftest.py is per-worker and stays isolated.
+        run: uv run pytest -q -m "not integration" -n auto
 
   frontend-build:
     name: frontend-build / mybookkeeper

--- a/apps/mybookkeeper/backend/tests/conftest.py
+++ b/apps/mybookkeeper/backend/tests/conftest.py
@@ -28,9 +28,9 @@ os.environ.setdefault("MINIO_BUCKET", "test-bucket")
 os.environ.setdefault("MINIO_PUBLIC_ENDPOINT", "test-minio:9000")
 import pytest_asyncio
 from sqlalchemy import event, JSON, String
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.dialects.postgresql import ARRAY, INET, JSONB
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from app.db.base import Base
 from app.models.organization.organization import Organization
@@ -96,10 +96,21 @@ def _patch_metadata_for_sqlite() -> None:
             table.columns[name].nullable = True
 
 
-@pytest_asyncio.fixture()
-async def db() -> AsyncGenerator[AsyncSession, None]:
-    """In-memory SQLite async session for tests."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+@pytest_asyncio.fixture(scope="session")
+async def _db_engine() -> AsyncGenerator[AsyncEngine, None]:
+    """One in-memory database, built once for the whole run.
+
+    The schema is 81 tables and 178 indexes. Creating it per test meant 259
+    DDL statements before every one of ~3.5k tests, which was the bulk of a
+    ten-minute suite. ``StaticPool`` keeps every connection pointed at the
+    same in-memory database so the schema survives between tests; isolation
+    comes from the per-test transaction in ``db`` below.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
 
     @event.listens_for(engine.sync_engine, "connect")
     def _set_fk(dbapi_conn, _rec):  # type: ignore[no-untyped-def]
@@ -110,11 +121,30 @@ async def db() -> AsyncGenerator[AsyncSession, None]:
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    async with async_session() as session:
-        yield session
+    yield engine
 
     await engine.dispose()
+
+
+@pytest_asyncio.fixture()
+async def db(_db_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
+    """A session on the shared database, emptied when the test ends.
+
+    Rows are deleted rather than rolled back: services under test commit
+    through their own sessions, and wrapping those in a savepoint made a
+    commit stop meaning what it means in production. Deleting afterwards
+    keeps commit semantics identical to a real database while still
+    skipping the schema rebuild — 81 DELETEs against mostly-empty tables
+    against 259 DDL statements.
+    """
+    session = AsyncSession(bind=_db_engine, expire_on_commit=False)
+    try:
+        yield session
+    finally:
+        await session.close()
+        async with _db_engine.begin() as conn:
+            for table in reversed(Base.metadata.sorted_tables):
+                await conn.execute(table.delete())
 
 
 test_user, test_org = make_user_fixture(

--- a/apps/mybookkeeper/scripts/run-affected-tests.sh
+++ b/apps/mybookkeeper/scripts/run-affected-tests.sh
@@ -68,18 +68,57 @@ else
   echo ""
 fi
 
-# Detect Python command — try python3 first, fall back to python, then check venv
-if python3 --version &>/dev/null; then
-  PYTHON_CMD="python3"
-elif python --version &>/dev/null; then
-  PYTHON_CMD="python"
-elif [[ -f "$REPO_ROOT/backend/.venv/Scripts/python.exe" ]]; then
-  PYTHON_CMD="$REPO_ROOT/backend/.venv/Scripts/python.exe"
-elif [[ -f "$REPO_ROOT/backend/.venv/bin/python" ]]; then
-  PYTHON_CMD="$REPO_ROOT/backend/.venv/bin/python"
-else
-  echo -e "${RED}Error: Python not found${NC}"
+# Detect the Python to run tests with.
+#
+# The venv comes first on purpose. A bare `python` on PATH is almost never the
+# one holding pytest-asyncio, and preferring it meant this script died with
+# `ModuleNotFoundError: No module named 'pytest_asyncio'` in any git worktree —
+# worktrees have no .venv of their own. Falling back to the main checkout's
+# venv is what makes the script usable from a worktree at all.
+# Resolve both paths through `cd`+`pwd` so they share one format. Comparing a
+# shell `pwd` (/c/Users/...) against a raw `git rev-parse` (C:/Users/...) on
+# Windows silently fails to match, which is how this lookup broke the first time.
+GIT_COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")"
+MAIN_CHECKOUT=""
+if [[ -n "$GIT_COMMON_DIR" ]]; then
+  MAIN_CHECKOUT="$(cd "${GIT_COMMON_DIR%/.git}" 2>/dev/null && pwd || echo "")"
+fi
+WORKTREE_ROOT="$(cd "$(git rev-parse --show-toplevel)" 2>/dev/null && pwd || echo "")"
+APP_REL="${REPO_ROOT#"$WORKTREE_ROOT"/}"
+
+for candidate in \
+  "$REPO_ROOT/backend/.venv/Scripts/python.exe" \
+  "$REPO_ROOT/backend/.venv/bin/python" \
+  "$MAIN_CHECKOUT/$APP_REL/backend/.venv/Scripts/python.exe" \
+  "$MAIN_CHECKOUT/$APP_REL/backend/.venv/bin/python"; do
+  if [[ -f "$candidate" ]]; then
+    PYTHON_CMD="$candidate"
+    break
+  fi
+done
+
+if [[ -z "${PYTHON_CMD:-}" ]]; then
+  if python3 --version &>/dev/null; then
+    PYTHON_CMD="python3"
+  elif python --version &>/dev/null; then
+    PYTHON_CMD="python"
+  else
+    echo -e "${RED}Error: Python not found${NC}"
+    exit 2
+  fi
+fi
+
+if ! "$PYTHON_CMD" -c "import pytest_asyncio" &>/dev/null; then
+  echo -e "${RED}Error: $PYTHON_CMD cannot import pytest_asyncio.${NC}"
+  echo -e "${RED}Run 'uv sync' in backend/, or point at a checkout that has a .venv.${NC}"
   exit 2
+fi
+
+# Spread the suite across cores when xdist is available. It is optional so the
+# script still runs on a venv that predates it; CI installs it explicitly.
+PYTEST_PARALLEL=()
+if "$PYTHON_CMD" -c "import xdist" &>/dev/null; then
+  PYTEST_PARALLEL=(-n auto)
 fi
 
 # Check if any shared path was modified (triggers full suite)
@@ -167,16 +206,13 @@ run_backend_tests() {
 
   cd "$REPO_ROOT/backend"
 
-  # Activate venv if it exists
-  if [[ -f ".venv/Scripts/activate" ]]; then
-    source .venv/Scripts/activate
-  elif [[ -f ".venv/bin/activate" ]]; then
-    source .venv/bin/activate
-  fi
+  # No venv activation here: $PYTHON_CMD was already resolved (and verified to
+  # import pytest_asyncio) at the top of the script, and it is the only
+  # interpreter that is correct in a worktree, where there is no local .venv.
 
   if [[ "$test_files" == "ALL" ]]; then
     echo -e "  Running: ${YELLOW}all backend tests${NC}"
-    if python -m pytest tests/ -v; then
+    if "$PYTHON_CMD" -m pytest tests/ -q "${PYTEST_PARALLEL[@]}"; then
       echo -e "  ${GREEN}Backend tests passed${NC}"
     else
       echo -e "  ${RED}Backend tests FAILED${NC}"
@@ -191,7 +227,7 @@ run_backend_tests() {
     echo -e "  Running: ${YELLOW}${#FILES[@]} test file(s)${NC}"
     echo "$test_files" | tr ',' '\n' | sed 's/^/    /'
 
-    if python -m pytest $pytest_args -v; then
+    if "$PYTHON_CMD" -m pytest $pytest_args -q "${PYTEST_PARALLEL[@]}"; then
       echo -e "  ${GREEN}Backend tests passed${NC}"
     else
       echo -e "  ${RED}Backend tests FAILED${NC}"


### PR DESCRIPTION
## The measurement

The backend suite was the single longest thing in the loop — 9–10 minutes in CI, and >10 minutes locally. I measured before changing anything:

```
3587 passed, 5 skipped in 615.26s (0:10:15)
```

The `db` fixture created a **fresh in-memory engine per test** and ran `Base.metadata.create_all`. The schema is **81 tables / 178 indexes**, so every test that touches the DB paid for 259 DDL statements before its first line ran. That was the bill — not the tests.

## The fix

Schema is created **once per session** on a `StaticPool` engine; each test's rows are deleted afterwards.

Deleting rather than rolling back is deliberate, and I tried it the other way first. Wrapping each test in a transaction with `join_transaction_mode="create_savepoint"` made `commit()` stop meaning what it means in production — services under test commit through their own sessions, and the run broke with `UNIQUE constraint failed: users.email` leaking across tests. 81 DELETEs against near-empty tables is still vastly cheaper than 259 DDL statements, and it keeps commit semantics honest.

CI additionally installs `pytest-xdist` and runs `-n auto`. Each worker is a separate process, so the session-scoped database is per-worker and isolation holds.

| | Time | Result |
|---|---|---|
| before | **615s** | 3587 passed, 5 skipped |
| after (serial) | **366s** | 3587 passed, 5 skipped |
| after + `-n auto` (32 cores) | **103s** | 3587 passed, 5 skipped |

**No tests were deleted or weakened** — identical pass counts at every step.

## Also: the targeted runner was broken in worktrees

`scripts/run-affected-tests.sh` exists precisely so you don't run everything, and it failed in a worktree — which is where most work happens.

- It preferred a bare `python` on PATH over the venv, then died with `ModuleNotFoundError: No module named 'pytest_asyncio'`. Now resolves the venv first, falls back to the **main checkout's** venv when run from a worktree (which has none of its own), and fails with a message naming the fix rather than a stack trace.
- It activated a venv and then invoked bare `python` anyway, ignoring the interpreter it had just resolved.
- Path comparison normalises through `cd`+`pwd`: a shell `pwd` yields `/c/Users/...` while `git rev-parse` yields `C:/Users/...`, and comparing the two silently never matches on Windows. That bug ate a debugging cycle on its own.
- `-n auto` is applied only when xdist is importable, so the script still works on a venv that predates it.

Verified from a worktree with no local `.venv`: `3589 passed, 5 skipped`.

## On deleting bloat

I scanned for tests that assert nothing. Nearly every hit was a legitimate does-not-raise test, where the call itself is the assertion. The waste here was per-test **cost**, not test **count**, so this PR removes none. One genuine target remains: `test_demo_service.py` re-seeds an entire demo dataset (12 months of transactions, PDF-bearing documents, tax forms) for each of 45 tests to assert one property each. Worth a follow-up that seeds once and shares — it's the top of the duration list even after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgX4F6Unf2PbXHwHAX2fVb