### PR TITLE
refactor(mbk): extract EquippedPlanFigure to its own file

### DIFF
--- a/apps/mybookkeeper/frontend/src/app/features/utility/EquippedPlanCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/EquippedPlanCard.tsx
@@ -1,19 +1,11 @@
 import { annualCostCents } from "@/shared/lib/offer-stats";
 import { formatOfferRate, formatWholeDollars } from "@/shared/lib/utility-offer-format";
 import type { UtilityOfferGroup } from "@/shared/types/utility/utility-offer-group";
+import EquippedPlanFigure from "./EquippedPlanFigure";
 
 export interface EquippedPlanCardProps {
   group: UtilityOfferGroup;
   referenceAnnualKwh: number;
-}
-
-function Figure({ label, value }: { label: string; value: string }) {
-  return (
-    <div>
-      <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</dt>
-      <dd className="text-sm font-medium mt-0.5">{value}</dd>
-    </div>
-  );
 }
 
 /**
@@ -46,12 +38,15 @@ export default function EquippedPlanCard({
         {group.current_provider_name ?? "Unknown provider"}
       </p>
       <dl className="mt-3 grid grid-cols-3 lg:grid-cols-1 gap-x-4 gap-y-3">
-        <Figure label="Rate" value={rate === null ? "—" : `${formatOfferRate(rate)}/kWh`} />
-        <Figure
+        <EquippedPlanFigure
+          label="Rate"
+          value={rate === null ? "—" : `${formatOfferRate(rate)}/kWh`}
+        />
+        <EquippedPlanFigure
           label="Yearly cost"
           value={yearly === null ? "—" : formatWholeDollars(yearly)}
         />
-        <Figure
+        <EquippedPlanFigure
           label="Cost to leave"
           value={
             group.switch_cost_cents === null

--- a/apps/mybookkeeper/frontend/src/app/features/utility/EquippedPlanFigure.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/EquippedPlanFigure.tsx
@@ -1,0 +1,22 @@
+export interface EquippedPlanFigureProps {
+  label: string;
+  value: string;
+}
+
+/**
+ * One labelled figure inside the equipped-plan card's stat list.
+ *
+ * A `<dt>`/`<dd>` pair rather than two divs so the label stays bound to its
+ * value for a screen reader reading the card's `<dl>` out of order.
+ */
+export default function EquippedPlanFigure({
+  label,
+  value,
+}: EquippedPlanFigureProps) {
+  return (
+    <div>
+      <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className="text-sm font-medium mt-0.5">{value}</dd>
+    </div>
+  );
+}


### PR DESCRIPTION
`Figure` was a component-shaped helper declared inside `EquippedPlanCard.tsx`, which the one-component-per-file rule forbids regardless of export status. Surfaced by the PR-create guard while opening an unrelated insurance PR; it's pre-existing from #1066, so it gets its own PR rather than riding along.

Pure move — same markup, same props, same rendered output. `EquippedPlanCard` is its only consumer and now imports it. Named for where it belongs rather than kept as the generic `Figure`, since it carries the card's specific `<dl>` styling and isn't a general-purpose label/value primitive.

`tsc` clean; `BetterPlansSection.test.tsx` 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us3w1x8DaRELqb4frym5KH