### PR TITLE
perf(mbk): stop the audit listener leaking into every later test

### DIFF
--- a/apps/mybookkeeper/backend/tests/conftest.py
+++ b/apps/mybookkeeper/backend/tests/conftest.py
@@ -147,6 +147,43 @@ async def db(_db_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
                 await conn.execute(table.delete())
 
 
+@pytest.fixture()
+def audit_listeners():
+    """Attach the audit listener for one test, then put the registry back.
+
+    The listener lives on the global SQLAlchemy ``Session`` class, so leaving
+    it attached makes every later test in the session write an audit row per
+    changed field — the demo-seeding tests went from 664 to 15,230 statements
+    purely from listener leakage. Any test that needs the listener must take
+    this fixture rather than calling ``register_audit_listeners()`` directly.
+
+    ``reset_registry()`` also clears the sensitive / skip sets, so the
+    import-time registrations from ``app.core.audit`` are re-applied here to
+    leave global state exactly as it was found.
+    """
+    from app.core.audit import (
+        MBK_SENSITIVE_FIELDS,
+        MBK_SKIP_FIELDS,
+        MBK_SKIP_TABLES,
+        register_audit_listeners,
+    )
+    from platform_shared.core.audit import (
+        register_sensitive_fields,
+        register_skip_fields,
+        register_skip_tables,
+        reset_registry,
+    )
+
+    register_audit_listeners()
+    try:
+        yield
+    finally:
+        reset_registry()
+        register_sensitive_fields(MBK_SENSITIVE_FIELDS)
+        register_skip_tables(MBK_SKIP_TABLES)
+        register_skip_fields(MBK_SKIP_FIELDS)
+
+
 test_user, test_org = make_user_fixture(
     user_model=User,
     org_model=Organization,

--- a/apps/mybookkeeper/backend/tests/test_applicant_audit_masking.py
+++ b/apps/mybookkeeper/backend/tests/test_applicant_audit_masking.py
@@ -19,7 +19,6 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.audit import register_audit_listeners
 from app.models.applicants.applicant import Applicant
 from app.models.applicants.reference import Reference
 from app.models.applicants.video_call_note import VideoCallNote
@@ -28,14 +27,15 @@ from app.models.system.audit_log import AuditLog
 from app.models.user.user import User
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _audit() -> None:
-    """Register audit listeners ONCE for the session.
+@pytest.fixture(autouse=True)
+def _audit(audit_listeners) -> None:
+    """Attach the audit listener for this module's tests only.
 
-    The audit listener attaches to the global ``Session`` class — registering
-    per-test would stack listeners and produce duplicate audit_log rows.
+    Delegates to the shared ``audit_listeners`` fixture so the listener is
+    detached afterwards — it lives on the global ``Session`` class, and
+    leaving it attached makes every later test in the run pay for audit
+    writes it never asked for.
     """
-    register_audit_listeners()
 
 
 class TestApplicantAuditMasking:

--- a/apps/mybookkeeper/backend/tests/test_inquiry_audit_masking.py
+++ b/apps/mybookkeeper/backend/tests/test_inquiry_audit_masking.py
@@ -14,7 +14,6 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.audit import register_audit_listeners
 from app.models.inquiries.inquiry import Inquiry
 from app.models.organization.organization import Organization
 from app.models.system.audit_log import AuditLog
@@ -22,8 +21,9 @@ from app.models.user.user import User
 
 
 @pytest.fixture(autouse=True)
-def _audit():
-    register_audit_listeners()
+def _audit(audit_listeners):
+    """Attach the audit listener for this module's tests only — see the
+    shared ``audit_listeners`` fixture for why it must be detached after."""
 
 
 class TestInquiryAuditMasking:

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_send_audit_masking.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_send_audit_masking.py
@@ -13,7 +13,6 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.audit import register_audit_listeners
 from app.models.organization.organization import Organization
 from app.models.system.audit_log import AuditLog
 from app.models.user.user import User
@@ -22,8 +21,9 @@ from app.models.welcome_manuals.welcome_manual_send import WelcomeManualSend
 
 
 @pytest.fixture(autouse=True)
-def _audit():
-    register_audit_listeners()
+def _audit(audit_listeners):
+    """Attach the audit listener for this module's tests only — see the
+    shared ``audit_listeners`` fixture for why it must be detached after."""
 
 
 class TestWelcomeManualSendAuditMasking:


### PR DESCRIPTION
## What

`tests/test_applicant_audit_masking.py` registered the SQLAlchemy audit listener in a `scope="session"` fixture and never detached it. That listener attaches to the **global `Session` class**, so once the module ran, every later test in the suite wrote one `audit_logs` INSERT per changed field.

## Evidence

Same test, empty database, only its position in the run order changed:

| position | SQL statements | time |
|---|---|---|
| demo first | 664 | 1.15s |
| demo last | 15,230 | 9.74s |

**14,566 of the 15,230 statements (96%) were `INSERT INTO audit_logs`.**

Three other hypotheses were measured and falsified first — Sentry's SQLAlchemy instrumentation, GC pressure, and SQLite freelist fragmentation (`VACUUM` in teardown). Each left the effect unchanged or made it worse. The profiler pointed at Windows asyncio/aiosqlite overhead, which turned out to be a symptom of the extra round-trips rather than the cause; counting actual SQL statements was what identified it.

## Why this is a correctness fix, not just a speed one

Tests running after the audit modules executed under different ORM behaviour than tests running before them. `test_applicant_audit_masking.py:121` had already been weakened to tolerate duplicate audit rows as a result.

## The fix

A shared `audit_listeners` fixture in `conftest.py` attaches the listener for a single test and, on teardown, calls the already-existing test-only `reset_registry()` and re-applies the import-time registrations from `app.core.audit` — leaving global state exactly as found. All three modules that need the listener go through it now.

## Result

| | before | after |
|---|---|---|
| full suite | 224.3s | **140.0s** (−38%) |
| slowest test | 10.32s | **2.71s** |

`3587 passed, 5 skipped` before and after — nothing was relying on the leak.

## Operational migration

None. Test-only change; no runtime, env, or schema impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrNVtvruwXJK7jyx78tAAG