### PR TITLE
fix(mbk): apply the SQLite type patch before test modules are imported

### DIFF
--- a/apps/mybookkeeper/backend/tests/conftest.py
+++ b/apps/mybookkeeper/backend/tests/conftest.py
@@ -33,6 +33,7 @@ from sqlalchemy.dialects.postgresql import ARRAY, INET, JSONB
 from sqlalchemy.pool import StaticPool
 
 from app.db.base import Base
+import app.models  # noqa: F401 — registers every table before the patch below
 from app.models.organization.organization import Organization
 from app.models.organization.organization_member import OrganizationMember
 from app.models.user.user import User
@@ -75,7 +76,10 @@ def _patch_storage_for_tests(monkeypatch):
 
 
 def _patch_metadata_for_sqlite() -> None:
-    """Make PostgreSQL-specific DDL compatible with SQLite for tests."""
+    """Make PostgreSQL-specific DDL compatible with SQLite for tests.
+
+    Must run before any test module is imported — see the call site below.
+    """
     for table in Base.metadata.tables.values():
         cols_to_drop: list[str] = []
         for column in table.columns:
@@ -94,6 +98,22 @@ def _patch_metadata_for_sqlite() -> None:
         for name in cols_to_drop:
             table.columns[name].computed = None
             table.columns[name].nullable = True
+
+
+# Swap the PostgreSQL-only column types at conftest import time, which pytest
+# does before it imports a single test module.
+#
+# SQLAlchemy memoizes a column's comparator on first use, and the comparator
+# is what decides how an operator renders: a JSONB column turns
+# ``Model.col.contains(...)`` into the PostgreSQL-only ``@>``, while a plain
+# JSON column renders a portable LIKE. Reassigning ``column.type`` afterwards
+# does NOT re-derive the memoized comparator. So if this patch ran later —
+# from the session-scoped engine fixture, say — any expression built before
+# the first database test kept ``@>`` and blew up on SQLite with
+# ``unrecognized token: "@"``. Which test got there first depended on
+# collection order and on how pytest-xdist happened to shard the run, so the
+# breakage moved around whenever tests were added.
+_patch_metadata_for_sqlite()
 
 
 @pytest_asyncio.fixture(scope="session")
@@ -115,8 +135,6 @@ async def _db_engine() -> AsyncGenerator[AsyncEngine, None]:
     @event.listens_for(engine.sync_engine, "connect")
     def _set_fk(dbapi_conn, _rec):  # type: ignore[no-untyped-def]
         dbapi_conn.execute("PRAGMA foreign_keys=OFF")
-
-    _patch_metadata_for_sqlite()
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)

--- a/apps/mybookkeeper/backend/tests/test_demo_service.py
+++ b/apps/mybookkeeper/backend/tests/test_demo_service.py
@@ -179,13 +179,16 @@ class TestDemoServiceAirbnbAttributionShowcase:
         org = await demo_repo.get_org_by_user(db, user.id)
         assert org is not None
 
