### PR TITLE
chore(mbk): declare pytest-xdist so parallel runs work outside CI

### DIFF
--- a/.github/workflows/ci-mybookkeeper.yml
+++ b/.github/workflows/ci-mybookkeeper.yml
@@ -74,14 +74,10 @@ jobs:
 
       - name: Sync backend dependencies
         working-directory: apps/mybookkeeper/backend
+        # Installs the `dev` dependency-group too (pytest, pytest-asyncio,
+        # aiosqlite, pytest-xdist), so CI and a local `uv sync` resolve the
+        # same test toolchain from the lockfile instead of drifting.
         run: uv sync --frozen
-
-      - name: Install test-only dependencies
-        working-directory: apps/mybookkeeper/backend
-        # Test deps are not pinned in pyproject.toml; install into the uv venv.
-        # Mirrors the standalone repo's CI pattern (pytest + pytest-asyncio + aiosqlite).
-        # pytest-xdist runs the suite across cores — see the -n flag below.
-        run: uv pip install pytest pytest-asyncio aiosqlite pytest-xdist
 
       - name: Install shared-backend package
         # platform_shared lives at packages/shared-backend and is imported by

--- a/apps/mybookkeeper/backend/pyproject.toml
+++ b/apps/mybookkeeper/backend/pyproject.toml
@@ -74,4 +74,8 @@ dev = [
     "pytest>=9.0.3",
     "pytest-anyio>=0.0.0",
     "pytest-asyncio>=1.3.0",
+    # Full-suite runs spread across cores via `-n auto`. Declared here rather
+    # than installed ad-hoc in CI so a local `uv sync` gets the same parallel
+    # path CI uses — otherwise local runs silently fall back to serial.
+    "pytest-xdist>=3.6",
 ]

--- a/apps/mybookkeeper/backend/requirements.txt
+++ b/apps/mybookkeeper/backend/requirements.txt
@@ -80,6 +80,8 @@ email-validator==2.3.0
     #   pydantic
 et-xmlfile==2.0.0
     # via openpyxl
+execnet==2.1.2
+    # via pytest-xdist
 fastapi==0.136.3
     # via
     #   fastapi-users
@@ -232,8 +234,10 @@ pytest==9.1.1
     # via
     #   pytest-anyio
     #   pytest-asyncio
+    #   pytest-xdist
 pytest-anyio==0.0.0
 pytest-asyncio==1.4.0
+pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
     # via icalendar
 python-docx==1.2.0

--- a/apps/mybookkeeper/backend/uv.lock
+++ b/apps/mybookkeeper/backend/uv.lock
@@ -354,6 +354,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
@@ -818,6 +827,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-anyio" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -869,6 +879,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-anyio", specifier = ">=0.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
 ]
 
 [[package]]
@@ -1256,6 +1267,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]

--- a/apps/mybookkeeper/scripts/run-affected-tests.sh
+++ b/apps/mybookkeeper/scripts/run-affected-tests.sh
@@ -114,8 +114,10 @@ if ! "$PYTHON_CMD" -c "import pytest_asyncio" &>/dev/null; then
   exit 2
 fi
 
-# Spread the suite across cores when xdist is available. It is optional so the
-# script still runs on a venv that predates it; CI installs it explicitly.
+# Spread the suite across cores when xdist is available. Only the full-suite
+# path uses it: spinning up one worker per core costs more than it saves on a
+# targeted run of a few files, which is the common case for this script.
+# The guard keeps the script working on a venv predating the dev-group dep.
 PYTEST_PARALLEL=()
 if "$PYTHON_CMD" -c "import xdist" &>/dev/null; then
   PYTEST_PARALLEL=(-n auto)
@@ -227,7 +229,7 @@ run_backend_tests() {
     echo -e "  Running: ${YELLOW}${#FILES[@]} test file(s)${NC}"
     echo "$test_files" | tr ',' '\n' | sed 's/^/    /'
 
-    if "$PYTHON_CMD" -m pytest $pytest_args -q "${PYTEST_PARALLEL[@]}"; then
+    if "$PYTHON_CMD" -m pytest $pytest_args -q; then
       echo -e "  ${GREEN}Backend tests passed${NC}"
     else
       echo -e "  ${RED}Backend tests FAILED${NC}"


### PR DESCRIPTION
## What

CI installed `pytest-xdist` ad-hoc, while the `dev` dependency-group declared `pytest` / `pytest-asyncio` / `aiosqlite`. Since `uv sync` already installs the `dev` group, that step was redundant for three of the four packages — and the fourth never reached a local venv.

That's why local full-suite runs silently fell back to serial (~366s) while CI ran `-n auto` (1m37s): the local venv simply had no xdist.

## Changes

- `pytest-xdist>=3.6` declared in the `dev` group; `uv.lock` + `requirements.txt` regenerated with the canonical export command from CLAUDE.md
- The ad-hoc `uv pip install pytest pytest-asyncio aiosqlite pytest-xdist` CI step removed — `uv sync --frozen` covers it, so CI and local now resolve the same toolchain from the lockfile instead of drifting
- **Fixes a flaw from #1071**: `run-affected-tests.sh` applied `-n auto` to the *targeted* run as well as the full-suite run. Targeted runs are a few files and are the common case for that script, so once xdist existed locally every dev-loop invocation would have paid one-worker-per-core startup for a handful of tests. Parallelism now applies only on the full-suite path.

## Note

`requirements.txt` already carried dev-group test deps (`pytest`, `aiosqlite`) before this change; xdist follows the same existing path. Narrowing that export to `--no-dev` is out of scope here — MyJobHunter's CI installs pytest *from* `requirements.txt`, so it would need a coordinated change.

## Operational migration

None. Test-tooling only; no runtime, env, or schema impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrNVtvruwXJK7jyx78tAAG