-        airbnb_txns = (await db.execute(
+        # Tag membership is filtered in Python rather than in SQL: containment
+        # over a JSON array is spelled differently in every dialect, and the
+        # test fixture is SQLite while production is PostgreSQL.
+        income_txns = (await db.execute(
             select(Transaction).where(
                 Transaction.organization_id == org.id,
-                Transaction.tags.contains(["airbnb"]),
                 Transaction.transaction_type == "income",
             )
         )).scalars().all()
+        airbnb_txns = [t for t in income_txns if "airbnb" in (t.tags or [])]
         assert len(airbnb_txns) > 0
         for txn in airbnb_txns:
             assert txn.channel == "airbnb"

--- a/apps/mybookkeeper/backend/tests/test_sqlite_metadata_patch.py
+++ b/apps/mybookkeeper/backend/tests/test_sqlite_metadata_patch.py
@@ -1,0 +1,54 @@
+"""Regression contract for ``conftest._patch_metadata_for_sqlite``.
+
+The patch swaps PostgreSQL-only column types for SQLite-compatible ones so the
+in-memory test database can hold the production schema. It has to run before
+any test module is imported: SQLAlchemy memoizes a column's comparator the
+first time an expression touches it, and a JSONB comparator renders
+``contains()`` as the PostgreSQL-only ``@>`` operator, which SQLite rejects
+with ``unrecognized token: "@"``. Reassigning the column type afterwards does
+not undo that memoization.
+
+Left to a session-scoped fixture, the patch ran only once the first database
+test started, so whether an expression came out portable depended on collection
+order and on how pytest-xdist sharded the run — a flake that moved whenever
+tests were added.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import ARRAY, INET, JSONB
+
+from app.db.base import Base
+from app.models.transactions.transaction import Transaction
+
+_POSTGRES_ONLY_TYPES = (JSONB, INET, ARRAY)
+
+
+class TestMetadataIsSqliteCompatible:
+    def test_the_patch_ran_before_this_module_was_imported(self) -> None:
+        # If this is empty the patch never ran at all — every other assertion
+        # here would pass vacuously.
+        assert len(Base.metadata.tables) > 0
+
+    def test_no_postgres_only_column_types_remain(self) -> None:
+        offenders = [
+            f"{table.name}.{column.name} ({type(column.type).__name__})"
+            for table in Base.metadata.tables.values()
+            for column in table.columns
+            if isinstance(column.type, _POSTGRES_ONLY_TYPES)
+        ]
+        assert offenders == []
+
+    def test_json_containment_compiles_to_portable_sql(self) -> None:
+        # The specific expression that used to compile to `tags @> ?`.
+        sql = str(select(Transaction).where(Transaction.tags.contains(["airbnb"])))
+        assert "@>" not in sql
+
+    @pytest.mark.asyncio
+    async def test_json_containment_actually_executes_on_the_fixture(self, db) -> None:
+        # Compiling is not enough — SQLite has to accept the statement too.
+        rows = (await db.execute(
+            select(Transaction).where(Transaction.tags.contains(["airbnb"])),
+        )).scalars().all()
+        assert rows == []


### PR DESCRIPTION
## The failure

`backend-tests / mybookkeeper` started failing intermittently with

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unrecognized token: "@"
[SQL: ... FROM transactions
      WHERE transactions.organization_id = ?
        AND transactions.tags @> ?
        AND transactions.transaction_type = ?]
```

from `tests/test_demo_service.py`, while the same test passed in isolation and every recent run on `main` was green. Nothing about the demo service had changed — the failure surfaced on an unrelated branch that only *added* test files.

## Root cause

SQLAlchemy memoizes a column's comparator the first time an expression touches it, and the comparator decides how an operator renders:

- **JSONB** column → `Model.col.contains(...)` compiles to the PostgreSQL-only `@>`
- plain **JSON** column → compiles to a portable `LIKE`

`conftest._patch_metadata_for_sqlite` swaps JSONB→JSON by reassigning `column.type`. That reassignment does **not** re-derive an already-memoized comparator.

The patch was called from the session-scoped `_db_engine` fixture — so it ran only once the first database test started. Any expression built before that point kept `@>` and blew up on SQLite. Which test got there first depended on collection order and on how `pytest-xdist` sharded the run, so the breakage moved around whenever tests were added anywhere in the suite.

Reproduced directly:

```
comparator touched BEFORE patch -> WHERE transactions.tags @> :tags_1
patch applied first             -> WHERE (transactions.tags LIKE '%' || :tags_1 || '%')
```

## The fix

1. **`tests/conftest.py`** — call `_patch_metadata_for_sqlite()` at conftest import time, which pytest performs before it imports a single test module. Added `import app.models` above it so every table is registered by then (`app.db.base` on its own registers zero tables). Removed the now-redundant call in the engine fixture.

2. **`tests/test_demo_service.py`** — filter tag membership in Python. Under the LIKE fallback that query only matched because the seeded tag list is exactly `["airbnb"]`; a row carrying a second tag would have been silently dropped from the result set. The assertion intent is unchanged.

3. **`tests/test_sqlite_metadata_patch.py`** (new) — the regression contract: no Postgres-only column types survive in `Base.metadata`, `contains()` compiles without `@>`, and the statement actually executes on the fixture. Run against the *old* conftest, three of its four assertions fail with the exact CI error.

## Verification

- New regression test against the pre-fix conftest: **3 failed** with `unrecognized token: "@"` — the failure this PR fixes.
- Full backend suite on this branch, run the way CI runs it (`pytest -q -m "not integration" -n auto`): **3590 passed, 6 skipped in 42s**.
- `backend/tests/conftest.py` is already listed in `scripts/test-map.json` `shared_paths`, so the targeted runner falls back to the full suite on this change — no test-map update needed.

Test-only change; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us3w1x8DaRELqb4frym5KH