### PR TITLE
feat(mybookkeeper): flag insurance policies priced above the market

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/insbench260813_add_insurance_benchmarks.py
+++ b/apps/mybookkeeper/backend/alembic/versions/insbench260813_add_insurance_benchmarks.py
@@ -1,0 +1,117 @@
+"""add insurance_benchmarks
+
+``insurance_policies`` now records what a policy costs, but a premium in
+isolation cannot answer "am I overpaying" — that needs something to compare
+against. This table holds it: the typical annual premium the operator observed
+for a comparable property, and the dwelling coverage that premium buys.
+
+Both numbers are stored, not just the premium, because a premium alone is not
+comparable. "$3,506 a year" means nothing until you know what it insures. With
+the coverage recorded, both sides reduce to annual premium per $1,000 of
+dwelling coverage, which is what lets a county average assembled from mixed
+housing stock be measured against one specific policy.
+
+One row per organization. The utility sibling (``market_rate_benchmarks``) is
+keyed by service type because electricity and internet are priced in different
+units; insurance policies here carry no comparable type discriminator, so the
+benchmark describes the operator's market as a whole.
+
+Operator-entered rather than fetched: no public feed of homeowners premiums
+exists, so ``source`` and ``observed_on`` carry the provenance that makes a
+stale or mis-sourced figure visible instead of silently driving a badge.
+
+Revision ID: insbench260813
+Revises: inspremium260812
+Create Date: 2026-08-13
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "insbench260813"
+down_revision = "inspremium260812"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "insurance_benchmarks",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        # Provenance only — never a query filter. See the model docstring.
+        sa.Column(
+            "recorded_by_user_id", postgresql.UUID(as_uuid=True), nullable=True,
+        ),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("annual_premium_cents", sa.BigInteger(), nullable=False),
+        sa.Column("coverage_amount_cents", sa.BigInteger(), nullable=False),
+        sa.Column("region_label", sa.String(length=120), nullable=True),
+        sa.Column("source", sa.String(length=255), nullable=True),
+        sa.Column("observed_on", sa.Date(), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # A zero premium is not a free market rate, and a zero coverage would
+        # make the per-$1,000 normalisation divide by zero. Refused here rather
+        # than guarded in the service.
+        sa.CheckConstraint(
+            "annual_premium_cents > 0",
+            name="chk_insurance_benchmark_premium_positive",
+        ),
+        sa.CheckConstraint(
+            "coverage_amount_cents > 0",
+            name="chk_insurance_benchmark_coverage_positive",
+        ),
+        sa.ForeignKeyConstraint(
+            ["recorded_by_user_id"], ["users.id"], ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE",
+        ),
+    )
+    op.create_index(
+        "ix_insurance_benchmarks_recorded_by_user_id",
+        "insurance_benchmarks",
+        ["recorded_by_user_id"],
+    )
+    op.create_index(
+        "ix_insurance_benchmarks_organization_id",
+        "insurance_benchmarks",
+        ["organization_id"],
+    )
+    # One benchmark per org: an outdated observation has no value once a newer
+    # one exists, and two rows would leave the comparison ambiguous.
+    op.create_index(
+        "uq_insurance_benchmark_org",
+        "insurance_benchmarks",
+        ["organization_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_insurance_benchmark_org", table_name="insurance_benchmarks")
+    op.drop_index(
+        "ix_insurance_benchmarks_organization_id", table_name="insurance_benchmarks",
+    )
+    op.drop_index(
+        "ix_insurance_benchmarks_recorded_by_user_id",
+        table_name="insurance_benchmarks",
+    )
+    op.drop_table("insurance_benchmarks")

--- a/apps/mybookkeeper/backend/app/api/insurance_benchmarks.py
+++ b/apps/mybookkeeper/backend/app/api/insurance_benchmarks.py
@@ -1,0 +1,72 @@
+"""HTTP routes for the organization's insurance benchmark.
+
+Route prefix: /insurance-benchmarks.
+
+A singleton resource: there is at most one benchmark per organization, so there
+is no id in the path and the write is a PUT (idempotent upsert) rather than a
+POST/PATCH pair.
+
+The comparison these benchmarks feed lives at
+``/insurance-policies/premium-comparison`` — it returns policies, so it belongs
+on the policy resource.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.schemas.insurance.insurance_benchmark_response import (
+    InsuranceBenchmarkResponse,
+)
+from app.schemas.insurance.insurance_benchmark_upsert_request import (
+    InsuranceBenchmarkUpsertRequest,
+)
+from app.services.insurance import insurance_benchmark_service
+
+router = APIRouter(prefix="/insurance-benchmarks", tags=["insurance-benchmarks"])
+
+
+@router.get("", response_model=InsuranceBenchmarkResponse | None)
+async def get_benchmark(
+    ctx: RequestContext = Depends(current_org_member),
+) -> InsuranceBenchmarkResponse | None:
+    """The organization's recorded market observation, or null if none.
+
+    Null rather than 404: "no benchmark recorded yet" is the ordinary starting
+    state of every organization, not a client error, and the form that records
+    one renders off exactly this response.
+    """
+    return await insurance_benchmark_service.get_benchmark(
+        organization_id=ctx.organization_id,
+    )
+
+
+@router.put("", response_model=InsuranceBenchmarkResponse)
+async def upsert_benchmark(
+    payload: InsuranceBenchmarkUpsertRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> InsuranceBenchmarkResponse:
+    return await insurance_benchmark_service.upsert_benchmark(
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
+        annual_premium_cents=payload.annual_premium_cents,
+        coverage_amount_cents=payload.coverage_amount_cents,
+        region_label=payload.region_label,
+        source=payload.source,
+        observed_on=payload.observed_on,
+        notes=payload.notes,
+    )
+
+
+@router.delete("", status_code=204)
+async def delete_benchmark(
+    ctx: RequestContext = Depends(require_write_access),
+) -> Response:
+    try:
+        await insurance_benchmark_service.delete_benchmark(
+            organization_id=ctx.organization_id,
+        )
+    except insurance_benchmark_service.InsuranceBenchmarkNotFoundError:
+        raise HTTPException(status_code=404, detail="Insurance benchmark not found")
+    return Response(status_code=204)

--- a/apps/mybookkeeper/backend/app/api/insurance_policies.py
+++ b/apps/mybookkeeper/backend/app/api/insurance_policies.py
@@ -21,11 +21,14 @@ from app.schemas.insurance.insurance_policy_create_request import (
 from app.schemas.insurance.insurance_policy_list_response import (
     InsurancePolicyListResponse,
 )
+from app.schemas.insurance.insurance_policy_premium_comparison_response import (
+    InsurancePolicyPremiumComparisonResponse,
+)
 from app.schemas.insurance.insurance_policy_response import InsurancePolicyResponse
 from app.schemas.insurance.insurance_policy_update_request import (
     InsurancePolicyUpdateRequest,
 )
-from app.services.insurance import insurance_policy_service
+from app.services.insurance import insurance_benchmark_service, insurance_policy_service
 
 router = APIRouter(prefix="/insurance-policies", tags=["insurance-policies"])
 
@@ -68,6 +71,24 @@ async def list_policies(
         expiring_before=expiring_before,
         limit=limit,
         offset=offset,
+    )
+
+
+@router.get(
+    "/premium-comparison", response_model=InsurancePolicyPremiumComparisonResponse,
+)
+async def get_premium_comparison(
+    ctx: RequestContext = Depends(current_org_member),
+) -> InsurancePolicyPremiumComparisonResponse:
+    """Unexpired policies priced materially above the recorded benchmark.
+
+    Lives on the policy resource rather than the benchmark one because it
+    returns policies. Declared before ``/{policy_id}`` so the literal path is
+    not swallowed by the UUID route.
+    """
+    return await insurance_benchmark_service.get_premium_comparison(
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
     )
 
 

--- a/apps/mybookkeeper/backend/app/core/insurance_benchmark_constants.py
+++ b/apps/mybookkeeper/backend/app/core/insurance_benchmark_constants.py
@@ -1,0 +1,66 @@
+"""Constants for comparing a recorded policy against the going market premium.
+
+The insurance sibling of ``market_benchmark_constants``. Same question — "am I
+paying well above what this costs elsewhere?" — asked about a different kind of
+product, so the thresholds differ where the product does and are shared where it
+does not.
+
+The comparable unit is **annual premium per $1,000 of dwelling coverage**, never
+raw premium. Two policies both costing $1,400 a year are not the same deal if
+one covers a $250,000 dwelling and the other a $500,000 one; the second buys
+twice the protection for the same money. Raw dollars would call them equal.
+Normalising also makes an operator's policy comparable against a county average
+assembled from homes of a different size, which is the only kind of benchmark
+that exists for this market.
+
+``BENCHMARK_STATUSES`` is mirrored as a TypeScript union in
+``frontend/src/shared/types/insurance/insurance-benchmark-status.ts`` — a value
+added here MUST be added there in the same PR.
+"""
+
+# Outcome of comparing one policy against the organization's benchmark.
+#   no_benchmark   — nothing recorded to compare against; the operator has not
+#                    told us what the market looks like yet
+#   not_comparable — a benchmark exists but this policy lacks a figure the
+#                    comparison needs (no premium recorded, or no coverage
+#                    amount to normalise it against)
+#   at_or_below    — the policy is at or under the market, within tolerance
+#   above          — the policy is materially above the market; worth shopping
+BENCHMARK_STATUS_NO_BENCHMARK = "no_benchmark"
+BENCHMARK_STATUS_NOT_COMPARABLE = "not_comparable"
+BENCHMARK_STATUS_AT_OR_BELOW = "at_or_below_market"
+BENCHMARK_STATUS_ABOVE = "above_market"
+
+BENCHMARK_STATUSES: frozenset[str] = frozenset({
+    BENCHMARK_STATUS_NO_BENCHMARK,
+    BENCHMARK_STATUS_NOT_COMPARABLE,
+    BENCHMARK_STATUS_AT_OR_BELOW,
+    BENCHMARK_STATUS_ABOVE,
+})
+
+# How far above the benchmark a policy must sit before it is worth surfacing.
+#
+# Wider than the utility feature's 10%. A utility benchmark is one product's
+# advertised rate against another's; a homeowners benchmark is a county-level
+# average across a whole population of dwellings, and two houses on the same
+# street legitimately differ by more than 10% on roof age, claims history and
+# distance to a fire station. At 10% this badge would light up for policies that
+# are priced perfectly fairly, and a badge that is usually wrong is a badge the
+# operator stops reading.
+MATERIAL_GAP_PCT = 25.0
+
+# How long a recorded benchmark is treated as describing the current market.
+#
+# Much longer than the utility feature's 90 days, because the underlying data
+# moves on a different clock. Retail energy offers reprice constantly; the
+# homeowners figures published by the Texas Department of Insurance are annual,
+# and a policy itself only reprices at renewal. A year is roughly one
+# publication cycle, so this labels a benchmark stale at about the point a newer
+# one exists to replace it.
+BENCHMARK_STALE_AFTER_DAYS = 365
+
+# Coverage is normalised to units of $1,000 before the comparison.
+#
+# ``coverage_amount_cents / 100_000`` converts cents of coverage into $1,000
+# units: $500,000 of coverage is 50_000_000 cents, or 500 units.
+CENTS_PER_COVERAGE_UNIT = 100_000

--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -32,7 +32,7 @@ from app.db.session import AsyncSessionLocal
 from app.schemas.user.user import UserRead, UserCreate, UserUpdate
 from app.services.storage.bucket_initializer import ensure_bucket
 from app.workers.upload_processor_worker import main as worker_main
-from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_policies, lease_templates, listings, market_rate_benchmarks, properties, public_inquiries, public_welcome_manuals, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, exports, imports, health_dashboard, totp, taxpayer_profiles, utility_plans, welcome_manuals
+from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_benchmarks, insurance_policies, lease_templates, listings, market_rate_benchmarks, properties, public_inquiries, public_welcome_manuals, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, exports, imports, health_dashboard, totp, taxpayer_profiles, utility_plans, welcome_manuals
 
 logging.basicConfig(
     level=logging.INFO,
@@ -205,6 +205,7 @@ app.include_router(applicants.router)
 app.include_router(lease_templates.router)
 app.include_router(signed_leases.router)
 app.include_router(insurance_policies.router)
+app.include_router(insurance_benchmarks.router)
 app.include_router(utility_plans.router)
 app.include_router(market_rate_benchmarks.router)
 app.include_router(screening.router)

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -44,6 +44,7 @@ from app.models.leases.signed_lease import SignedLease
 from app.models.leases.signed_lease_attachment import SignedLeaseAttachment
 from app.models.leases.signed_lease_template import SignedLeaseTemplate
 from app.models.leases.lease_term_version import LeaseTermVersion
+from app.models.insurance.insurance_benchmark import InsuranceBenchmark
 from app.models.insurance.insurance_policy import InsurancePolicy
 from app.models.insurance.insurance_policy_attachment import InsurancePolicyAttachment
 from app.models.vendors.vendor import Vendor

--- a/apps/mybookkeeper/backend/app/models/insurance/insurance_benchmark.py
+++ b/apps/mybookkeeper/backend/app/models/insurance/insurance_benchmark.py
@@ -1,0 +1,140 @@
+"""ORM model for ``insurance_benchmarks`` — what property insurance costs here.
+
+One row per organization: the typical annual premium the operator last observed
+for a comparable property, and the dwelling coverage that premium buys.
+``insurance_policies`` records what is being paid; this records what the market
+charges, and the gap between them is the only thing a "you may be overpaying"
+flag needs.
+
+**Two numbers, not one.** A premium on its own is not comparable — "$3,506 a
+year" says nothing until you know what it insures. Storing the coverage the
+benchmark assumes lets both sides of the comparison be reduced to the same unit
+(annual premium per $1,000 of dwelling coverage), which is what makes a county
+average assembled from mixed housing stock usable against one specific policy.
+It also mirrors how a policy row itself is shaped, so the same arithmetic runs
+over both.
+
+Scoped to the **organization alone**, like ``market_rate_benchmarks`` and unlike
+almost every other table here. What the market charges is a fact about the
+market, not about the member who looked it up. ``recorded_by_user_id`` is
+provenance only and is never a query filter — filtering on it would contradict
+the unique index below, and the second member of an organization would see "no
+benchmark recorded" while their write collided with a row they could not read.
+
+**One row per organization, with no type dimension.** The utility equivalent is
+keyed by service type because electricity and internet are priced in different
+units. Insurance policies here carry no comparable type discriminator, and
+inventing one would mean guessing which bucket each policy belongs in — so the
+benchmark describes the operator's market as a whole. If policy types are ever
+modelled, this is the constraint to revisit.
+
+Deliberately operator-maintained rather than fetched. No public feed of
+homeowners premiums exists: HelpInsure's rate wizard is a session-based form
+with no API, and the Texas Department of Insurance publishes its county averages
+only through a Tableau visualisation. A wrong automatic number would be worse
+than an absent one — it would flag confidently against a market that is not
+this one. ``source`` and ``observed_on`` exist so a stale or mis-sourced
+benchmark is visible instead of silently driving the badge.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class InsuranceBenchmark(Base):
+    __tablename__ = "insurance_benchmarks"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    # Provenance, NOT a tenant key — read the class docstring before filtering
+    # on it. Nullable with ``SET NULL`` so removing the member who recorded the
+    # figure leaves the organization's benchmark standing.
+    recorded_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    # The typical annual premium, always annualised. Unlike a policy — which
+    # stores what the carrier bills and derives the year — a published benchmark
+    # is already an annual figure, so there is no billing period to preserve.
+    annual_premium_cents: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    # The dwelling coverage that premium buys. Without it the premium cannot be
+    # normalised, so it is NOT NULL: a benchmark that cannot participate in the
+    # comparison has no reason to exist.
+    coverage_amount_cents: Mapped[int] = mapped_column(BigInteger, nullable=False)
+
+    # Which market this describes, in the operator's own words — "Harris County,
+    # TX". Free text on purpose: the useful granularity varies (county, ZIP,
+    # metro) and no enum could anticipate it. Nullable because a single-market
+    # operator gains nothing from restating it.
+    region_label: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    # Where the number came from — "TDI 2025 county averages, Harris". Without
+    # it a benchmark is an unfalsifiable number.
+    source: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # The day the figure was observed, not the day the row was written, so a
+    # benchmark entered from an older publication ages from when it was true.
+    observed_on: Mapped[_dt.date] = mapped_column(Date, nullable=False)
+
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        onupdate=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        # Both must be strictly positive. A zero premium is not a free market
+        # rate, and a zero coverage would make the normalisation divide by zero
+        # — the DB refuses the row rather than leaving the service to guard it.
+        CheckConstraint(
+            "annual_premium_cents > 0",
+            name="chk_insurance_benchmark_premium_positive",
+        ),
+        CheckConstraint(
+            "coverage_amount_cents > 0",
+            name="chk_insurance_benchmark_coverage_positive",
+        ),
+        # One benchmark per org. History is not the point: an outdated market
+        # observation has no value once a newer one exists, and keeping several
+        # would leave the comparison ambiguous about which to use.
+        Index(
+            "uq_insurance_benchmark_org",
+            "organization_id",
+            unique=True,
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/repositories/insurance/insurance_benchmark_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/insurance/insurance_benchmark_repo.py
@@ -1,0 +1,127 @@
+"""Repository for ``insurance_benchmarks``.
+
+Scoped by ``organization_id`` alone — see the model docstring. The insurance
+policy tables scope by ``(user_id, organization_id)``; this one must not,
+because its unique index is ``(organization_id)`` and a narrower read filter
+would let one member's write collide with a row they cannot see.
+
+No soft delete: a benchmark is a snapshot the operator can overwrite or remove.
+A tombstone would leave two rows competing to describe one market, which the
+unique index exists to prevent.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import delete, inspect, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.insurance.insurance_benchmark import InsuranceBenchmark
+
+
+async def get_for_org(
+    db: AsyncSession, *, organization_id: uuid.UUID,
+) -> InsuranceBenchmark | None:
+    result = await db.execute(
+        select(InsuranceBenchmark).where(
+            InsuranceBenchmark.organization_id == organization_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+def _apply_values(
+    benchmark: InsuranceBenchmark,
+    *,
+    recorded_by_user_id: uuid.UUID | None,
+    annual_premium_cents: int,
+    coverage_amount_cents: int,
+    region_label: str | None,
+    source: str | None,
+    observed_on: _dt.date,
+    notes: str | None,
+) -> None:
+    benchmark.recorded_by_user_id = recorded_by_user_id
+    benchmark.annual_premium_cents = annual_premium_cents
+    benchmark.coverage_amount_cents = coverage_amount_cents
+    benchmark.region_label = region_label
+    benchmark.source = source
+    benchmark.observed_on = observed_on
+    benchmark.notes = notes
+
+
+async def upsert(
+    db: AsyncSession,
+    *,
+    recorded_by_user_id: uuid.UUID | None,
+    organization_id: uuid.UUID,
+    annual_premium_cents: int,
+    coverage_amount_cents: int,
+    region_label: str | None,
+    source: str | None,
+    observed_on: _dt.date,
+    notes: str | None,
+) -> InsuranceBenchmark:
+    """Create the org's benchmark, or replace its values.
+
+    Read-then-write rather than a dialect-specific ``ON CONFLICT``, so the query
+    stays portable to SQLite in tests like the rest of this package. The insert
+    is wrapped in a SAVEPOINT and the unique-index violation is caught: two
+    writers that both miss on the read converge on an update instead of the
+    loser surfacing as a 500. That makes the endpoint genuinely idempotent
+    rather than idempotent-if-unraced.
+    """
+    values = {
+        "recorded_by_user_id": recorded_by_user_id,
+        "annual_premium_cents": annual_premium_cents,
+        "coverage_amount_cents": coverage_amount_cents,
+        "region_label": region_label,
+        "source": source,
+        "observed_on": observed_on,
+        "notes": notes,
+    }
+
+    existing = await get_for_org(db, organization_id=organization_id)
+    if existing is not None:
+        _apply_values(existing, **values)
+        await db.flush()
+        return existing
+
+    benchmark = InsuranceBenchmark(organization_id=organization_id, **values)
+    try:
+        async with db.begin_nested():
+            db.add(benchmark)
+            await db.flush()
+    except IntegrityError:
+        # Another writer inserted this org's row between our read and our
+        # write. The SAVEPOINT rolled back, so the session is usable: re-read
+        # the winner and apply our values on top.
+        #
+        # The rollback usually evicts the pending instance itself, in which
+        # case expunging again raises InvalidRequestError — and that exception
+        # would replace the IntegrityError we are handling, turning a recovered
+        # race into a 500. Only expunge if it is still attached.
+        if inspect(benchmark).session_id is not None:
+            db.expunge(benchmark)
+        winner = await get_for_org(db, organization_id=organization_id)
+        if winner is None:
+            # The violation was not the unique index — surface it rather than
+            # swallowing a genuine constraint failure as a silent no-op.
+            raise
+        _apply_values(winner, **values)
+        await db.flush()
+        return winner
+    return benchmark
+
+
+async def delete_for_org(
+    db: AsyncSession, *, organization_id: uuid.UUID,
+) -> bool:
+    result = await db.execute(
+        delete(InsuranceBenchmark).where(
+            InsuranceBenchmark.organization_id == organization_id,
+        )
+    )
+    return (result.rowcount or 0) > 0

--- a/apps/mybookkeeper/backend/app/repositories/properties/market_rate_benchmark_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/properties/market_rate_benchmark_repo.py
@@ -15,7 +15,7 @@ import datetime as _dt
 import uuid
 from decimal import Decimal
 
-from sqlalchemy import Select, delete, select
+from sqlalchemy import Select, delete, inspect, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -130,7 +130,13 @@ async def upsert(
         # Another writer inserted this org's row between our read and our
         # write. The SAVEPOINT rolled back, so the session is usable: re-read
         # the winner and apply our values on top.
-        db.expunge(benchmark)
+        #
+        # The rollback usually evicts the pending instance itself, in which
+        # case expunging again raises InvalidRequestError — and that exception
+        # would replace the IntegrityError we are handling, turning a recovered
+        # race into a 500. Only expunge if it is still attached.
+        if inspect(benchmark).session_id is not None:
+            db.expunge(benchmark)
         winner = await get_by_service_type(
             db, organization_id=organization_id, service_type=service_type,
         )

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_benchmark_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_benchmark_response.py
@@ -1,0 +1,52 @@
+"""The organization's recorded market observation, as returned to the client.
+
+``rate_cents_per_1000_coverage`` and ``is_stale`` are both derived rather than
+stored — the rate so it can never disagree with the premium and coverage it
+comes from, and staleness so it cannot drift from the clock.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, computed_field
+
+from app.services.insurance._insurance_benchmark_compare import (
+    is_stale,
+    rate_cents_per_1000_coverage,
+)
+
+
+class InsuranceBenchmarkResponse(BaseModel):
+    id: uuid.UUID
+    annual_premium_cents: int
+    coverage_amount_cents: int
+    region_label: str | None = None
+    source: str | None = None
+    observed_on: _dt.date
+    notes: str | None = None
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def rate_cents_per_1000_coverage(self) -> Decimal | None:
+        """The benchmark in the unit the comparison actually runs on.
+
+        Surfaced so the UI can show the operator the same normalised figure
+        their policies are measured against, instead of two raw numbers they
+        would have to divide themselves.
+        """
+        rate = rate_cents_per_1000_coverage(
+            self.annual_premium_cents, self.coverage_amount_cents,
+        )
+        return None if rate is None else rate.quantize(Decimal("0.01"))
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def is_stale(self) -> bool:
+        """True once the observation is too old to describe the current market."""
+        return is_stale(self.observed_on)
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_benchmark_upsert_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_benchmark_upsert_request.py
@@ -1,0 +1,48 @@
+"""Schema for PUT /insurance-benchmarks.
+
+An upsert rather than a create/update pair: there is at most one benchmark per
+organization, so the caller never needs to know whether one already exists, and
+the route can be driven straight from a single form.
+
+Both figures are required. A premium without the coverage it buys cannot be
+normalised, and a benchmark that cannot participate in the comparison has no
+reason to exist — so this refuses the half-set pair rather than storing a row
+that would silently never match anything.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# The browser fills this field with *its* local date, which can be a calendar
+# day ahead of the server's. Rejecting on the server's date alone would 422 a
+# user east of the server for picking their own today. One day of slack absorbs
+# every real offset (max +14h) while still rejecting an actual forecast.
+_FUTURE_DATE_SLACK = _dt.timedelta(days=1)
+
+# $10,000,000/yr of premium and $1,000,000,000 of coverage are both far beyond
+# any residential policy. The caps exist to catch a cents/dollars mix-up at the
+# boundary rather than to express a real limit.
+MAX_ANNUAL_PREMIUM_CENTS = 1_000_000_000
+MAX_COVERAGE_AMOUNT_CENTS = 100_000_000_000
+
+
+class InsuranceBenchmarkUpsertRequest(BaseModel):
+    annual_premium_cents: int = Field(..., gt=0, le=MAX_ANNUAL_PREMIUM_CENTS)
+    coverage_amount_cents: int = Field(..., gt=0, le=MAX_COVERAGE_AMOUNT_CENTS)
+
+    region_label: str | None = Field(None, max_length=120)
+    source: str | None = Field(None, max_length=255)
+    observed_on: _dt.date
+    notes: str | None = Field(None, max_length=5000)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _check_observed_on(self) -> InsuranceBenchmarkUpsertRequest:
+        # A future-dated observation is a typo, not a forecast, and it would
+        # make the staleness check permanently pass.
+        if self.observed_on > _dt.date.today() + _FUTURE_DATE_SLACK:
+            raise ValueError("observed_on cannot be in the future.")
+        return self

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_premium_comparison_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_premium_comparison_response.py
@@ -1,0 +1,46 @@
+"""Dashboard payload for policies priced above the market.
+
+Shaped like ``UtilityPlanRateComparisonResponse`` so the two comparison cards
+behave identically: a short list plus a count, not a page of rows the client has
+to filter itself.
+
+Only policies that have not expired are measured. A lapsed policy's price is
+history — the operator cannot act on it, so flagging it would be noise.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.insurance.insurance_benchmark_response import (
+    InsuranceBenchmarkResponse,
+)
+from app.schemas.insurance.insurance_policy_premium_comparison_row import (
+    InsurancePolicyPremiumComparisonRow,
+)
+
+
+class InsurancePolicyPremiumComparisonResponse(BaseModel):
+    # The gap that had to be exceeded for a row to land in ``above_market``, so
+    # the UI can say "more than N% above" without hardcoding the threshold.
+    material_gap_pct: float
+    # The benchmark every row was measured against, echoed so the card can show
+    # what it is comparing to — and when that figure was last observed — without
+    # a second request. Null when none is recorded yet.
+    benchmark: InsuranceBenchmarkResponse | None = None
+    # Sorted widest gap first — the most expensive mistake reads first.
+    above_market: list[InsurancePolicyPremiumComparisonRow]
+    # Policies that could not be measured: no benchmark recorded, no premium, or
+    # no coverage amount to normalise against. Surfaced rather than dropped,
+    # because "we are not checking this one" is itself worth seeing.
+    not_compared: list[InsurancePolicyPremiumComparisonRow]
+    total_above_market: int
+    # Every unexpired policy the comparison looked at, including the ones that
+    # came back fine and so appear in neither list. Without it a portfolio
+    # priced entirely at or below market is indistinguishable from an empty
+    # one — both render as two empty lists, and only one of them is good news.
+    total_considered: int
+    # True when the benchmark is past its freshness window, so the card can
+    # caveat the whole set in one line.
+    has_stale_benchmark: bool
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_premium_comparison_row.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_premium_comparison_row.py
@@ -1,0 +1,26 @@
+"""One policy measured against the organization's insurance benchmark."""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.insurance.insurance_policy_summary import InsurancePolicySummary
+
+
+class InsurancePolicyPremiumComparisonRow(BaseModel):
+    policy: InsurancePolicySummary
+    # One of app.core.insurance_benchmark_constants.BENCHMARK_STATUSES.
+    status: str
+    # Both figures are cents of annual premium per $1,000 of dwelling coverage.
+    # Raw premiums are never compared — see _insurance_benchmark_compare.
+    policy_rate_cents_per_1000: Decimal | None = None
+    benchmark_rate_cents_per_1000: Decimal | None = None
+    # Signed: negative means the policy beats the market, which is worth showing
+    # as the evidence that an earlier switch worked.
+    gap_pct: Decimal | None = None
+    # True when the benchmark behind this row is old enough that the comparison
+    # deserves a caveat rather than a confident badge.
+    benchmark_is_stale: bool = False
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/services/insurance/_insurance_benchmark_compare.py
+++ b/apps/mybookkeeper/backend/app/services/insurance/_insurance_benchmark_compare.py
@@ -1,0 +1,142 @@
+"""Pure comparison of one insurance policy against one benchmark.
+
+No I/O, no ORM — every function takes plain values so the arithmetic that
+decides whether a badge lights up is directly testable without a database.
+
+Both sides are reduced to the same unit before anything is compared: **annual
+premium per $1,000 of dwelling coverage**. Comparing raw premiums would call a
+$1,400 policy on a $250,000 dwelling equal to a $1,400 policy on a $500,000 one,
+when the second buys twice the protection for the same money. Normalising is
+also the only way a county average assembled from mixed housing stock can be
+measured against one specific policy.
+
+The comparison is deliberately shallow. It answers "is this policy priced well
+above what the market charges?" and nothing more. It does not adjust for roof
+age, claims history, distance to a fire station, or the wind/hail deductible the
+policy carries — all of which legitimately move a premium. Those belong to
+deciding whether to *act*; requiring them would mean the flag could not fire
+until a complete underwriting model existed, which is how a comparison feature
+ends up never shipping. Surface the gap; let the operator judge it.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Protocol
+
+from app.core.insurance_benchmark_constants import (
+    BENCHMARK_STALE_AFTER_DAYS,
+    BENCHMARK_STATUS_ABOVE,
+    BENCHMARK_STATUS_AT_OR_BELOW,
+    BENCHMARK_STATUS_NO_BENCHMARK,
+    BENCHMARK_STATUS_NOT_COMPARABLE,
+    CENTS_PER_COVERAGE_UNIT,
+    MATERIAL_GAP_PCT,
+)
+
+
+class ComparablePolicy(Protocol):
+    """The parts of an insurance policy this module measures."""
+
+    premium_cents: int | None
+    premium_frequency: str | None
+    coverage_amount_cents: int | None
+
+
+class ComparableBenchmark(Protocol):
+    """The parts of a benchmark this module measures against."""
+
+    annual_premium_cents: int
+    coverage_amount_cents: int
+    observed_on: _dt.date
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyComparison:
+    """Outcome of measuring one policy against the market.
+
+    ``gap_pct`` is signed — negative means the policy beats the market, which is
+    worth showing rather than hiding, since it is the evidence that a previous
+    switch worked.
+    """
+
+    status: str
+    policy_rate_cents_per_1000: Decimal | None = None
+    benchmark_rate_cents_per_1000: Decimal | None = None
+    gap_pct: Decimal | None = None
+    is_stale: bool = False
+
+
+def rate_cents_per_1000_coverage(
+    annual_premium_cents: int | None, coverage_amount_cents: int | None,
+) -> Decimal | None:
+    """Annual premium expressed per $1,000 of dwelling coverage.
+
+    ``None`` when either half is missing or the coverage is zero — an unpriced
+    or uncovered policy has no rate, and saying so is different from saying the
+    rate is zero.
+
+    $1,344/yr against $500,000 of coverage is 268.8 cents per $1,000.
+    """
+    if annual_premium_cents is None or coverage_amount_cents is None:
+        return None
+    if coverage_amount_cents <= 0:
+        return None
+    coverage_units = Decimal(coverage_amount_cents) / Decimal(CENTS_PER_COVERAGE_UNIT)
+    return Decimal(annual_premium_cents) / coverage_units
+
+
+def is_stale(observed_on: _dt.date, *, today: _dt.date | None = None) -> bool:
+    """True once an observation is too old to describe the current market."""
+    reference = today or _dt.date.today()
+    return (reference - observed_on).days > BENCHMARK_STALE_AFTER_DAYS
+
+
+def compare(
+    policy_annual_premium_cents: int | None,
+    policy_coverage_amount_cents: int | None,
+    benchmark: ComparableBenchmark | None,
+    *,
+    today: _dt.date | None = None,
+    material_gap_pct: float = MATERIAL_GAP_PCT,
+) -> PolicyComparison:
+    """Classify one policy against the organization's benchmark.
+
+    Takes the policy's *annualised* premium rather than the policy row, because
+    annualising is ``premium_math``'s job and doing it in two places is how the
+    two figures drift apart.
+    """
+    if benchmark is None:
+        return PolicyComparison(status=BENCHMARK_STATUS_NO_BENCHMARK)
+
+    stale = is_stale(benchmark.observed_on, today=today)
+    market = rate_cents_per_1000_coverage(
+        benchmark.annual_premium_cents, benchmark.coverage_amount_cents,
+    )
+    mine = rate_cents_per_1000_coverage(
+        policy_annual_premium_cents, policy_coverage_amount_cents,
+    )
+
+    if market is None or mine is None:
+        # A policy with a premium but no coverage amount lands here rather than
+        # being compared on raw dollars. Comparing an unnormalised premium
+        # against a normalised benchmark would be a confidently wrong verdict,
+        # which is worse than declining to answer.
+        return PolicyComparison(status=BENCHMARK_STATUS_NOT_COMPARABLE, is_stale=stale)
+
+    gap_pct = (mine - market) / market * Decimal(100)
+    status = (
+        BENCHMARK_STATUS_ABOVE
+        if gap_pct > Decimal(str(material_gap_pct))
+        else BENCHMARK_STATUS_AT_OR_BELOW
+    )
+    return PolicyComparison(
+        status=status,
+        # Quantized for transport: the extra digits are false precision on a
+        # hand-recorded benchmark, and they make the JSON noisy to read.
+        policy_rate_cents_per_1000=mine.quantize(Decimal("0.01")),
+        benchmark_rate_cents_per_1000=market.quantize(Decimal("0.01")),
+        gap_pct=gap_pct.quantize(Decimal("0.1")),
+        is_stale=stale,
+    )

--- a/apps/mybookkeeper/backend/app/services/insurance/insurance_benchmark_service.py
+++ b/apps/mybookkeeper/backend/app/services/insurance/insurance_benchmark_service.py
@@ -1,0 +1,177 @@
+"""Service layer for the insurance benchmark and the premium comparison.
+
+Two responsibilities, both thin:
+
+CRUD over the operator's recorded market observation — at most one per
+organization, so the write is an upsert with no key beyond the org.
+
+``get_premium_comparison``, which measures every unexpired policy against that
+benchmark. It mirrors the utility feature's ``get_rate_comparison``: same
+"sorted worst first, plus a count" shape, so the two dashboard cards behave
+identically.
+
+All data access goes through repositories; this module never imports SQLAlchemy.
+The arithmetic is pure and lives in ``_insurance_benchmark_compare``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from app.core.insurance_benchmark_constants import (
+    BENCHMARK_STATUS_ABOVE,
+    BENCHMARK_STATUS_AT_OR_BELOW,
+    MATERIAL_GAP_PCT,
+)
+from app.db.session import unit_of_work
+from app.repositories.insurance import (
+    insurance_benchmark_repo,
+    insurance_policy_repo,
+)
+from app.schemas.insurance.insurance_benchmark_response import (
+    InsuranceBenchmarkResponse,
+)
+from app.schemas.insurance.insurance_policy_premium_comparison_response import (
+    InsurancePolicyPremiumComparisonResponse,
+)
+from app.schemas.insurance.insurance_policy_premium_comparison_row import (
+    InsurancePolicyPremiumComparisonRow,
+)
+from app.schemas.insurance.insurance_policy_summary import InsurancePolicySummary
+from app.services.insurance._insurance_benchmark_compare import compare
+from app.services.insurance.premium_math import annual_premium_cents
+
+# The comparison never pages. One benchmark measures every policy the operator
+# holds, and a portfolio of insurance policies is bounded by the number of
+# listings — this is not a table that grows without limit.
+_COMPARISON_PAGE_SIZE = 500
+
+
+class InsuranceBenchmarkNotFoundError(LookupError):
+    pass
+
+
+async def get_benchmark(
+    *, organization_id: uuid.UUID,
+) -> InsuranceBenchmarkResponse | None:
+    async with unit_of_work() as db:
+        row = await insurance_benchmark_repo.get_for_org(
+            db, organization_id=organization_id,
+        )
+        return None if row is None else InsuranceBenchmarkResponse.model_validate(row)
+
+
+async def upsert_benchmark(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    annual_premium_cents: int,
+    coverage_amount_cents: int,
+    region_label: str | None,
+    source: str | None,
+    observed_on: _dt.date,
+    notes: str | None,
+) -> InsuranceBenchmarkResponse:
+    async with unit_of_work() as db:
+        row = await insurance_benchmark_repo.upsert(
+            db,
+            recorded_by_user_id=user_id,
+            organization_id=organization_id,
+            annual_premium_cents=annual_premium_cents,
+            coverage_amount_cents=coverage_amount_cents,
+            region_label=region_label,
+            source=source,
+            observed_on=observed_on,
+            notes=notes,
+        )
+        return InsuranceBenchmarkResponse.model_validate(row)
+
+
+async def delete_benchmark(*, organization_id: uuid.UUID) -> None:
+    async with unit_of_work() as db:
+        deleted = await insurance_benchmark_repo.delete_for_org(
+            db, organization_id=organization_id,
+        )
+    if not deleted:
+        raise InsuranceBenchmarkNotFoundError
+
+
+def _is_expired(policy_expiration: _dt.date | None, today: _dt.date) -> bool:
+    """A policy whose term has already ended.
+
+    Unexpired includes policies with no expiration date recorded: an unknown
+    end date is not evidence the policy has lapsed, and dropping those rows
+    would silently exclude them from the comparison.
+    """
+    return policy_expiration is not None and policy_expiration < today
+
+
+async def get_premium_comparison(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    today: _dt.date | None = None,
+) -> InsurancePolicyPremiumComparisonResponse:
+    """Every unexpired policy measured against the organization's benchmark."""
+    reference = today or _dt.date.today()
+
+    async with unit_of_work() as db:
+        benchmark = await insurance_benchmark_repo.get_for_org(
+            db, organization_id=organization_id,
+        )
+        rows = await insurance_policy_repo.list_for_org(
+            db,
+            user_id=user_id,
+            organization_id=organization_id,
+            limit=_COMPARISON_PAGE_SIZE,
+            offset=0,
+        )
+
+    above: list[InsurancePolicyPremiumComparisonRow] = []
+    not_compared: list[InsurancePolicyPremiumComparisonRow] = []
+    considered = 0
+
+    for row in rows:
+        if _is_expired(row.expiration_date, reference):
+            continue
+        considered += 1
+        summary = InsurancePolicySummary.model_validate(row)
+        result = compare(
+            annual_premium_cents(row.premium_cents, row.premium_frequency),
+            row.coverage_amount_cents,
+            benchmark,
+            today=reference,
+        )
+        comparison_row = InsurancePolicyPremiumComparisonRow(
+            policy=summary,
+            status=result.status,
+            policy_rate_cents_per_1000=result.policy_rate_cents_per_1000,
+            benchmark_rate_cents_per_1000=result.benchmark_rate_cents_per_1000,
+            gap_pct=result.gap_pct,
+            benchmark_is_stale=result.is_stale,
+        )
+        if result.status == BENCHMARK_STATUS_ABOVE:
+            above.append(comparison_row)
+        elif result.status != BENCHMARK_STATUS_AT_OR_BELOW:
+            # no_benchmark and not_comparable. A policy that is at or below the
+            # market is deliberately absent from both lists: it needs no action
+            # and no explanation, and listing it would bury the ones that do.
+            not_compared.append(comparison_row)
+
+    # Widest gap first — the most expensive mistake reads first. ``gap_pct`` is
+    # never None on an above-market row, but the fallback keeps the sort total
+    # rather than trusting that invariant at runtime.
+    above.sort(key=lambda r: r.gap_pct or 0, reverse=True)
+
+    return InsurancePolicyPremiumComparisonResponse(
+        material_gap_pct=MATERIAL_GAP_PCT,
+        benchmark=(
+            None if benchmark is None
+            else InsuranceBenchmarkResponse.model_validate(benchmark)
+        ),
+        above_market=above,
+        not_compared=not_compared,
+        total_above_market=len(above),
+        total_considered=considered,
+        has_stale_benchmark=any(r.benchmark_is_stale for r in above + not_compared),
+    )

--- a/apps/mybookkeeper/backend/tests/test_insurance_benchmark_compare.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_benchmark_compare.py
@@ -1,0 +1,181 @@
+"""Unit tests for the pure insurance-premium comparison.
+
+No database — every function here takes plain values, which is the point of
+keeping the arithmetic that decides whether a badge lights up out of the
+service layer.
+
+The case that matters most is normalisation: two policies with the same premium
+and different coverage are not the same deal, and a comparison that missed that
+would flag the wrong one.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from decimal import Decimal
+
+from app.core.insurance_benchmark_constants import (
+    BENCHMARK_STALE_AFTER_DAYS,
+    BENCHMARK_STATUS_ABOVE,
+    BENCHMARK_STATUS_AT_OR_BELOW,
+    BENCHMARK_STATUS_NO_BENCHMARK,
+    BENCHMARK_STATUS_NOT_COMPARABLE,
+    MATERIAL_GAP_PCT,
+)
+from app.services.insurance._insurance_benchmark_compare import (
+    compare,
+    is_stale,
+    rate_cents_per_1000_coverage,
+)
+
+TODAY = _dt.date(2026, 8, 13)
+
+# $1,200/yr on $400,000 of coverage — 300 cents per $1,000.
+MARKET_PREMIUM_CENTS = 120_000
+MARKET_COVERAGE_CENTS = 40_000_000_00 // 100  # $400,000 in cents
+
+
+class _Benchmark:
+    """Minimal stand-in for the columns the comparison reads."""
+
+    def __init__(
+        self,
+        *,
+        annual_premium_cents: int = MARKET_PREMIUM_CENTS,
+        coverage_amount_cents: int = MARKET_COVERAGE_CENTS,
+        observed_on: _dt.date = TODAY,
+    ) -> None:
+        self.annual_premium_cents = annual_premium_cents
+        self.coverage_amount_cents = coverage_amount_cents
+        self.observed_on = observed_on
+
+
+class TestRateCentsPer1000Coverage:
+    def test_divides_the_premium_by_coverage_in_thousands(self) -> None:
+        # $1,344/yr on $500,000 → 500 units of $1,000 → 268.8 cents each.
+        assert rate_cents_per_1000_coverage(134_400, 50_000_000) == Decimal("268.8")
+
+    def test_same_premium_on_more_coverage_is_a_lower_rate(self) -> None:
+        """The whole reason the comparison normalises at all."""
+        small = rate_cents_per_1000_coverage(140_000, 25_000_000)
+        large = rate_cents_per_1000_coverage(140_000, 50_000_000)
+        assert small is not None and large is not None
+        assert large < small
+
+    def test_missing_half_yields_no_rate_rather_than_zero(self) -> None:
+        """Zero would read as a free policy and beat every benchmark."""
+        assert rate_cents_per_1000_coverage(None, 50_000_000) is None
+        assert rate_cents_per_1000_coverage(134_400, None) is None
+
+    def test_zero_coverage_yields_no_rate_rather_than_dividing(self) -> None:
+        assert rate_cents_per_1000_coverage(134_400, 0) is None
+        assert rate_cents_per_1000_coverage(134_400, -1) is None
+
+
+class TestIsStale:
+    def test_fresh_observation_is_not_stale(self) -> None:
+        assert is_stale(TODAY - _dt.timedelta(days=1), today=TODAY) is False
+
+    def test_boundary_day_is_not_yet_stale(self) -> None:
+        observed = TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS)
+        assert is_stale(observed, today=TODAY) is False
+
+    def test_one_day_past_the_window_is_stale(self) -> None:
+        observed = TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS + 1)
+        assert is_stale(observed, today=TODAY) is True
+
+    def test_window_is_a_year_because_policies_reprice_at_renewal(self) -> None:
+        """Shorter than a year would flag a benchmark stale before the thing it
+        measures has had any chance to change."""
+        assert BENCHMARK_STALE_AFTER_DAYS >= 365
+
+
+class TestCompare:
+    def test_no_benchmark_short_circuits(self) -> None:
+        result = compare(134_400, 50_000_000, None)
+        assert result.status == BENCHMARK_STATUS_NO_BENCHMARK
+        assert result.gap_pct is None
+
+    def test_materially_higher_rate_is_above_market(self) -> None:
+        # $2,000/yr on $400,000 → 500¢ per $1,000 against a 300¢ market: +66.7%.
+        result = compare(200_000, MARKET_COVERAGE_CENTS, _Benchmark(), today=TODAY)
+        assert result.status == BENCHMARK_STATUS_ABOVE
+        assert result.policy_rate_cents_per_1000 == Decimal("500.00")
+        assert result.benchmark_rate_cents_per_1000 == Decimal("300.00")
+        assert result.gap_pct == Decimal("66.7")
+
+    def test_gap_inside_the_threshold_is_not_flagged(self) -> None:
+        """A county average spans houses that legitimately differ by more than
+        a rounding error — 20% apart is not evidence of overpaying."""
+        result = compare(144_000, MARKET_COVERAGE_CENTS, _Benchmark(), today=TODAY)
+        assert result.gap_pct == Decimal("20.0")
+        assert result.status == BENCHMARK_STATUS_AT_OR_BELOW
+
+    def test_threshold_is_exclusive_so_exactly_the_threshold_is_not_flagged(
+        self,
+    ) -> None:
+        premium = int(MARKET_PREMIUM_CENTS * (1 + MATERIAL_GAP_PCT / 100))
+        result = compare(premium, MARKET_COVERAGE_CENTS, _Benchmark(), today=TODAY)
+        assert result.gap_pct == Decimal(str(MATERIAL_GAP_PCT))
+        assert result.status == BENCHMARK_STATUS_AT_OR_BELOW
+
+    def test_beating_the_market_reports_a_negative_gap(self) -> None:
+        result = compare(90_000, MARKET_COVERAGE_CENTS, _Benchmark(), today=TODAY)
+        assert result.status == BENCHMARK_STATUS_AT_OR_BELOW
+        assert result.gap_pct is not None and result.gap_pct < 0
+
+    def test_more_coverage_for_the_same_premium_is_not_flagged(self) -> None:
+        """The normalisation earning its keep: an identical premium buying twice
+        the market's coverage is a bargain, not an overpay."""
+        expensive_looking = compare(
+            MARKET_PREMIUM_CENTS,
+            MARKET_COVERAGE_CENTS * 2,
+            _Benchmark(),
+            today=TODAY,
+        )
+        assert expensive_looking.status == BENCHMARK_STATUS_AT_OR_BELOW
+
+    def test_policy_without_coverage_is_not_comparable(self) -> None:
+        """Compared on raw dollars it would look cheap or dear at random."""
+        result = compare(200_000, None, _Benchmark(), today=TODAY)
+        assert result.status == BENCHMARK_STATUS_NOT_COMPARABLE
+        assert result.gap_pct is None
+
+    def test_policy_without_a_premium_is_not_comparable(self) -> None:
+        result = compare(None, MARKET_COVERAGE_CENTS, _Benchmark(), today=TODAY)
+        assert result.status == BENCHMARK_STATUS_NOT_COMPARABLE
+
+    def test_stale_benchmark_still_compares_but_is_marked(self) -> None:
+        """Old data is worth caveating, not worth discarding."""
+        result = compare(
+            200_000,
+            MARKET_COVERAGE_CENTS,
+            _Benchmark(
+                observed_on=TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS + 1),
+            ),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_ABOVE
+        assert result.is_stale is True
+
+    def test_not_comparable_still_reports_staleness(self) -> None:
+        result = compare(
+            200_000,
+            None,
+            _Benchmark(
+                observed_on=TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS + 1),
+            ),
+            today=TODAY,
+        )
+        assert result.status == BENCHMARK_STATUS_NOT_COMPARABLE
+        assert result.is_stale is True
+
+    def test_threshold_is_caller_supplied(self) -> None:
+        args = (144_000, MARKET_COVERAGE_CENTS, _Benchmark())
+        assert (
+            compare(*args, today=TODAY, material_gap_pct=10.0).status
+            == BENCHMARK_STATUS_ABOVE
+        )
+        assert (
+            compare(*args, today=TODAY, material_gap_pct=50.0).status
+            == BENCHMARK_STATUS_AT_OR_BELOW
+        )

--- a/apps/mybookkeeper/backend/tests/test_insurance_benchmark_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_benchmark_repo.py
@@ -1,0 +1,157 @@
+"""Repository-level tests for ``insurance_benchmarks``.
+
+Two things are worth pinning here that the service tests cannot see: the
+singleton-per-organization invariant the unique index enforces, and the
+race-loser path in ``upsert`` — the branch that turns a concurrent insert from
+a 500 into a second update.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.insurance.insurance_benchmark import InsuranceBenchmark
+from app.repositories.insurance import insurance_benchmark_repo
+
+pytestmark = pytest.mark.asyncio
+
+TODAY = _dt.date(2026, 8, 13)
+
+
+async def _upsert(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    *,
+    user_id: uuid.UUID | None = None,
+    annual_premium_cents: int = 120_000,
+    coverage_amount_cents: int = 40_000_000,
+    source: str | None = "TDI HelpInsure",
+) -> InsuranceBenchmark:
+    return await insurance_benchmark_repo.upsert(
+        db,
+        recorded_by_user_id=user_id,
+        organization_id=org_id,
+        annual_premium_cents=annual_premium_cents,
+        coverage_amount_cents=coverage_amount_cents,
+        region_label="Harris County, TX",
+        source=source,
+        observed_on=TODAY,
+        notes=None,
+    )
+
+
+class TestUpsert:
+    async def test_creates_when_absent(self, db: AsyncSession) -> None:
+        org_id = uuid.uuid4()
+        saved = await _upsert(db, org_id)
+
+        assert saved.organization_id == org_id
+        assert saved.annual_premium_cents == 120_000
+        assert await insurance_benchmark_repo.get_for_org(
+            db, organization_id=org_id,
+        ) is not None
+
+    async def test_second_write_updates_rather_than_inserting(
+        self, db: AsyncSession,
+    ) -> None:
+        """One benchmark per organization — a second row would leave two
+        figures competing to describe the same market."""
+        org_id = uuid.uuid4()
+        first = await _upsert(db, org_id)
+        second = await _upsert(db, org_id, annual_premium_cents=150_000)
+
+        assert second.id == first.id
+        rows = (
+            await db.execute(
+                select(InsuranceBenchmark).where(
+                    InsuranceBenchmark.organization_id == org_id,
+                ),
+            )
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].annual_premium_cents == 150_000
+
+    async def test_a_racing_insert_converges_on_an_update(
+        self, db: AsyncSession,
+    ) -> None:
+        """Simulates the loser of a concurrent write: the row appears between
+        the read and the insert. The SAVEPOINT catches the unique violation and
+        the caller ends up updating the winner instead of seeing a 500."""
+        org_id = uuid.uuid4()
+        real_get = insurance_benchmark_repo.get_for_org
+        calls = {"n": 0}
+
+        async def _get_missing_first(db_arg, *, organization_id):
+            # First read reports "absent" even though the row is about to exist;
+            # later reads (including the post-IntegrityError re-read) tell the
+            # truth.
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return None
+            return await real_get(db_arg, organization_id=organization_id)
+
+        # The winner's row, already committed by the other writer.
+        await _upsert(db, org_id, source="Winner")
+
+        insurance_benchmark_repo.get_for_org = _get_missing_first  # type: ignore[assignment]
+        try:
+            result = await _upsert(db, org_id, source="Loser", annual_premium_cents=99_000)
+        finally:
+            insurance_benchmark_repo.get_for_org = real_get  # type: ignore[assignment]
+
+        assert result.source == "Loser"
+        assert result.annual_premium_cents == 99_000
+        rows = (
+            await db.execute(
+                select(InsuranceBenchmark).where(
+                    InsuranceBenchmark.organization_id == org_id,
+                ),
+            )
+        ).scalars().all()
+        assert len(rows) == 1
+
+    async def test_organizations_do_not_share_a_benchmark(
+        self, db: AsyncSession,
+    ) -> None:
+        org_a, org_b = uuid.uuid4(), uuid.uuid4()
+        await _upsert(db, org_a, annual_premium_cents=120_000)
+        await _upsert(db, org_b, annual_premium_cents=200_000)
+
+        a = await insurance_benchmark_repo.get_for_org(db, organization_id=org_a)
+        b = await insurance_benchmark_repo.get_for_org(db, organization_id=org_b)
+        assert a is not None and b is not None
+        assert a.annual_premium_cents == 120_000
+        assert b.annual_premium_cents == 200_000
+
+
+class TestDeleteForOrg:
+    async def test_reports_whether_anything_was_removed(
+        self, db: AsyncSession,
+    ) -> None:
+        org_id = uuid.uuid4()
+        await _upsert(db, org_id)
+
+        assert await insurance_benchmark_repo.delete_for_org(
+            db, organization_id=org_id,
+        ) is True
+        # The second call has nothing to remove — the service turns this into
+        # a 404 rather than reporting a delete that did not happen.
+        assert await insurance_benchmark_repo.delete_for_org(
+            db, organization_id=org_id,
+        ) is False
+
+    async def test_does_not_touch_another_organizations_row(
+        self, db: AsyncSession,
+    ) -> None:
+        org_a, org_b = uuid.uuid4(), uuid.uuid4()
+        await _upsert(db, org_a)
+        await _upsert(db, org_b)
+
+        await insurance_benchmark_repo.delete_for_org(db, organization_id=org_a)
+        assert await insurance_benchmark_repo.get_for_org(
+            db, organization_id=org_b,
+        ) is not None

--- a/apps/mybookkeeper/backend/tests/test_insurance_benchmark_service.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_benchmark_service.py
@@ -1,0 +1,435 @@
+"""Tests for the insurance benchmark service and the premium comparison.
+
+The arithmetic itself is covered in ``test_insurance_benchmark_compare.py``.
+What these pin is the orchestration around it: which policies get measured
+(unexpired ones only), how unmeasurable policies are surfaced rather than
+dropped, the ordering that puts the most expensive mistake first, and the
+upsert semantics of a per-organization singleton.
+
+The service opens its own session via ``unit_of_work()``; ``_make_fake_uow``
+patches it to yield the in-memory SQLite test session instead.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.insurance_benchmark_constants import (
+    BENCHMARK_STALE_AFTER_DAYS,
+    BENCHMARK_STATUS_NOT_COMPARABLE,
+    BENCHMARK_STATUS_NO_BENCHMARK,
+)
+from app.models.listings.listing import Listing
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.insurance import insurance_benchmark_repo, insurance_policy_repo
+from app.services.insurance import insurance_benchmark_service
+
+pytestmark = pytest.mark.asyncio
+
+TODAY = _dt.date(2026, 8, 13)
+
+_UOW_TARGET = "app.services.insurance.insurance_benchmark_service.unit_of_work"
+
+# $1,200/yr on $400,000 → 300 cents per $1,000 of coverage.
+MARKET_PREMIUM_CENTS = 120_000
+MARKET_COVERAGE_CENTS = 40_000_000
+
+
+def _make_fake_uow(session: AsyncSession):
+    @asynccontextmanager
+    async def _fake_uow():
+        yield session
+    return _fake_uow
+
+
+async def _make_listing(
+    db: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID,
+) -> Listing:
+    listing = Listing(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        property_id=uuid.uuid4(),
+        title="6732 Peerless St",
+        slug=f"peerless-{uuid.uuid4().hex[:6]}",
+        status="active",
+        room_type="private_room",
+        monthly_rate=1500.00,
+    )
+    db.add(listing)
+    await db.flush()
+    return listing
+
+
+async def _make_policy(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    listing_id: uuid.UUID,
+    policy_name: str = "Dwelling HO-3",
+    premium_cents: int | None = 200_000,
+    premium_frequency: str | None = "annual",
+    coverage_amount_cents: int | None = MARKET_COVERAGE_CENTS,
+    expiration_date: _dt.date | None = _dt.date(2027, 3, 1),
+):
+    return await insurance_policy_repo.create(
+        db,
+        user_id=user_id,
+        organization_id=org_id,
+        listing_id=listing_id,
+        policy_name=policy_name,
+        premium_cents=premium_cents,
+        premium_frequency=premium_frequency,
+        coverage_amount_cents=coverage_amount_cents,
+        expiration_date=expiration_date,
+    )
+
+
+async def _make_benchmark(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    annual_premium_cents: int = MARKET_PREMIUM_CENTS,
+    coverage_amount_cents: int = MARKET_COVERAGE_CENTS,
+    observed_on: _dt.date = TODAY,
+):
+    return await insurance_benchmark_repo.upsert(
+        db,
+        recorded_by_user_id=user_id,
+        organization_id=org_id,
+        annual_premium_cents=annual_premium_cents,
+        coverage_amount_cents=coverage_amount_cents,
+        region_label="Harris County, TX",
+        source="TDI HelpInsure, HO-3, $2,500 deductible",
+        observed_on=observed_on,
+        notes=None,
+    )
+
+
+class TestBenchmarkCrud:
+    async def test_get_returns_none_before_anything_is_recorded(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The ordinary starting state of every organization, not an error."""
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            assert (
+                await insurance_benchmark_service.get_benchmark(
+                    organization_id=test_org.id,
+                )
+                is None
+            )
+
+    async def test_upsert_creates_then_replaces_the_single_row(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            first = await insurance_benchmark_service.upsert_benchmark(
+                user_id=test_user.id,
+                organization_id=test_org.id,
+                annual_premium_cents=MARKET_PREMIUM_CENTS,
+                coverage_amount_cents=MARKET_COVERAGE_CENTS,
+                region_label="Harris County, TX",
+                source="TDI HelpInsure",
+                observed_on=TODAY,
+                notes=None,
+            )
+            second = await insurance_benchmark_service.upsert_benchmark(
+                user_id=test_user.id,
+                organization_id=test_org.id,
+                annual_premium_cents=150_000,
+                coverage_amount_cents=MARKET_COVERAGE_CENTS,
+                region_label="Harris County, TX",
+                source="Renewal quote",
+                observed_on=TODAY,
+                notes=None,
+            )
+
+        # Same row updated, not a second one — the org has one benchmark.
+        assert second.id == first.id
+        assert second.annual_premium_cents == 150_000
+
+    async def test_response_carries_the_normalised_rate(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """So the UI can show the same figure policies are measured against."""
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            saved = await insurance_benchmark_service.upsert_benchmark(
+                user_id=test_user.id,
+                organization_id=test_org.id,
+                annual_premium_cents=MARKET_PREMIUM_CENTS,
+                coverage_amount_cents=MARKET_COVERAGE_CENTS,
+                region_label=None,
+                source=None,
+                observed_on=TODAY,
+                notes=None,
+            )
+        assert saved.rate_cents_per_1000_coverage == Decimal("300.00")
+
+    async def test_delete_removes_it_and_then_reports_not_found(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        await _make_benchmark(db, org_id=test_org.id, user_id=test_user.id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            await insurance_benchmark_service.delete_benchmark(
+                organization_id=test_org.id,
+            )
+            with pytest.raises(
+                insurance_benchmark_service.InsuranceBenchmarkNotFoundError,
+            ):
+                await insurance_benchmark_service.delete_benchmark(
+                    organization_id=test_org.id,
+                )
+
+    async def test_one_org_cannot_read_anothers_benchmark(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        await _make_benchmark(db, org_id=test_org.id, user_id=test_user.id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            assert (
+                await insurance_benchmark_service.get_benchmark(
+                    organization_id=uuid.uuid4(),
+                )
+                is None
+            )
+
+
+class TestGetPremiumComparison:
+    async def test_flags_a_policy_priced_above_the_market(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        # $2,000/yr on $400,000 → 500¢ per $1,000 against a 300¢ market.
+        await _make_policy(
+            db, org_id=test_org.id, user_id=test_user.id, listing_id=listing.id,
+        )
+        await _make_benchmark(db, org_id=test_org.id, user_id=test_user.id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await insurance_benchmark_service.get_premium_comparison(
+                user_id=test_user.id, organization_id=test_org.id, today=TODAY,
+            )
+
+        assert result.total_above_market == 1
+        assert result.total_considered == 1
+        row = result.above_market[0]
+        assert row.policy.policy_name == "Dwelling HO-3"
+        assert row.gap_pct == Decimal("66.7")
+        assert result.has_stale_benchmark is False
+        # Echoed so the card can name what it compared against.
+        assert result.benchmark is not None
+        assert result.benchmark.rate_cents_per_1000_coverage == Decimal("300.00")
+
+    async def test_a_well_priced_policy_appears_in_neither_list(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """At-or-below is the quiet case — nothing for the operator to do."""
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            listing_id=listing.id,
+            premium_cents=110_000,
+        )
+        await _make_benchmark(db, org_id=test_org.id, user_id=test_user.id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await insurance_benchmark_service.get_premium_comparison(
+                user_id=test_user.id, organization_id=test_org.id, today=TODAY,
+            )
+
+        assert result.above_market == []
+        assert result.not_compared == []
+        # But it was looked at — without this the card could not tell an
+        # all-clear from an empty portfolio.
+        assert result.total_considered == 1
+
+    async def test_premium_is_annualised_before_it_is_compared(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """$167/mo is $2,004/yr — comparing the monthly figure raw would call
+        the most expensive policy in the portfolio a bargain."""
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            listing_id=listing.id,
+            premium_cents=16_700,
+            premium_frequency="monthly",
+        )
+        await _make_benchmark(db, org_id=test_org.id, user_id=test_user.id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await insurance_benchmark_service.get_premium_comparison(
+                user_id=test_user.id, organization_id=test_org.id, today=TODAY,
+            )
+
+        assert result.total_above_market == 1
+
+    async def test_expired_policies_are_not_measured(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """A lapsed policy's price is history; flagging it would be noise."""
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            listing_id=listing.id,
+            policy_name="Lapsed and expensive",
+            premium_cents=400_000,
+            expiration_date=TODAY - _dt.timedelta(days=1),
+        )
+        await _make_benchmark(db, org_id=test_org.id, user_id=test_user.id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await insurance_benchmark_service.get_premium_comparison(
+                user_id=test_user.id, organization_id=test_org.id, today=TODAY,
+            )
+
+        assert result.above_market == []
+        assert result.total_considered == 0
+
+    async def test_a_policy_with_no_expiration_date_is_still_measured(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """An unknown end date is not evidence the policy lapsed."""
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            listing_id=listing.id,
+            expiration_date=None,
+        )
+        await _make_benchmark(db, org_id=test_org.id, user_id=test_user.id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await insurance_benchmark_service.get_premium_comparison(
+                user_id=test_user.id, organization_id=test_org.id, today=TODAY,
+            )
+
+        assert result.total_above_market == 1
+
+    async def test_policy_without_a_benchmark_is_surfaced_not_dropped(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Silence would read as an all-clear the app has not earned."""
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        await _make_policy(
+            db, org_id=test_org.id, user_id=test_user.id, listing_id=listing.id,
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await insurance_benchmark_service.get_premium_comparison(
+                user_id=test_user.id, organization_id=test_org.id, today=TODAY,
+            )
+
+        assert result.above_market == []
+        assert len(result.not_compared) == 1
+        assert result.not_compared[0].status == BENCHMARK_STATUS_NO_BENCHMARK
+        assert result.benchmark is None
+
+    async def test_policy_without_coverage_is_surfaced_as_not_comparable(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            listing_id=listing.id,
+            coverage_amount_cents=None,
+        )
+        await _make_benchmark(db, org_id=test_org.id, user_id=test_user.id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await insurance_benchmark_service.get_premium_comparison(
+                user_id=test_user.id, organization_id=test_org.id, today=TODAY,
+            )
+
+        assert len(result.not_compared) == 1
+        assert result.not_compared[0].status == BENCHMARK_STATUS_NOT_COMPARABLE
+
+    async def test_widest_gap_reads_first(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            listing_id=listing.id,
+            policy_name="Merely dear",
+            premium_cents=180_000,
+        )
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            listing_id=listing.id,
+            policy_name="Worst offender",
+            premium_cents=300_000,
+        )
+        await _make_benchmark(db, org_id=test_org.id, user_id=test_user.id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await insurance_benchmark_service.get_premium_comparison(
+                user_id=test_user.id, organization_id=test_org.id, today=TODAY,
+            )
+
+        assert [r.policy.policy_name for r in result.above_market] == [
+            "Worst offender",
+            "Merely dear",
+        ]
+
+    async def test_stale_benchmark_is_flagged_on_the_payload(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        await _make_policy(
+            db, org_id=test_org.id, user_id=test_user.id, listing_id=listing.id,
+        )
+        await _make_benchmark(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            observed_on=TODAY - _dt.timedelta(days=BENCHMARK_STALE_AFTER_DAYS + 1),
+        )
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await insurance_benchmark_service.get_premium_comparison(
+                user_id=test_user.id, organization_id=test_org.id, today=TODAY,
+            )
+
+        assert result.has_stale_benchmark is True
+        assert result.above_market[0].benchmark_is_stale is True
+
+    async def test_another_orgs_policies_are_not_measured(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        await _make_policy(
+            db, org_id=test_org.id, user_id=test_user.id, listing_id=listing.id,
+        )
+        await _make_benchmark(db, org_id=test_org.id, user_id=test_user.id)
+
+        with patch(_UOW_TARGET, _make_fake_uow(db)):
+            result = await insurance_benchmark_service.get_premium_comparison(
+                user_id=uuid.uuid4(), organization_id=uuid.uuid4(), today=TODAY,
+            )
+
+        assert result.total_considered == 0
+        assert result.above_market == []

--- a/apps/mybookkeeper/backend/tests/test_insurance_benchmarks_api.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_benchmarks_api.py
@@ -1,0 +1,305 @@
+"""HTTP route tests for /insurance-benchmarks and the premium comparison.
+
+The service is mocked — its behaviour is covered in
+``test_insurance_benchmark_service.py``. What these pin is the contract the
+routes own: payload validation (both figures required, no future observation),
+status codes, the permission dependency each route hangs off, and the
+route-ordering hazard where ``/premium-comparison`` would be swallowed by
+``/{policy_id}``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.insurance_benchmark_constants import (
+    BENCHMARK_STATUS_ABOVE,
+    MATERIAL_GAP_PCT,
+)
+from app.core.permissions import current_org_member, require_write_access
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.insurance.insurance_benchmark_response import (
+    InsuranceBenchmarkResponse,
+)
+from app.schemas.insurance.insurance_policy_premium_comparison_response import (
+    InsurancePolicyPremiumComparisonResponse,
+)
+from app.schemas.insurance.insurance_policy_premium_comparison_row import (
+    InsurancePolicyPremiumComparisonRow,
+)
+from app.schemas.insurance.insurance_policy_summary import InsurancePolicySummary
+from app.services.insurance.insurance_benchmark_service import (
+    InsuranceBenchmarkNotFoundError,
+)
+
+ORG_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+LISTING_ID = uuid.uuid4()
+POLICY_ID = uuid.uuid4()
+
+_SERVICE = "app.api.insurance_benchmarks.insurance_benchmark_service"
+_POLICY_ROUTE_SERVICE = "app.api.insurance_policies.insurance_benchmark_service"
+
+TODAY = _dt.date(2026, 8, 13)
+
+_VALID_PAYLOAD = {
+    "annual_premium_cents": 120_000,
+    "coverage_amount_cents": 40_000_000,
+    "observed_on": TODAY.isoformat(),
+}
+
+
+def _ctx(role: OrgRole = OrgRole.OWNER) -> RequestContext:
+    return RequestContext(organization_id=ORG_ID, user_id=USER_ID, org_role=role)
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[current_org_member] = lambda: _ctx()
+    app.dependency_overrides[require_write_access] = lambda: _ctx()
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _benchmark(**overrides) -> InsuranceBenchmarkResponse:
+    now = _dt.datetime.now(_dt.timezone.utc)
+    base = {
+        "id": uuid.uuid4(),
+        "annual_premium_cents": 120_000,
+        "coverage_amount_cents": 40_000_000,
+        "region_label": "Harris County, TX",
+        "source": "TDI HelpInsure, HO-3, $2,500 deductible",
+        "observed_on": TODAY,
+        "notes": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    base.update(overrides)
+    return InsuranceBenchmarkResponse(**base)
+
+
+def _summary() -> InsurancePolicySummary:
+    now = _dt.datetime.now(_dt.timezone.utc)
+    return InsurancePolicySummary(
+        id=POLICY_ID,
+        listing_id=LISTING_ID,
+        policy_name="Dwelling HO-3",
+        carrier="State Farm",
+        effective_date=_dt.date(2026, 3, 1),
+        expiration_date=_dt.date(2027, 3, 1),
+        coverage_amount_cents=40_000_000,
+        premium_cents=200_000,
+        premium_frequency="annual",
+        deductible_cents=250_000,
+        wind_hail_deductible_pct=Decimal("2.00"),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _comparison() -> InsurancePolicyPremiumComparisonResponse:
+    return InsurancePolicyPremiumComparisonResponse(
+        material_gap_pct=MATERIAL_GAP_PCT,
+        benchmark=_benchmark(),
+        above_market=[
+            InsurancePolicyPremiumComparisonRow(
+                policy=_summary(),
+                status=BENCHMARK_STATUS_ABOVE,
+                policy_rate_cents_per_1000=Decimal("500.00"),
+                benchmark_rate_cents_per_1000=Decimal("300.00"),
+                gap_pct=Decimal("66.7"),
+                benchmark_is_stale=False,
+            ),
+        ],
+        not_compared=[],
+        total_above_market=1,
+        total_considered=1,
+        has_stale_benchmark=False,
+    )
+
+
+class TestGetBenchmark:
+    def test_returns_the_recorded_benchmark(self, client: TestClient) -> None:
+        with patch(f"{_SERVICE}.get_benchmark", new=AsyncMock(return_value=_benchmark())):
+            response = client.get("/insurance-benchmarks")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["annual_premium_cents"] == 120_000
+        # Decimal is serialized as a string so precision survives the trip.
+        assert body["rate_cents_per_1000_coverage"] == "300.00"
+        assert body["is_stale"] is False
+
+    def test_returns_null_rather_than_404_when_none_is_recorded(
+        self, client: TestClient,
+    ) -> None:
+        """"None recorded yet" is every org's starting state, not a client
+        error — and the form that records one renders off this response."""
+        with patch(f"{_SERVICE}.get_benchmark", new=AsyncMock(return_value=None)):
+            response = client.get("/insurance-benchmarks")
+
+        assert response.status_code == 200
+        assert response.json() is None
+
+    def test_hangs_off_the_read_permission(self, client: TestClient) -> None:
+        app.dependency_overrides[current_org_member] = lambda: _ctx(OrgRole.VIEWER)
+        with patch(f"{_SERVICE}.get_benchmark", new=AsyncMock(return_value=None)):
+            assert client.get("/insurance-benchmarks").status_code == 200
+
+
+class TestUpsertBenchmark:
+    def test_saves_both_figures(self, client: TestClient) -> None:
+        mock = AsyncMock(return_value=_benchmark())
+        with patch(f"{_SERVICE}.upsert_benchmark", new=mock):
+            response = client.put("/insurance-benchmarks", json=_VALID_PAYLOAD)
+
+        assert response.status_code == 200
+        assert mock.await_args.kwargs["annual_premium_cents"] == 120_000
+        assert mock.await_args.kwargs["coverage_amount_cents"] == 40_000_000
+
+    def test_rejects_a_premium_with_no_coverage(self, client: TestClient) -> None:
+        """It could never be normalised, so it would match nothing — and the
+        operator would believe their policies were being checked."""
+        response = client.put(
+            "/insurance-benchmarks",
+            json={"annual_premium_cents": 120_000, "observed_on": TODAY.isoformat()},
+        )
+        assert response.status_code == 422
+
+    def test_rejects_coverage_with_no_premium(self, client: TestClient) -> None:
+        response = client.put(
+            "/insurance-benchmarks",
+            json={"coverage_amount_cents": 40_000_000, "observed_on": TODAY.isoformat()},
+        )
+        assert response.status_code == 422
+
+    def test_rejects_non_positive_figures(self, client: TestClient) -> None:
+        assert (
+            client.put(
+                "/insurance-benchmarks", json={**_VALID_PAYLOAD, "annual_premium_cents": 0},
+            ).status_code
+            == 422
+        )
+        assert (
+            client.put(
+                "/insurance-benchmarks", json={**_VALID_PAYLOAD, "coverage_amount_cents": 0},
+            ).status_code
+            == 422
+        )
+
+    def test_rejects_a_figure_past_the_cents_dollars_sanity_cap(
+        self, client: TestClient,
+    ) -> None:
+        """$10,000,000/yr of premium is a cents/dollars mix-up, not a quote."""
+        response = client.put(
+            "/insurance-benchmarks",
+            json={**_VALID_PAYLOAD, "annual_premium_cents": 2_000_000_000},
+        )
+        assert response.status_code == 422
+
+    def test_rejects_a_future_observation(self, client: TestClient) -> None:
+        """A future date is a typo, and it would never age into staleness."""
+        next_week = _dt.date.today() + _dt.timedelta(days=7)
+        response = client.put(
+            "/insurance-benchmarks",
+            json={**_VALID_PAYLOAD, "observed_on": next_week.isoformat()},
+        )
+        assert response.status_code == 422
+
+    def test_accepts_a_client_whose_today_is_a_day_ahead(
+        self, client: TestClient,
+    ) -> None:
+        """The browser sends *its* local date, which can lead the server's.
+
+        Without a day of slack, a user east of the server is rejected for
+        picking today on their own calendar — a 422 they cannot act on.
+        """
+        tomorrow = _dt.date.today() + _dt.timedelta(days=1)
+        with patch(f"{_SERVICE}.upsert_benchmark", new=AsyncMock(return_value=_benchmark())):
+            response = client.put(
+                "/insurance-benchmarks",
+                json={**_VALID_PAYLOAD, "observed_on": tomorrow.isoformat()},
+            )
+        assert response.status_code == 200
+
+    def test_rejects_unknown_fields(self, client: TestClient) -> None:
+        response = client.put(
+            "/insurance-benchmarks",
+            json={**_VALID_PAYLOAD, "wishful_thinking": True},
+        )
+        assert response.status_code == 422
+
+    def test_hangs_off_the_write_permission(self, client: TestClient) -> None:
+        def _deny():
+            raise HTTPException(status_code=403, detail="Read-only")
+
+        app.dependency_overrides[require_write_access] = _deny
+        response = client.put("/insurance-benchmarks", json=_VALID_PAYLOAD)
+        assert response.status_code == 403
+
+
+class TestDeleteBenchmark:
+    def test_returns_204_on_success(self, client: TestClient) -> None:
+        with patch(f"{_SERVICE}.delete_benchmark", new=AsyncMock(return_value=None)):
+            assert client.delete("/insurance-benchmarks").status_code == 204
+
+    def test_returns_404_when_nothing_was_recorded(self, client: TestClient) -> None:
+        with patch(
+            f"{_SERVICE}.delete_benchmark",
+            new=AsyncMock(side_effect=InsuranceBenchmarkNotFoundError()),
+        ):
+            assert client.delete("/insurance-benchmarks").status_code == 404
+
+    def test_hangs_off_the_write_permission(self, client: TestClient) -> None:
+        def _deny():
+            raise HTTPException(status_code=403, detail="Read-only")
+
+        app.dependency_overrides[require_write_access] = _deny
+        assert client.delete("/insurance-benchmarks").status_code == 403
+
+
+class TestPremiumComparisonRoute:
+    def test_returns_the_comparison(self, client: TestClient) -> None:
+        with patch(
+            f"{_POLICY_ROUTE_SERVICE}.get_premium_comparison",
+            new=AsyncMock(return_value=_comparison()),
+        ):
+            response = client.get("/insurance-policies/premium-comparison")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total_above_market"] == 1
+        assert body["total_considered"] == 1
+        assert body["above_market"][0]["gap_pct"] == "66.7"
+        assert body["material_gap_pct"] == MATERIAL_GAP_PCT
+        # The benchmark is echoed so the card can name what it compared to.
+        assert body["benchmark"]["rate_cents_per_1000_coverage"] == "300.00"
+
+    def test_literal_path_is_not_swallowed_by_the_uuid_route(
+        self, client: TestClient,
+    ) -> None:
+        """Declaring ``/{policy_id}`` first would turn this into a 422."""
+        with patch(
+            f"{_POLICY_ROUTE_SERVICE}.get_premium_comparison",
+            new=AsyncMock(return_value=_comparison()),
+        ) as mock:
+            client.get("/insurance-policies/premium-comparison")
+        assert mock.await_count == 1
+
+    def test_hangs_off_the_read_permission(self, client: TestClient) -> None:
+        app.dependency_overrides[current_org_member] = lambda: _ctx(OrgRole.VIEWER)
+        with patch(
+            f"{_POLICY_ROUTE_SERVICE}.get_premium_comparison",
+            new=AsyncMock(return_value=_comparison()),
+        ):
+            assert (
+                client.get("/insurance-policies/premium-comparison").status_code == 200
+            )

--- a/apps/mybookkeeper/backend/tests/test_market_rate_benchmark_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_market_rate_benchmark_repo.py
@@ -138,6 +138,47 @@ class TestUpsert:
         assert updated.id == first.id
         assert updated.recorded_by_user_id == member_b
 
+    async def test_a_racing_insert_converges_on_an_update(
+        self, db: AsyncSession,
+    ) -> None:
+        """Simulates the loser of a concurrent write: the row appears between
+        the read and the insert. The SAVEPOINT catches the unique violation and
+        the caller ends up updating the winner instead of seeing a 500."""
+        org_id = uuid.uuid4()
+        real_get = market_rate_benchmark_repo.get_by_service_type
+        calls = {"n": 0}
+
+        async def _get_missing_first(db_arg, *, organization_id, service_type):
+            # First read reports "absent" even though the row is about to
+            # exist; later reads (including the post-IntegrityError re-read)
+            # tell the truth.
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return None
+            return await real_get(
+                db_arg, organization_id=organization_id, service_type=service_type,
+            )
+
+        # The winner's row, already written by the other writer.
+        await _upsert(db, org_id=org_id, source="Winner")
+
+        market_rate_benchmark_repo.get_by_service_type = _get_missing_first  # type: ignore[assignment]
+        try:
+            result = await _upsert(
+                db,
+                org_id=org_id,
+                source="Loser",
+                rate_cents_per_kwh=Decimal("9.0000"),
+            )
+        finally:
+            market_rate_benchmark_repo.get_by_service_type = real_get  # type: ignore[assignment]
+
+        assert result.source == "Loser"
+        rows = await market_rate_benchmark_repo.list_for_org(
+            db, organization_id=org_id,
+        )
+        assert len(rows) == 1
+
 
 class TestOrganizationScoping:
     """A benchmark belongs to the org, not to whoever looked the rate up."""

--- a/apps/mybookkeeper/frontend/e2e/insurance-premium-benchmark.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/insurance-premium-benchmark.spec.ts
@@ -1,0 +1,332 @@
+import { test, expect, type APIRequestContext, type Page } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * Insurance market-premium benchmark — full-flow behavioural E2E.
+ *
+ * Drives the journey the feature exists for: a policy nowhere near expiry — so
+ * the expiration badge says nothing about it — gets flagged as overpriced once a
+ * market premium is recorded through the dialog. That is the blind spot this
+ * closes; a lapsing policy was already covered.
+ *
+ * The two policies are deliberately priced the *same* on different dwelling
+ * amounts. Compared raw they look identical; normalised per $1,000 of coverage
+ * one is double the other, and only one is above market. A comparison that
+ * skipped the normalisation would flag both or neither, so this is the assertion
+ * that proves the unit is doing real work.
+ *
+ * Verifies UI state AND backend state via the public API, and cleans up every
+ * seeded row in `finally` per the project's "never leave test data" rule. The
+ * benchmark is a singleton per organization and this account is shared with the
+ * sibling insurance specs, so every assertion targets the seeded policies' own
+ * rows rather than a total, and the benchmark is removed on the way out.
+ */
+
+interface CreatedListing {
+  id: string;
+}
+
+interface ComparisonRow {
+  policy: { id: string; policy_name: string };
+  status: string;
+  policy_rate_cents_per_1000: string | null;
+  benchmark_rate_cents_per_1000: string | null;
+  gap_pct: string | null;
+  benchmark_is_stale: boolean;
+}
+
+interface Comparison {
+  material_gap_pct: number;
+  benchmark: { rate_cents_per_1000_coverage: string | null; is_stale: boolean } | null;
+  above_market: ComparisonRow[];
+  not_compared: ComparisonRow[];
+  total_above_market: number;
+  total_considered: number;
+  has_stale_benchmark: boolean;
+}
+
+/** ``offsetDays`` from today as ``YYYY-MM-DD``. Negative is in the past. */
+function isoDateOffset(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+async function createListing(
+  api: APIRequestContext,
+  propertyId: string,
+  title: string,
+): Promise<CreatedListing> {
+  const res = await api.post("/listings", {
+    data: {
+      property_id: propertyId,
+      title,
+      monthly_rate: "1500.00",
+      room_type: "private_room",
+      status: "active",
+      private_bath: false,
+      parking_assigned: false,
+      furnished: false,
+      pets_on_premises: false,
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`createListing failed: ${res.status()} ${await res.text()}`);
+  }
+  return { id: ((await res.json()) as { id: string }).id };
+}
+
+async function seedPolicy(
+  api: APIRequestContext,
+  listingId: string,
+  data: { policy_name: string; premium_cents: number; coverage_amount_cents: number },
+): Promise<string> {
+  const res = await api.post("/insurance-policies", {
+    data: {
+      listing_id: listingId,
+      carrier: "E2E Mutual",
+      premium_frequency: "annual",
+      // Years from expiry: the expiration badge has nothing to say here, which
+      // is exactly the blind spot the premium check covers.
+      effective_date: isoDateOffset(-30),
+      expiration_date: isoDateOffset(335),
+      ...data,
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedPolicy failed: ${res.status()} ${await res.text()}`);
+  }
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function fetchComparison(api: APIRequestContext): Promise<Comparison> {
+  const res = await api.get("/insurance-policies/premium-comparison");
+  if (!res.ok()) {
+    throw new Error(`fetchComparison failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function waitForPoliciesPage(page: Page): Promise<void> {
+  await expect(page.getByRole("heading", { name: "Insurance" })).toBeVisible({
+    timeout: 15000,
+  });
+  await page.waitForLoadState("networkidle");
+}
+
+test.describe("Insurance premium benchmark", () => {
+  test("record a market premium, see the overpriced policy flagged per $1,000 of coverage, remove it", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const pricey = `E2E Overpriced Policy ${runId}`;
+    const fair = `E2E Fairly Priced Policy ${runId}`;
+    let propertyId: string | null = null;
+    let listingId: string | null = null;
+    let priceyId: string | null = null;
+    let fairId: string | null = null;
+    let benchmarkRecorded = false;
+
+    try {
+      const property = await createProperty(api, {
+        name: `E2E Benchmark Insurance Property ${runId}`,
+      });
+      propertyId = property.id;
+      listingId = (
+        await createListing(api, propertyId, `E2E Benchmark Listing ${runId}`)
+      ).id;
+
+      // Same premium, different dwelling amounts. Raw they are identical; per
+      // $1,000 of coverage one is 600¢ and the other 300¢.
+      priceyId = await seedPolicy(api, listingId, {
+        policy_name: pricey,
+        premium_cents: 240_000,
+        coverage_amount_cents: 40_000_000,
+      });
+      fairId = await seedPolicy(api, listingId, {
+        policy_name: fair,
+        premium_cents: 240_000,
+        coverage_amount_cents: 80_000_000,
+      });
+
+      // ── Before any benchmark: nothing is being checked ───────────────────
+      const before = await fetchComparison(api);
+      expect(before.benchmark).toBeNull();
+      expect(before.above_market.some((r) => r.policy.id === priceyId)).toBe(false);
+      // The policies are surfaced as unmeasured rather than silently dropped.
+      expect(before.not_compared.find((r) => r.policy.id === priceyId)?.status).toBe(
+        "no_benchmark",
+      );
+
+      await page.goto("/insurance-policies");
+      await waitForPoliciesPage(page);
+      await expect(page.getByTestId("insurance-benchmark-summary-empty")).toBeVisible();
+
+      // ── Record the market premium through the dialog ────────────────────
+      await page.getByTestId("insurance-benchmark-summary-record").click();
+      await expect(page.getByTestId("insurance-benchmark-dialog")).toBeVisible();
+
+      // $1,200/yr on $400,000 of dwelling → 300¢ per $1,000.
+      await page.getByTestId("insurance-benchmark-premium").fill("1200");
+      await page.getByTestId("insurance-benchmark-coverage").fill("400000");
+      await page.getByTestId("insurance-benchmark-region").fill("Harris County, TX");
+      await page
+        .getByTestId("insurance-benchmark-source")
+        .fill(`TDI HelpInsure HO-3 ${runId}`);
+      await page.getByTestId("insurance-benchmark-save-button").click();
+      benchmarkRecorded = true;
+
+      await expect(page.getByTestId("insurance-benchmark-dialog")).toBeHidden({
+        timeout: 15000,
+      });
+
+      // ── The page now names what it is comparing against ─────────────────
+      await expect(page.getByTestId("insurance-benchmark-summary-figure")).toContainText(
+        "$1,200/yr on $400,000 of dwelling coverage — $3.00 per $1,000",
+        { timeout: 15000 },
+      );
+
+      // ── Backend state: normalised, and only the overpriced one flagged ──
+      const after = await fetchComparison(api);
+      expect(Number(after.benchmark?.rate_cents_per_1000_coverage)).toBeCloseTo(300, 2);
+
+      const flagged = after.above_market.find((r) => r.policy.id === priceyId);
+      expect(flagged, "the overpriced policy was not flagged").toBeTruthy();
+      expect(flagged!.status).toBe("above_market");
+      expect(Number(flagged!.policy_rate_cents_per_1000)).toBeCloseTo(600, 2);
+      // 600 against 300 is +100% — comfortably past the materiality threshold.
+      expect(Number(flagged!.gap_pct)).toBeGreaterThan(after.material_gap_pct);
+
+      // The identically-priced policy on twice the coverage is NOT flagged.
+      // Comparing raw premiums would have flagged both.
+      expect(after.above_market.some((r) => r.policy.id === fairId)).toBe(false);
+      expect(after.not_compared.some((r) => r.policy.id === fairId)).toBe(false);
+
+      // ── The dashboard card names the policy and both figures ────────────
+      await page.goto("/");
+      await expect(page.getByTestId("insurance-premium-comparison-card")).toBeVisible({
+        timeout: 20000,
+      });
+      await expect(
+        page.getByTestId(`insurance-premium-comparison-${priceyId}`),
+      ).toContainText("paying $6.00 per $1,000 vs market $3.00 per $1,000");
+      await expect(
+        page.getByTestId(`insurance-premium-comparison-gap-${priceyId}`),
+      ).toContainText("above market");
+      // The one that is priced fine never appears on the card.
+      await expect(
+        page.getByTestId(`insurance-premium-comparison-${fairId}`),
+      ).toHaveCount(0);
+
+      // ── Removing the benchmark stops the flag ───────────────────────────
+      await page.goto("/insurance-policies");
+      await waitForPoliciesPage(page);
+      await page.getByTestId("insurance-benchmark-summary-edit").click();
+      await expect(page.getByTestId("insurance-benchmark-dialog")).toBeVisible();
+      await page.getByTestId("insurance-benchmark-remove-button").click();
+      await expect(page.getByTestId("insurance-benchmark-dialog")).toBeHidden({
+        timeout: 15000,
+      });
+      benchmarkRecorded = false;
+
+      await expect(page.getByTestId("insurance-benchmark-summary-empty")).toBeVisible({
+        timeout: 15000,
+      });
+      const cleared = await fetchComparison(api);
+      expect(cleared.benchmark).toBeNull();
+      expect(cleared.above_market.some((r) => r.policy.id === priceyId)).toBe(false);
+    } finally {
+      if (benchmarkRecorded) {
+        await api.delete("/insurance-benchmarks").catch(() => {});
+      }
+      if (priceyId) await api.delete(`/insurance-policies/${priceyId}`).catch(() => {});
+      if (fairId) await api.delete(`/insurance-policies/${fairId}`).catch(() => {});
+      if (listingId) await api.delete(`/listings/${listingId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+
+  test("a policy with no coverage amount is reported as unmeasurable, not as fine", async ({
+    api,
+  }) => {
+    // Without the dwelling amount the premium cannot be normalised. Dropping it
+    // silently would let the operator read the all-clear as covering it.
+    const runId = Date.now();
+    let propertyId: string | null = null;
+    let listingId: string | null = null;
+    let policyId: string | null = null;
+    let benchmarkRecorded = false;
+
+    try {
+      const property = await createProperty(api, {
+        name: `E2E Unmeasurable Property ${runId}`,
+      });
+      propertyId = property.id;
+      listingId = (
+        await createListing(api, propertyId, `E2E Unmeasurable Listing ${runId}`)
+      ).id;
+
+      const created = await api.post("/insurance-policies", {
+        data: {
+          listing_id: listingId,
+          policy_name: `E2E Coverage-less Policy ${runId}`,
+          premium_cents: 240_000,
+          premium_frequency: "annual",
+        },
+      });
+      expect(created.ok()).toBe(true);
+      policyId = ((await created.json()) as { id: string }).id;
+
+      const benchRes = await api.put("/insurance-benchmarks", {
+        data: {
+          annual_premium_cents: 120_000,
+          coverage_amount_cents: 40_000_000,
+          observed_on: isoDateOffset(0),
+        },
+      });
+      expect(benchRes.ok()).toBe(true);
+      benchmarkRecorded = true;
+
+      const comparison = await fetchComparison(api);
+      expect(comparison.above_market.some((r) => r.policy.id === policyId)).toBe(false);
+      expect(
+        comparison.not_compared.find((r) => r.policy.id === policyId)?.status,
+      ).toBe("not_comparable");
+    } finally {
+      if (benchmarkRecorded) {
+        await api.delete("/insurance-benchmarks").catch(() => {});
+      }
+      if (policyId) await api.delete(`/insurance-policies/${policyId}`).catch(() => {});
+      if (listingId) await api.delete(`/listings/${listingId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+
+  test("the API refuses a premium recorded without the coverage it bought", async ({
+    api,
+  }) => {
+    // It could never be normalised, so it would match nothing — and the
+    // operator would believe their policies were being checked.
+    const premiumOnly = await api.put("/insurance-benchmarks", {
+      data: { annual_premium_cents: 120_000, observed_on: isoDateOffset(0) },
+    });
+    expect(premiumOnly.status()).toBe(422);
+
+    const coverageOnly = await api.put("/insurance-benchmarks", {
+      data: { coverage_amount_cents: 40_000_000, observed_on: isoDateOffset(0) },
+    });
+    expect(coverageOnly.status()).toBe(422);
+
+    // A future observation date is a typo, and it would never age into
+    // staleness — the one signal that tells the operator to look again.
+    const future = await api.put("/insurance-benchmarks", {
+      data: {
+        annual_premium_cents: 120_000,
+        coverage_amount_cents: 40_000_000,
+        observed_on: isoDateOffset(7),
+      },
+    });
+    expect(future.status()).toBe(422);
+  });
+});

--- a/apps/mybookkeeper/frontend/e2e/insurance-premium-comparison-layout.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/insurance-premium-comparison-layout.spec.ts
@@ -1,0 +1,259 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * Layout E2E for the dashboard premium-comparison card and the market-premium
+ * dialog.
+ *
+ * Verifies:
+ *   1. The card's loading skeleton has the same row count and the same
+ *      text-block-plus-pill shape as the loaded card, so the dashboard does not
+ *      shift when the comparison arrives.
+ *   2. Neither the dashboard, the policies page, nor the dialog overflows
+ *      horizontally at mobile / tablet / desktop widths.
+ *   3. The dialog's close control meets the 44px touch-target minimum.
+ *
+ * The benchmark is a singleton per organization and this account is shared with
+ * the sibling insurance specs, so this file runs serially and removes the
+ * benchmark on the way out — two tests upserting the same row concurrently
+ * would race on the unique index.
+ */
+
+/** Matches the placeholder row count in ``InsurancePremiumComparisonCardSkeleton``. */
+const SKELETON_ROW_COUNT = 2;
+
+const BENCHMARK_URL = "/insurance-benchmarks";
+
+function isoDateOffset(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+async function createListing(
+  api: APIRequestContext,
+  propertyId: string,
+  title: string,
+): Promise<string> {
+  const res = await api.post("/listings", {
+    data: {
+      property_id: propertyId,
+      title,
+      monthly_rate: "1500.00",
+      room_type: "private_room",
+      status: "active",
+      private_bath: false,
+      parking_assigned: false,
+      furnished: false,
+      pets_on_premises: false,
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`createListing failed: ${res.status()} ${await res.text()}`);
+  }
+  return ((await res.json()) as { id: string }).id;
+}
+
+/** An unambiguously above-market policy: 600¢ per $1,000 against a 300¢ market. */
+async function seedPolicy(
+  api: APIRequestContext,
+  listingId: string,
+  policyName: string,
+): Promise<string> {
+  const res = await api.post("/insurance-policies", {
+    data: {
+      listing_id: listingId,
+      policy_name: policyName,
+      carrier: "E2E Mutual",
+      premium_cents: 240_000,
+      premium_frequency: "annual",
+      coverage_amount_cents: 40_000_000,
+      effective_date: isoDateOffset(-30),
+      expiration_date: isoDateOffset(335),
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedPolicy failed: ${res.status()} ${await res.text()}`);
+  }
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function seedBenchmark(api: APIRequestContext, source: string): Promise<void> {
+  const res = await api.put(BENCHMARK_URL, {
+    data: {
+      annual_premium_cents: 120_000,
+      coverage_amount_cents: 40_000_000,
+      region_label: "Harris County, TX",
+      source,
+      observed_on: isoDateOffset(0),
+    },
+  });
+  expect(res.ok()).toBe(true);
+}
+
+async function hasHorizontalOverflow(
+  page: import("@playwright/test").Page,
+): Promise<boolean> {
+  return page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+  );
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Insurance premium comparison layout", () => {
+  test("skeleton row count and shape match the loaded card", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    let propertyId: string | null = null;
+    let listingId: string | null = null;
+    let policyId: string | null = null;
+    let benchmarkRecorded = false;
+
+    try {
+      const property = await createProperty(api, {
+        name: `E2E Premium Layout ${runId}`,
+      });
+      propertyId = property.id;
+      listingId = await createListing(api, propertyId, `E2E Premium Layout ${runId}`);
+      policyId = await seedPolicy(api, listingId, `E2E Premium Layout Policy ${runId}`);
+      await seedBenchmark(api, `E2E premium layout ${runId}`);
+      benchmarkRecorded = true;
+
+      // Hold the comparison response long enough to observe the skeleton. The
+      // glob is exact so the sibling `/insurance-policies` list call is
+      // untouched.
+      await page.route("**/api/insurance-policies/premium-comparison", async (route) => {
+        await new Promise((r) => setTimeout(r, 1500));
+        await route.continue();
+      });
+
+      const navPromise = page.goto("/");
+
+      const skeleton = page.getByTestId("insurance-premium-comparison-card-loading");
+      await expect(skeleton).toBeVisible({ timeout: 15000 });
+      await expect(skeleton.locator("ul > li")).toHaveCount(SKELETON_ROW_COUNT);
+      // Each placeholder row reserves exactly one gap-pill slot, like a real row.
+      await expect(skeleton.locator(".rounded-full")).toHaveCount(SKELETON_ROW_COUNT);
+
+      await navPromise;
+
+      await expect(page.getByTestId("insurance-premium-comparison-card")).toBeVisible({
+        timeout: 20000,
+      });
+      await expect(
+        page.getByTestId(`insurance-premium-comparison-${policyId}`),
+      ).toBeVisible();
+      // One gap pill per row, loaded and loading alike — that 1:1 ratio is the
+      // shape the skeleton promises, and it keeps the right-hand column from
+      // jumping when the data lands. Counted rather than compared to a fixed
+      // number because the account is shared with the sibling insurance specs.
+      // Scoped to the above-market list specifically: the card also renders a
+      // "not checked" list, whose rows carry no gap pill by design.
+      const loadedRows = page.locator(
+        '[data-testid="insurance-premium-comparison-above-list"] > li',
+      );
+      const loadedCount = await loadedRows.count();
+      expect(loadedCount).toBeGreaterThanOrEqual(1);
+      await expect(
+        page.locator('[data-testid^="insurance-premium-comparison-gap-"]'),
+      ).toHaveCount(loadedCount);
+    } finally {
+      if (benchmarkRecorded) await api.delete(BENCHMARK_URL).catch(() => {});
+      if (policyId) await api.delete(`/insurance-policies/${policyId}`).catch(() => {});
+      if (listingId) await api.delete(`/listings/${listingId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+
+  test("the card and dialog fit every viewport and keep 44px touch targets", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    let propertyId: string | null = null;
+    let listingId: string | null = null;
+    let policyId: string | null = null;
+    let benchmarkRecorded = false;
+
+    try {
+      const property = await createProperty(api, {
+        name: `E2E Wide Premium Property Name That Could Overflow ${runId}`,
+      });
+      propertyId = property.id;
+      listingId = await createListing(
+        api,
+        propertyId,
+        `E2E Wide Premium Listing ${runId}`,
+      );
+      policyId = await seedPolicy(
+        api,
+        listingId,
+        `E2E Premium Policy With A Deliberately Long Name ${runId}`,
+      );
+      await seedBenchmark(
+        api,
+        `E2E a deliberately long provenance string for overflow ${runId}`,
+      );
+      benchmarkRecorded = true;
+
+      for (const size of [
+        { width: 375, height: 800 },
+        { width: 768, height: 900 },
+        { width: 1440, height: 900 },
+      ]) {
+        await page.setViewportSize(size);
+        await page.goto("/");
+        await expect(
+          page.getByTestId(`insurance-premium-comparison-${policyId}`),
+        ).toBeVisible({ timeout: 20000 });
+        expect(
+          await hasHorizontalOverflow(page),
+          `dashboard overflow at ${size.width}px`,
+        ).toBe(false);
+
+        await page.goto("/insurance-policies");
+        await expect(page.getByTestId("insurance-benchmark-summary")).toBeVisible({
+          timeout: 15000,
+        });
+        expect(
+          await hasHorizontalOverflow(page),
+          `policies page overflow at ${size.width}px`,
+        ).toBe(false);
+      }
+
+      // The dialog is the tightest layout — a modal on a 375px viewport, and
+      // the only place two currency fields sit side by side.
+      await page.setViewportSize({ width: 375, height: 800 });
+      await page.goto("/insurance-policies");
+      await page.getByTestId("insurance-benchmark-summary-edit").click();
+      await expect(page.getByTestId("insurance-benchmark-dialog")).toBeVisible();
+      expect(await hasHorizontalOverflow(page), "dialog overflow at 375px").toBe(false);
+
+      // Both figures must stay tappable, not just visible.
+      for (const field of [
+        "insurance-benchmark-premium",
+        "insurance-benchmark-coverage",
+      ]) {
+        const box = await page.getByTestId(field).boundingBox();
+        expect(box, `${field} has no box`).not.toBeNull();
+        expect(box!.height, `${field} height`).toBeGreaterThanOrEqual(44);
+      }
+
+      const close = page
+        .getByTestId("insurance-benchmark-dialog")
+        .getByRole("button", { name: "Close" });
+      const box = await close.boundingBox();
+      expect(box, "close control has no box").not.toBeNull();
+      expect(box!.width, "close width").toBeGreaterThanOrEqual(44);
+      expect(box!.height, "close height").toBeGreaterThanOrEqual(44);
+    } finally {
+      if (benchmarkRecorded) await api.delete(BENCHMARK_URL).catch(() => {});
+      if (policyId) await api.delete(`/insurance-policies/${policyId}`).catch(() => {});
+      if (listingId) await api.delete(`/listings/${listingId}`).catch(() => {});
+      if (propertyId) await deleteProperty(api, propertyId);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/InsuranceBenchmarkDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/InsuranceBenchmarkDialog.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * Unit tests for the market-premium dialog.
+ *
+ * The thing worth protecting is that both figures are required. The comparison
+ * runs on premium *per $1,000 of coverage*, so a premium saved without the
+ * dwelling amount it was priced against cannot be normalised — it would sit in
+ * the database matching nothing while the operator believed their policies were
+ * being checked. Refusing it is the whole point of the guard.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { showError } from "@/shared/lib/toast-store";
+import { store } from "@/shared/store";
+import InsuranceBenchmarkDialog from "@/app/features/insurance/InsuranceBenchmarkDialog";
+import type { InsuranceBenchmark } from "@/shared/types/insurance/insurance-benchmark";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockUpsert = vi.fn();
+const mockDelete = vi.fn();
+let mockBenchmark: InsuranceBenchmark | null = null;
+let mockLoading = false;
+
+vi.mock("@/shared/store/insuranceBenchmarksApi", () => ({
+  useGetInsuranceBenchmarkQuery: vi.fn(() => ({
+    data: mockBenchmark,
+    isLoading: mockLoading,
+  })),
+  useUpsertInsuranceBenchmarkMutation: vi.fn(() => [mockUpsert, { isLoading: false }]),
+  useDeleteInsuranceBenchmarkMutation: vi.fn(() => [mockDelete, { isLoading: false }]),
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+function makeBenchmark(overrides: Partial<InsuranceBenchmark> = {}): InsuranceBenchmark {
+  return {
+    id: "bench-1",
+    annual_premium_cents: 120_000,
+    coverage_amount_cents: 40_000_000,
+    region_label: "Harris County, TX",
+    source: "TDI HelpInsure, HO-3, $2,500 deductible",
+    observed_on: "2026-08-01",
+    notes: null,
+    rate_cents_per_1000_coverage: "300.00",
+    is_stale: false,
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const onClose = vi.fn();
+
+function renderDialog() {
+  return render(
+    <Provider store={store}>
+      <InsuranceBenchmarkDialog onClose={onClose} />
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBenchmark = null;
+  mockLoading = false;
+  mockUpsert.mockReturnValue({ unwrap: () => Promise.resolve(makeBenchmark()) });
+  mockDelete.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("InsuranceBenchmarkDialog — recording a premium", () => {
+  it("sends both figures as integer cents", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("insurance-benchmark-premium"), "1344.50");
+    await user.type(screen.getByTestId("insurance-benchmark-coverage"), "400000");
+    await user.click(screen.getByTestId("insurance-benchmark-save-button"));
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const arg = mockUpsert.mock.calls[0][0];
+    expect(arg.annual_premium_cents).toBe(134_450);
+    expect(arg.coverage_amount_cents).toBe(40_000_000);
+  });
+
+  it("sends blank optional fields as null rather than empty strings", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("insurance-benchmark-premium"), "1344");
+    await user.type(screen.getByTestId("insurance-benchmark-coverage"), "400000");
+    await user.click(screen.getByTestId("insurance-benchmark-save-button"));
+
+    const arg = mockUpsert.mock.calls[0][0];
+    expect(arg.region_label).toBeNull();
+    expect(arg.source).toBeNull();
+    expect(arg.notes).toBeNull();
+  });
+
+  it("trims the free-text fields it does send", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("insurance-benchmark-premium"), "1344");
+    await user.type(screen.getByTestId("insurance-benchmark-coverage"), "400000");
+    await user.type(screen.getByTestId("insurance-benchmark-region"), "  Harris County  ");
+    await user.click(screen.getByTestId("insurance-benchmark-save-button"));
+
+    expect(mockUpsert.mock.calls[0][0].region_label).toBe("Harris County");
+  });
+
+  it("defaults the observation date to today so it can age into staleness", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("insurance-benchmark-premium"), "1344");
+    await user.type(screen.getByTestId("insurance-benchmark-coverage"), "400000");
+    await user.click(screen.getByTestId("insurance-benchmark-save-button"));
+
+    const now = new Date();
+    const today = `${now.getFullYear()}-${`${now.getMonth() + 1}`.padStart(2, "0")}-${`${now.getDate()}`.padStart(2, "0")}`;
+    expect(mockUpsert.mock.calls[0][0].observed_on).toBe(today);
+  });
+
+  it("closes once the save resolves", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("insurance-benchmark-premium"), "1344");
+    await user.type(screen.getByTestId("insurance-benchmark-coverage"), "400000");
+    await user.click(screen.getByTestId("insurance-benchmark-save-button"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays open when the save fails", async () => {
+    mockUpsert.mockReturnValue({ unwrap: () => Promise.reject(new Error("boom")) });
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("insurance-benchmark-premium"), "1344");
+    await user.type(screen.getByTestId("insurance-benchmark-coverage"), "400000");
+    await user.click(screen.getByTestId("insurance-benchmark-save-button"));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the backend's reason rather than a generic retry", async () => {
+    // The server names the rule the payload broke — a future observation date,
+    // a cents/dollars mix-up. "Try again" would send the operator to retype a
+    // value that will be rejected identically.
+    mockUpsert.mockReturnValue({
+      unwrap: () =>
+        Promise.reject({
+          status: 422,
+          data: { detail: "observed_on cannot be in the future." },
+        }),
+    });
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("insurance-benchmark-premium"), "1344");
+    await user.type(screen.getByTestId("insurance-benchmark-coverage"), "400000");
+    await user.click(screen.getByTestId("insurance-benchmark-save-button"));
+
+    expect(showError).toHaveBeenCalledWith("observed_on cannot be in the future.");
+  });
+});
+
+describe("InsuranceBenchmarkDialog — both figures are required", () => {
+  it("keeps save disabled until both are entered", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    expect(screen.getByTestId("insurance-benchmark-save-button")).toBeDisabled();
+
+    await user.type(screen.getByTestId("insurance-benchmark-premium"), "1344");
+    // A premium alone can never be normalised, so it is still not submittable.
+    expect(screen.getByTestId("insurance-benchmark-save-button")).toBeDisabled();
+
+    await user.type(screen.getByTestId("insurance-benchmark-coverage"), "400000");
+    expect(screen.getByTestId("insurance-benchmark-save-button")).toBeEnabled();
+  });
+
+  it("does not accept coverage on its own either", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("insurance-benchmark-coverage"), "400000");
+
+    expect(screen.getByTestId("insurance-benchmark-save-button")).toBeDisabled();
+  });
+
+  it("rejects a zero premium as unusable, not as a free policy", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByTestId("insurance-benchmark-premium"), "0");
+    await user.type(screen.getByTestId("insurance-benchmark-coverage"), "400000");
+
+    expect(screen.getByTestId("insurance-benchmark-save-button")).toBeDisabled();
+  });
+});
+
+describe("InsuranceBenchmarkDialog — an existing premium", () => {
+  it("prefills both figures as dollars", () => {
+    mockBenchmark = makeBenchmark();
+
+    renderDialog();
+
+    expect(screen.getByTestId("insurance-benchmark-premium")).toHaveValue(1200);
+    expect(screen.getByTestId("insurance-benchmark-coverage")).toHaveValue(400000);
+    expect(screen.getByTestId("insurance-benchmark-source")).toHaveValue(
+      "TDI HelpInsure, HO-3, $2,500 deductible",
+    );
+    expect(screen.getByTestId("insurance-benchmark-save-button")).toHaveTextContent(
+      "Update premium",
+    );
+  });
+
+  it("shows a skeleton rather than an empty form while loading", () => {
+    mockLoading = true;
+
+    renderDialog();
+
+    expect(
+      screen.getByTestId("insurance-benchmark-dialog-loading"),
+    ).toHaveAttribute("aria-busy", "true");
+    expect(
+      screen.queryByTestId("insurance-benchmark-premium"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("InsuranceBenchmarkDialog — removing a premium", () => {
+  it("offers no removal when nothing is recorded", () => {
+    renderDialog();
+
+    expect(
+      screen.queryByTestId("insurance-benchmark-remove-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("removes the recorded premium and closes", async () => {
+    // Without this a premium taken from a quote that turned out not to apply
+    // could only be overwritten, never retracted — and every policy would keep
+    // being measured against it.
+    mockBenchmark = makeBenchmark();
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByTestId("insurance-benchmark-remove-button"));
+
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays open when the removal fails", async () => {
+    mockBenchmark = makeBenchmark();
+    mockDelete.mockReturnValue({ unwrap: () => Promise.reject(new Error("boom")) });
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByTestId("insurance-benchmark-remove-button"));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/InsuranceBenchmarkSummary.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/InsuranceBenchmarkSummary.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the market-premium summary on the policies page.
+ *
+ * The summary exists so the number driving the above-market flag is visible
+ * next to the policies it judges. A benchmark the operator cannot see is one
+ * they cannot tell has gone stale — so both the figure and its age are pinned
+ * here, as is the empty state, which must read as "nothing is being checked"
+ * rather than as silence.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import InsuranceBenchmarkSummary from "@/app/features/insurance/InsuranceBenchmarkSummary";
+import type { InsuranceBenchmark } from "@/shared/types/insurance/insurance-benchmark";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+let mockBenchmark: InsuranceBenchmark | null = null;
+let mockLoading = false;
+
+vi.mock("@/shared/store/insuranceBenchmarksApi", () => ({
+  useGetInsuranceBenchmarkQuery: vi.fn(() => ({
+    data: mockBenchmark,
+    isLoading: mockLoading,
+  })),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+function makeBenchmark(overrides: Partial<InsuranceBenchmark> = {}): InsuranceBenchmark {
+  return {
+    id: "bench-1",
+    annual_premium_cents: 120_000,
+    coverage_amount_cents: 40_000_000,
+    region_label: "Harris County, TX",
+    source: "TDI HelpInsure, HO-3, $2,500 deductible",
+    observed_on: "2026-08-01",
+    notes: null,
+    rate_cents_per_1000_coverage: "300.00",
+    is_stale: false,
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const onEdit = vi.fn();
+
+function renderSummary() {
+  return render(<InsuranceBenchmarkSummary onEdit={onEdit} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBenchmark = null;
+  mockLoading = false;
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("InsuranceBenchmarkSummary — nothing recorded", () => {
+  it("says nothing is being checked rather than staying silent", () => {
+    renderSummary();
+
+    expect(screen.getByTestId("insurance-benchmark-summary-empty")).toHaveTextContent(
+      "No market premium recorded, so no policy is being checked for overpaying.",
+    );
+  });
+
+  it("opens the editor from the empty state", async () => {
+    const user = userEvent.setup();
+    renderSummary();
+
+    await user.click(screen.getByRole("button", { name: "Record one" }));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a placeholder rather than the empty state while loading", () => {
+    mockLoading = true;
+
+    renderSummary();
+
+    expect(screen.getByTestId("insurance-benchmark-summary-loading")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+    expect(
+      screen.queryByTestId("insurance-benchmark-summary-empty"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("InsuranceBenchmarkSummary — a recorded premium", () => {
+  it("shows the premium, the coverage it buys, and the normalised rate", () => {
+    mockBenchmark = makeBenchmark();
+
+    renderSummary();
+
+    expect(screen.getByTestId("insurance-benchmark-summary-figure")).toHaveTextContent(
+      "$1,200/yr on $400,000 of dwelling coverage — $3.00 per $1,000",
+    );
+  });
+
+  it("names where the figure came from and when it was seen", () => {
+    mockBenchmark = makeBenchmark();
+
+    renderSummary();
+
+    const summary = screen.getByTestId("insurance-benchmark-summary");
+    expect(summary).toHaveTextContent("Harris County, TX");
+    expect(summary).toHaveTextContent("TDI HelpInsure, HO-3, $2,500 deductible");
+    expect(summary).toHaveTextContent("seen Aug 1, 2026");
+  });
+
+  it("renders the date from the plain date string without a timezone shift", () => {
+    // parseISO on a date-only string stays local; `new Date(...)` would parse it
+    // as UTC midnight and render the previous day west of Greenwich.
+    mockBenchmark = makeBenchmark({ observed_on: "2026-01-01" });
+
+    renderSummary();
+
+    expect(screen.getByTestId("insurance-benchmark-summary")).toHaveTextContent(
+      "seen Jan 1, 2026",
+    );
+  });
+
+  it("flags an ageing figure as worth rechecking", () => {
+    mockBenchmark = makeBenchmark({ is_stale: true });
+
+    renderSummary();
+
+    expect(screen.getByTestId("insurance-benchmark-summary-stale")).toHaveTextContent(
+      "worth rechecking",
+    );
+  });
+
+  it("does not flag a fresh figure", () => {
+    mockBenchmark = makeBenchmark();
+
+    renderSummary();
+
+    expect(
+      screen.queryByTestId("insurance-benchmark-summary-stale"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("omits the region and source separators when neither was recorded", () => {
+    mockBenchmark = makeBenchmark({ region_label: null, source: null });
+
+    renderSummary();
+
+    const summary = screen.getByTestId("insurance-benchmark-summary");
+    expect(summary).toHaveTextContent("seen Aug 1, 2026");
+    expect(summary).not.toHaveTextContent("·");
+  });
+
+  it("opens the editor from the update link", async () => {
+    mockBenchmark = makeBenchmark();
+    const user = userEvent.setup();
+    renderSummary();
+
+    await user.click(screen.getByTestId("insurance-benchmark-summary-edit"));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/InsurancePremiumComparisonCard.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/InsurancePremiumComparisonCard.test.tsx
@@ -1,0 +1,367 @@
+/**
+ * Unit tests for the dashboard premium-comparison card.
+ *
+ * The behaviour worth protecting is the ``no-benchmark`` case: with no market
+ * premium recorded, the card must say so rather than fall through to an
+ * all-clear. Silence there would read as "your premiums are fine" when the
+ * truth is "nothing was checked" — which is the exact failure this card exists
+ * to fix, since a policy renews itself quietly every year at whatever the
+ * carrier decides.
+ *
+ * The second thing pinned here is that "nothing tracked" and "all clear" stay
+ * distinguishable. Both arrive as two empty lists; only ``total_considered``
+ * tells them apart, and only one of them is good news.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { store } from "@/shared/store";
+import InsurancePremiumComparisonCard from "@/app/features/insurance/InsurancePremiumComparisonCard";
+import type { InsuranceBenchmark } from "@/shared/types/insurance/insurance-benchmark";
+import type { InsurancePolicySummary } from "@/shared/types/insurance/insurance-policy-summary";
+import type { InsurancePremiumComparison } from "@/shared/types/insurance/insurance-premium-comparison";
+import type { InsurancePremiumComparisonRow } from "@/shared/types/insurance/insurance-premium-comparison-row";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockRefetch = vi.fn();
+let mockComparison: InsurancePremiumComparison | undefined;
+let mockLoading = false;
+let mockError = false;
+let mockFetching = false;
+
+vi.mock("@/shared/store/insuranceBenchmarksApi", () => ({
+  useGetInsurancePremiumComparisonQuery: vi.fn(() => ({
+    data: mockComparison,
+    isLoading: mockLoading,
+    isError: mockError,
+    isFetching: mockFetching,
+    refetch: mockRefetch,
+  })),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+function makePolicy(
+  overrides: Partial<InsurancePolicySummary> = {},
+): InsurancePolicySummary {
+  return {
+    id: "policy-a",
+    listing_id: "listing-1",
+    policy_name: "Dwelling HO-3",
+    carrier: "State Farm",
+    effective_date: "2026-03-01",
+    expiration_date: "2027-03-01",
+    coverage_amount_cents: 40_000_000,
+    premium_cents: 200_000,
+    premium_frequency: "annual",
+    deductible_cents: 250_000,
+    wind_hail_deductible_pct: "2.00",
+    annual_premium_cents: 200_000,
+    created_at: "2026-03-01T00:00:00Z",
+    updated_at: "2026-03-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRow(
+  overrides: Partial<InsurancePremiumComparisonRow> = {},
+): InsurancePremiumComparisonRow {
+  return {
+    policy: makePolicy(),
+    status: "above_market",
+    policy_rate_cents_per_1000: "500.00",
+    benchmark_rate_cents_per_1000: "300.00",
+    gap_pct: "66.7",
+    benchmark_is_stale: false,
+    ...overrides,
+  };
+}
+
+function makeBenchmark(): InsuranceBenchmark {
+  return {
+    id: "bench-1",
+    annual_premium_cents: 120_000,
+    coverage_amount_cents: 40_000_000,
+    region_label: "Harris County, TX",
+    source: "TDI HelpInsure, HO-3, $2,500 deductible",
+    observed_on: "2026-08-13",
+    notes: null,
+    rate_cents_per_1000_coverage: "300.00",
+    is_stale: false,
+    created_at: "2026-08-13T00:00:00Z",
+    updated_at: "2026-08-13T00:00:00Z",
+  };
+}
+
+function makeComparison(
+  overrides: Partial<InsurancePremiumComparison> = {},
+): InsurancePremiumComparison {
+  return {
+    material_gap_pct: 25,
+    benchmark: makeBenchmark(),
+    above_market: [],
+    not_compared: [],
+    total_above_market: 0,
+    total_considered: 3,
+    has_stale_benchmark: false,
+    ...overrides,
+  };
+}
+
+function renderCard() {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <InsurancePremiumComparisonCard />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockComparison = undefined;
+  mockLoading = false;
+  mockError = false;
+  mockFetching = false;
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("InsurancePremiumComparisonCard — when it renders at all", () => {
+  it("renders nothing when the operator tracks no policies", () => {
+    mockComparison = makeComparison({ total_considered: 0 });
+
+    const { container } = renderCard();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("prompts for a market premium rather than implying an all-clear", () => {
+    mockComparison = makeComparison({ benchmark: null });
+
+    renderCard();
+
+    expect(
+      screen.getByTestId("insurance-premium-comparison-card-no-benchmark"),
+    ).toHaveTextContent("No market premium recorded yet");
+    expect(
+      screen.queryByTestId("insurance-premium-comparison-card-clear"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("points the no-benchmark prompt at the page that records one", () => {
+    mockComparison = makeComparison({ benchmark: null });
+
+    renderCard();
+
+    expect(screen.getByRole("link", { name: "Record one" })).toHaveAttribute(
+      "href",
+      "/insurance-policies",
+    );
+  });
+
+  it("states the all-clear once a benchmark exists and nothing is above it", () => {
+    mockComparison = makeComparison();
+
+    renderCard();
+
+    expect(
+      screen.getByTestId("insurance-premium-comparison-card-clear"),
+    ).toHaveTextContent(
+      "No policy costs more than 25% above the market premium you recorded",
+    );
+  });
+
+  it("reads the threshold off the payload rather than hardcoding one", () => {
+    mockComparison = makeComparison({ material_gap_pct: 40 });
+
+    renderCard();
+
+    expect(
+      screen.getByTestId("insurance-premium-comparison-card-clear"),
+    ).toHaveTextContent("more than 40% above");
+  });
+
+  it("shows a skeleton matching the loaded card while loading", () => {
+    mockLoading = true;
+
+    renderCard();
+
+    const skeleton = screen.getByTestId(
+      "insurance-premium-comparison-card-loading",
+    );
+    expect(skeleton).toHaveAttribute("aria-busy", "true");
+    // Two placeholder rows, each ending in a pill slot — the loaded shape.
+    expect(skeleton.querySelectorAll(".rounded-full")).toHaveLength(2);
+  });
+
+  it("offers a retry when the comparison query fails", async () => {
+    mockError = true;
+    const user = userEvent.setup();
+
+    renderCard();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("says the retry is in flight rather than looking unclicked", () => {
+    mockError = true;
+    mockFetching = true;
+
+    renderCard();
+
+    expect(screen.getByRole("button", { name: "Retrying..." })).toBeInTheDocument();
+  });
+
+  it("does not read a failed query as 'no policies tracked'", () => {
+    // The two are indistinguishable in the payload but opposite in meaning:
+    // one means nothing to check, the other means we do not know.
+    mockError = true;
+    mockComparison = undefined;
+
+    renderCard();
+
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+});
+
+describe("InsurancePremiumComparisonCard — above-market rows", () => {
+  it("names the policy, both normalised figures, and the gap", () => {
+    mockComparison = makeComparison({
+      above_market: [makeRow()],
+      total_above_market: 1,
+    });
+
+    renderCard();
+
+    const row = screen.getByTestId("insurance-premium-comparison-policy-a");
+    expect(row).toHaveTextContent("Dwelling HO-3");
+    expect(row).toHaveTextContent("State Farm");
+    // Normalised, not raw: cents per $1,000 of dwelling coverage.
+    expect(row).toHaveTextContent("paying $5.00 per $1,000 vs market $3.00 per $1,000");
+    expect(
+      screen.getByTestId("insurance-premium-comparison-gap-policy-a"),
+    ).toHaveTextContent("66.7% above market");
+  });
+
+  it("counts the flagged policies in the heading", () => {
+    mockComparison = makeComparison({
+      above_market: [
+        makeRow(),
+        makeRow({ policy: makePolicy({ id: "policy-b", policy_name: "Umbrella" }) }),
+      ],
+      total_above_market: 2,
+    });
+
+    renderCard();
+
+    expect(screen.getByTestId("insurance-premium-comparison-card")).toHaveTextContent(
+      "Paying above market (2)",
+    );
+    expect(
+      screen.queryByTestId("insurance-premium-comparison-card-clear"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("marks a row measured against an ageing benchmark", () => {
+    mockComparison = makeComparison({
+      above_market: [makeRow({ benchmark_is_stale: true })],
+      total_above_market: 1,
+      has_stale_benchmark: true,
+    });
+
+    renderCard();
+
+    expect(
+      screen.getByTestId("insurance-premium-comparison-stale-policy-a"),
+    ).toHaveTextContent("recorded a while ago");
+  });
+});
+
+describe("InsurancePremiumComparisonCard — caveats on good news", () => {
+  it("carries the staleness notice into the all-clear too", () => {
+    // An all-clear resting on a year-old figure is a weaker claim than one
+    // resting on a fresh one, and the reader cannot tell without being told.
+    mockComparison = makeComparison({ has_stale_benchmark: true });
+
+    renderCard();
+
+    expect(
+      screen.getByTestId("insurance-premium-comparison-stale-notice"),
+    ).toHaveTextContent("recorded a while ago");
+  });
+
+  it("omits the staleness notice when the benchmark is fresh", () => {
+    mockComparison = makeComparison();
+
+    renderCard();
+
+    expect(
+      screen.queryByTestId("insurance-premium-comparison-stale-notice"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("lists the policies it could not measure, and why", () => {
+    mockComparison = makeComparison({
+      not_compared: [
+        makeRow({
+          policy: makePolicy({
+            id: "policy-c",
+            policy_name: "Flood",
+            carrier: null,
+            coverage_amount_cents: null,
+          }),
+          status: "not_comparable",
+          policy_rate_cents_per_1000: null,
+          benchmark_rate_cents_per_1000: "300.00",
+          gap_pct: null,
+        }),
+      ],
+    });
+
+    renderCard();
+
+    const block = screen.getByTestId("insurance-premium-comparison-not-compared");
+    expect(block).toHaveTextContent("Not checked (1)");
+    expect(
+      screen.getByTestId("insurance-premium-not-compared-policy-c"),
+    ).toHaveTextContent("Missing premium or coverage");
+  });
+
+  it("keeps the not-checked list visible alongside the all-clear", () => {
+    // "Nothing was flagged" and "nothing was checked" look identical from the
+    // outside — the list is what separates them.
+    mockComparison = makeComparison({
+      not_compared: [
+        makeRow({
+          policy: makePolicy({ id: "policy-c" }),
+          status: "not_comparable",
+        }),
+      ],
+    });
+
+    renderCard();
+
+    expect(
+      screen.getByTestId("insurance-premium-comparison-card-clear"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("insurance-premium-comparison-not-compared"),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the not-checked block when every policy was measured", () => {
+    mockComparison = makeComparison();
+
+    renderCard();
+
+    expect(
+      screen.queryByTestId("insurance-premium-comparison-not-compared"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/benchmark-format.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/benchmark-format.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Unit tests for the shared market-gap helper.
+ *
+ * Shared by the utility rate card and the insurance premium card, so a change
+ * here moves both — which is the point: two cards disagreeing about whether
+ * ``-0.04`` is "below market" or "level" would be a bug the reader could only
+ * catch by putting them side by side.
+ */
+import { describe, it, expect } from "vitest";
+import { formatBenchmarkGap } from "@/shared/lib/benchmark-format";
+
+describe("formatBenchmarkGap", () => {
+  it("spells out the direction so a negative does not read as bad news", () => {
+    expect(formatBenchmarkGap("35.7")).toBe("35.7% above market");
+    expect(formatBenchmarkGap("-12.0")).toBe("12% below market");
+  });
+
+  it("names an exact tie rather than showing 0%", () => {
+    expect(formatBenchmarkGap("0")).toBe("level with market");
+  });
+
+  it("does not claim a direction on a difference rounding erased", () => {
+    // -0.04 rounds to 0 for display; calling it "0% below market" would assert
+    // a direction the reader cannot see in the number shown.
+    expect(formatBenchmarkGap("-0.04")).toBe("level with market");
+  });
+
+  it("falls back to a dash for missing or invalid input", () => {
+    expect(formatBenchmarkGap(null)).toBe("—");
+    expect(formatBenchmarkGap("")).toBe("—");
+    expect(formatBenchmarkGap("garbage")).toBe("—");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/insurance-policy-format.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/insurance-policy-format.test.ts
@@ -10,6 +10,7 @@ import {
   FREQUENCY_LABEL,
   formatAnnualPremium,
   formatBilledPremium,
+  formatCoverageRate,
   formatPolicyMoney,
   formatWindHailDeductible,
 } from "@/shared/lib/insurance-policy-format";
@@ -95,6 +96,30 @@ describe("formatWindHailDeductible", () => {
 
   it("renders an em dash for an unparseable value", () => {
     expect(formatWindHailDeductible("abc", 50000000)).toBe("—");
+  });
+});
+
+describe("formatCoverageRate", () => {
+  it("renders the comparison unit from a Decimal string of cents", () => {
+    expect(formatCoverageRate("300.00")).toBe("$3.00 per $1,000");
+  });
+
+  it("keeps the cents, since the gap between two rates lives there", () => {
+    // $2.69 and $3.00 per $1,000 is a 12% difference — rounding to whole
+    // dollars would erase most of what the comparison is measuring.
+    expect(formatCoverageRate("268.80")).toBe("$2.69 per $1,000");
+  });
+
+  it("renders an em dash when the rate could not be derived", () => {
+    expect(formatCoverageRate(null)).toBe("—");
+  });
+
+  it("renders an em dash for a blank string", () => {
+    expect(formatCoverageRate("  ")).toBe("—");
+  });
+
+  it("renders an em dash for an unparseable value", () => {
+    expect(formatCoverageRate("abc")).toBe("—");
   });
 });
 

--- a/apps/mybookkeeper/frontend/src/__tests__/utility-plan-format.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/utility-plan-format.test.ts
@@ -7,7 +7,6 @@
  */
 import { describe, it, expect } from "vitest";
 import {
-  formatBenchmarkGap,
   formatCents,
   formatCentsPerKwh,
   formatComparisonFigure,
@@ -83,22 +82,6 @@ describe("formatPlanDate", () => {
   it("falls back to a dash for missing or invalid input", () => {
     expect(formatPlanDate(null)).toBe("—");
     expect(formatPlanDate("garbage")).toBe("—");
-  });
-});
-
-describe("formatBenchmarkGap", () => {
-  it("spells out the direction so a negative does not read as bad news", () => {
-    expect(formatBenchmarkGap("35.7")).toBe("35.7% above market");
-    expect(formatBenchmarkGap("-12.0")).toBe("12% below market");
-  });
-
-  it("names an exact tie rather than showing 0%", () => {
-    expect(formatBenchmarkGap("0")).toBe("level with market");
-  });
-
-  it("falls back to a dash for missing or invalid input", () => {
-    expect(formatBenchmarkGap(null)).toBe("—");
-    expect(formatBenchmarkGap("garbage")).toBe("—");
   });
 });
 

--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/DashboardSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/DashboardSkeleton.tsx
@@ -1,6 +1,7 @@
 import Skeleton from "@/shared/components/ui/Skeleton";
 import Card from "@/shared/components/ui/Card";
 import UtilityPlanComparisonCardSkeleton from "@/app/features/utility/UtilityPlanComparisonCardSkeleton";
+import InsurancePremiumComparisonCardSkeleton from "@/app/features/insurance/InsurancePremiumComparisonCardSkeleton";
 
 export default function DashboardSkeleton() {
   return (
@@ -44,6 +45,10 @@ export default function DashboardSkeleton() {
       {/* Rate comparison card. Rendered from the card's own skeleton rather
           than re-described here, so the two cannot drift apart. */}
       <UtilityPlanComparisonCardSkeleton />
+
+      {/* Premium comparison card, same arrangement — its own skeleton, not a
+          copy of it. */}
+      <InsurancePremiumComparisonCardSkeleton />
 
       {/* Monthly Average card — matches MonthlyAverageCard */}
       <Card>

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsuranceBenchmarkDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsuranceBenchmarkDialog.tsx
@@ -1,0 +1,60 @@
+import InsuranceBenchmarkForm from "./InsuranceBenchmarkForm";
+import InsurancePolicyDialogShell from "./InsurancePolicyDialogShell";
+import { useGetInsuranceBenchmarkQuery } from "@/shared/store/insuranceBenchmarksApi";
+
+export interface InsuranceBenchmarkDialogProps {
+  onClose: () => void;
+}
+
+/**
+ * Records what comparable property insurance costs today.
+ *
+ * Operator-entered rather than fetched. Texas publishes county averages
+ * through TDI, but only inside an interactive viz with no feed behind it, and
+ * every quote depends on the roof age, claim history and deductible of the
+ * specific house — so a scraped figure would carry the same confident badge as
+ * a real quote while meaning considerably less.
+ */
+export default function InsuranceBenchmarkDialog({
+  onClose,
+}: InsuranceBenchmarkDialogProps) {
+  const { data: benchmark, isLoading } = useGetInsuranceBenchmarkQuery();
+
+  return (
+    <InsurancePolicyDialogShell
+      title="Record the market premium"
+      testId="insurance-benchmark-dialog"
+      onClose={onClose}
+    >
+      <div className="p-5 space-y-4">
+        <p className="text-sm text-muted-foreground">
+          A comparable quote for a comparable house. Your policies get measured
+          against it per $1,000 of dwelling coverage, so note where it came from
+          — a premium with no source is impossible to check later.
+        </p>
+
+        {isLoading ? (
+          <div
+            className="space-y-4 animate-pulse"
+            aria-busy="true"
+            data-testid="insurance-benchmark-dialog-loading"
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="h-16 bg-muted rounded" />
+              <div className="h-16 bg-muted rounded" />
+            </div>
+            <div className="h-16 bg-muted rounded" />
+            <div className="h-16 bg-muted rounded" />
+            <div className="h-16 bg-muted rounded" />
+          </div>
+        ) : (
+          <InsuranceBenchmarkForm
+            existing={benchmark}
+            onSaved={onClose}
+            onCancel={onClose}
+          />
+        )}
+      </div>
+    </InsurancePolicyDialogShell>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsuranceBenchmarkForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsuranceBenchmarkForm.tsx
@@ -1,0 +1,198 @@
+import { Button, LoadingButton } from "@platform/ui";
+import { INSURANCE_POLICY_INPUT_CLASS } from "./insurance-policy-input-class";
+import { useInsuranceBenchmarkForm } from "./useInsuranceBenchmarkForm";
+import type { InsuranceBenchmark } from "@/shared/types/insurance/insurance-benchmark";
+
+export interface InsuranceBenchmarkFormProps {
+  existing: InsuranceBenchmark | null | undefined;
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * The fields of the market-premium dialog.
+ *
+ * Premium and coverage are asked for together and side by side because they
+ * are only meaningful as a pair — the comparison divides one by the other, and
+ * a quote copied without the dwelling amount it was priced against is not a
+ * benchmark, just a number.
+ */
+export default function InsuranceBenchmarkForm({
+  existing,
+  onSaved,
+  onCancel,
+}: InsuranceBenchmarkFormProps) {
+  const form = useInsuranceBenchmarkForm({ existing, onSaved });
+
+  return (
+    <form onSubmit={(e) => void form.handleSubmit(e)} className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label
+            htmlFor="insurance-benchmark-premium"
+            className="block text-sm font-medium mb-1"
+          >
+            Annual premium ($)
+          </label>
+          <input
+            id="insurance-benchmark-premium"
+            type="number"
+            inputMode="decimal"
+            step="0.01"
+            min="0"
+            value={form.premium}
+            onChange={(e) => form.setPremium(e.target.value)}
+            className={INSURANCE_POLICY_INPUT_CLASS}
+            data-testid="insurance-benchmark-premium"
+            required
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            The yearly cost, even if the quote was monthly.
+          </p>
+        </div>
+
+        <div>
+          <label
+            htmlFor="insurance-benchmark-coverage"
+            className="block text-sm font-medium mb-1"
+          >
+            Dwelling coverage ($)
+          </label>
+          <input
+            id="insurance-benchmark-coverage"
+            type="number"
+            inputMode="numeric"
+            step="1000"
+            min="0"
+            value={form.coverage}
+            onChange={(e) => form.setCoverage(e.target.value)}
+            className={INSURANCE_POLICY_INPUT_CLASS}
+            data-testid="insurance-benchmark-coverage"
+            required
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            What that premium buys — your policies are measured per $1,000 of it.
+          </p>
+        </div>
+      </div>
+
+      <div>
+        <label
+          htmlFor="insurance-benchmark-region"
+          className="block text-sm font-medium mb-1"
+        >
+          Area it applies to
+        </label>
+        <input
+          id="insurance-benchmark-region"
+          type="text"
+          maxLength={120}
+          value={form.regionLabel}
+          onChange={(e) => form.setRegionLabel(e.target.value)}
+          placeholder="Harris County, TX"
+          className={INSURANCE_POLICY_INPUT_CLASS}
+          data-testid="insurance-benchmark-region"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Premiums swing hard by county — coastal wind exposure alone can double
+          them, so a figure with no area attached cannot be sanity-checked later.
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor="insurance-benchmark-source"
+          className="block text-sm font-medium mb-1"
+        >
+          Where you saw it
+        </label>
+        <input
+          id="insurance-benchmark-source"
+          type="text"
+          maxLength={255}
+          value={form.source}
+          onChange={(e) => form.setSource(e.target.value)}
+          placeholder="TDI HelpInsure quote, HO-3, $2,500 deductible"
+          className={INSURANCE_POLICY_INPUT_CLASS}
+          data-testid="insurance-benchmark-source"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Include the policy form and deductible — they are what makes the number
+          checkable against your own.
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor="insurance-benchmark-observed-on"
+          className="block text-sm font-medium mb-1"
+        >
+          Date observed
+        </label>
+        <input
+          id="insurance-benchmark-observed-on"
+          type="date"
+          value={form.observedOn}
+          max={form.maxObservedOn}
+          onChange={(e) => form.setObservedOn(e.target.value)}
+          className={INSURANCE_POLICY_INPUT_CLASS}
+          data-testid="insurance-benchmark-observed-on"
+          required
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="insurance-benchmark-notes"
+          className="block text-sm font-medium mb-1"
+        >
+          Notes
+        </label>
+        <textarea
+          id="insurance-benchmark-notes"
+          rows={2}
+          value={form.notes}
+          onChange={(e) => form.setNotes(e.target.value)}
+          className={`${INSURANCE_POLICY_INPUT_CLASS} resize-none`}
+          data-testid="insurance-benchmark-notes"
+        />
+      </div>
+
+      {/* Removal sits apart from save/cancel: without it a premium recorded
+          from a quote that turned out not to apply could only ever be
+          overwritten, never retracted, and every policy would keep being
+          measured against it. */}
+      <div className="flex items-center justify-between gap-3">
+        {form.canRemove ? (
+          <button
+            type="button"
+            onClick={() => void form.handleRemove()}
+            disabled={!form.canRemove}
+            className="text-sm font-medium text-destructive hover:underline disabled:opacity-50"
+            data-testid="insurance-benchmark-remove-button"
+          >
+            {form.isRemoving ? "Removing..." : "Remove premium"}
+          </button>
+        ) : (
+          <span />
+        )}
+        <div className="flex gap-3 pt-2 justify-end">
+          <Button type="button" variant="secondary" size="md" onClick={onCancel}>
+            Cancel
+          </Button>
+          <LoadingButton
+            type="submit"
+            variant="primary"
+            size="md"
+            isLoading={form.isSaving}
+            loadingText="Saving..."
+            disabled={!form.canSubmit}
+            data-testid="insurance-benchmark-save-button"
+          >
+            {existing ? "Update premium" : "Save premium"}
+          </LoadingButton>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsuranceBenchmarkSummary.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsuranceBenchmarkSummary.tsx
@@ -1,0 +1,89 @@
+import { format, parseISO } from "date-fns";
+import {
+  formatAnnualPremium,
+  formatCoverageRate,
+  formatPolicyMoney,
+} from "@/shared/lib/insurance-policy-format";
+import { useGetInsuranceBenchmarkQuery } from "@/shared/store/insuranceBenchmarksApi";
+
+export interface InsuranceBenchmarkSummaryProps {
+  onEdit: () => void;
+}
+
+/**
+ * The market premium the policies on this page are measured against.
+ *
+ * Shown here rather than only in the dialog so the number driving the
+ * above-market flag is visible next to the policies it judges — a benchmark the
+ * operator cannot see is one they cannot tell has gone stale.
+ */
+export default function InsuranceBenchmarkSummary({
+  onEdit,
+}: InsuranceBenchmarkSummaryProps) {
+  const { data: benchmark, isLoading } = useGetInsuranceBenchmarkQuery();
+
+  if (isLoading) {
+    return (
+      <div
+        className="h-9 bg-muted rounded animate-pulse"
+        aria-busy="true"
+        data-testid="insurance-benchmark-summary-loading"
+      />
+    );
+  }
+
+  if (!benchmark) {
+    return (
+      <p
+        className="text-sm text-muted-foreground"
+        data-testid="insurance-benchmark-summary-empty"
+      >
+        No market premium recorded, so no policy is being checked for overpaying.{" "}
+        <button
+          type="button"
+          onClick={onEdit}
+          className="font-medium text-primary hover:underline"
+          data-testid="insurance-benchmark-summary-record"
+        >
+          Record one
+        </button>
+        .
+      </p>
+    );
+  }
+
+  return (
+    <div
+      className="text-sm text-muted-foreground space-y-1"
+      data-testid="insurance-benchmark-summary"
+    >
+      <p className="font-medium text-foreground">Comparing against</p>
+      <p data-testid="insurance-benchmark-summary-figure">
+        {formatAnnualPremium(benchmark.annual_premium_cents)} on{" "}
+        {formatPolicyMoney(benchmark.coverage_amount_cents)} of dwelling coverage —{" "}
+        {formatCoverageRate(benchmark.rate_cents_per_1000_coverage)}
+      </p>
+      <p>
+        {benchmark.region_label ? `${benchmark.region_label} · ` : ""}
+        {benchmark.source ? `${benchmark.source} · ` : ""}seen{" "}
+        {format(parseISO(benchmark.observed_on), "MMM d, yyyy")}
+        {benchmark.is_stale ? (
+          <span
+            className="ml-1 text-amber-700 dark:text-amber-400"
+            data-testid="insurance-benchmark-summary-stale"
+          >
+            (worth rechecking)
+          </span>
+        ) : null}
+      </p>
+      <button
+        type="button"
+        onClick={onEdit}
+        className="font-medium text-primary hover:underline"
+        data-testid="insurance-benchmark-summary-edit"
+      >
+        Update market premium
+      </button>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyFormFields.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyFormFields.tsx
@@ -1,9 +1,8 @@
 import FormField from "@/shared/components/ui/FormField";
+import { INSURANCE_POLICY_INPUT_CLASS } from "./insurance-policy-input-class";
 import { FREQUENCY_LABEL } from "@/shared/lib/insurance-policy-format";
 import type { InsurancePolicyFormValues } from "@/shared/types/insurance/insurance-policy-form-values";
 import type { InsurancePremiumFrequency } from "@/shared/types/insurance/insurance-premium-frequency";
-
-const INPUT_CLASS = "w-full px-3 py-2 text-sm border rounded-md";
 
 const FREQUENCIES: InsurancePremiumFrequency[] = [
   "annual",
@@ -39,7 +38,7 @@ export default function InsurancePolicyFormFields({
           value={values.policyName}
           onChange={(e) => onChange("policyName", e.target.value)}
           placeholder="e.g. Landlord Insurance — 123 Main St"
-          className={INPUT_CLASS}
+          className={INSURANCE_POLICY_INPUT_CLASS}
           maxLength={255}
           required
           data-testid="insurance-policy-name-input"
@@ -52,7 +51,7 @@ export default function InsurancePolicyFormFields({
           value={values.carrier}
           onChange={(e) => onChange("carrier", e.target.value)}
           placeholder="e.g. State Farm"
-          className={INPUT_CLASS}
+          className={INSURANCE_POLICY_INPUT_CLASS}
           maxLength={255}
           data-testid="insurance-carrier-input"
         />
@@ -64,7 +63,7 @@ export default function InsurancePolicyFormFields({
           value={values.policyNumber}
           onChange={(e) => onChange("policyNumber", e.target.value)}
           placeholder="e.g. POL-123456"
-          className={INPUT_CLASS}
+          className={INSURANCE_POLICY_INPUT_CLASS}
           maxLength={255}
           data-testid="insurance-policy-number-input"
         />
@@ -76,7 +75,7 @@ export default function InsurancePolicyFormFields({
             type="date"
             value={values.effectiveDate}
             onChange={(e) => onChange("effectiveDate", e.target.value)}
-            className={INPUT_CLASS}
+            className={INSURANCE_POLICY_INPUT_CLASS}
             data-testid="insurance-effective-date-input"
           />
         </FormField>
@@ -86,7 +85,7 @@ export default function InsurancePolicyFormFields({
             type="date"
             value={values.expirationDate}
             onChange={(e) => onChange("expirationDate", e.target.value)}
-            className={INPUT_CLASS}
+            className={INSURANCE_POLICY_INPUT_CLASS}
             data-testid="insurance-expiration-date-input"
           />
         </FormField>
@@ -100,7 +99,7 @@ export default function InsurancePolicyFormFields({
           placeholder="e.g. 500000"
           min="0"
           step="1"
-          className={INPUT_CLASS}
+          className={INSURANCE_POLICY_INPUT_CLASS}
           data-testid="insurance-coverage-input"
         />
       </FormField>
@@ -120,7 +119,7 @@ export default function InsurancePolicyFormFields({
               placeholder="e.g. 1240"
               min="0"
               step="0.01"
-              className={INPUT_CLASS}
+              className={INSURANCE_POLICY_INPUT_CLASS}
               data-testid="insurance-premium-input"
             />
           </FormField>
@@ -129,7 +128,7 @@ export default function InsurancePolicyFormFields({
             <select
               value={values.premiumFrequency}
               onChange={(e) => onChange("premiumFrequency", e.target.value)}
-              className={INPUT_CLASS}
+              className={INSURANCE_POLICY_INPUT_CLASS}
               data-testid="insurance-premium-frequency-select"
             >
               {/* Blank rather than a default period: guessing "annually" over a
@@ -153,7 +152,7 @@ export default function InsurancePolicyFormFields({
               placeholder="e.g. 2500"
               min="0"
               step="1"
-              className={INPUT_CLASS}
+              className={INSURANCE_POLICY_INPUT_CLASS}
               data-testid="insurance-deductible-input"
             />
           </FormField>
@@ -167,7 +166,7 @@ export default function InsurancePolicyFormFields({
               min="0"
               max="100"
               step="0.01"
-              className={INPUT_CLASS}
+              className={INSURANCE_POLICY_INPUT_CLASS}
               data-testid="insurance-wind-hail-input"
             />
           </FormField>
@@ -179,7 +178,7 @@ export default function InsurancePolicyFormFields({
           value={values.notes}
           onChange={(e) => onChange("notes", e.target.value)}
           placeholder="Any additional notes about this policy..."
-          className={`${INPUT_CLASS} resize-none`}
+          className={`${INSURANCE_POLICY_INPUT_CLASS} resize-none`}
           rows={3}
           maxLength={5000}
           data-testid="insurance-notes-input"

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePremiumComparisonCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePremiumComparisonCard.tsx
@@ -1,0 +1,145 @@
+import { Link } from "react-router-dom";
+import AlertBox from "@/shared/components/ui/AlertBox";
+import Card from "@/shared/components/ui/Card";
+import { useGetInsurancePremiumComparisonQuery } from "@/shared/store/insuranceBenchmarksApi";
+import InsurancePremiumComparisonRow from "./InsurancePremiumComparisonRow";
+import InsurancePremiumComparisonCardSkeleton from "./InsurancePremiumComparisonCardSkeleton";
+import InsurancePremiumNotComparedRow from "./InsurancePremiumNotComparedRow";
+import { useInsuranceComparisonCardMode } from "./useInsuranceComparisonCardMode";
+import { INSURANCE_COMPARISON_CARD_MODES } from "@/shared/types/insurance/insurance-comparison-card-mode";
+
+/**
+ * Dashboard card for policies priced materially above the recorded market
+ * premium.
+ *
+ * The sibling expiration badge answers "is a policy about to lapse?". This one
+ * answers the question that badge cannot: a policy can be years from expiry and
+ * still cost half again what the same coverage sells for, and nothing in the
+ * app would have said so — insurance renews itself quietly at whatever the
+ * carrier decides.
+ *
+ * Every branch that reports good news also reports what that news rests on —
+ * the staleness caveat and the not-checked list render in the all-clear case
+ * too, because "no policy is above market" is only worth reading alongside how
+ * many were actually measured and how old the yardstick is.
+ */
+export default function InsurancePremiumComparisonCard() {
+  const { data, isLoading, isError, refetch, isFetching } =
+    useGetInsurancePremiumComparisonQuery();
+
+  const mode = useInsuranceComparisonCardMode({
+    isLoading,
+    isError,
+    totalAboveMarket: data?.total_above_market,
+    hasAnyPolicies: (data?.total_considered ?? 0) > 0,
+    hasBenchmark: data?.benchmark != null,
+  });
+
+  if (mode === INSURANCE_COMPARISON_CARD_MODES.LOADING) {
+    return <InsurancePremiumComparisonCardSkeleton />;
+  }
+  if (mode === INSURANCE_COMPARISON_CARD_MODES.HIDDEN) return null;
+
+  if (mode === INSURANCE_COMPARISON_CARD_MODES.ERROR) {
+    return (
+      <AlertBox variant="error" className="flex items-center justify-between gap-3">
+        <span>Couldn't compare your insurance premiums to the market.</span>
+        <button
+          type="button"
+          onClick={() => void refetch()}
+          className="text-sm font-medium hover:underline"
+        >
+          {isFetching ? "Retrying..." : "Retry"}
+        </button>
+      </AlertBox>
+    );
+  }
+
+  if (mode === INSURANCE_COMPARISON_CARD_MODES.NO_BENCHMARK) {
+    return (
+      <Card title="Premium check" className="text-sm text-muted-foreground">
+        <p data-testid="insurance-premium-comparison-card-no-benchmark">
+          No market premium recorded yet, so nothing is being checked against
+          your policies.{" "}
+          <Link to="/insurance-policies" className="font-medium text-primary hover:underline">
+            Record one
+          </Link>{" "}
+          to find out whether you are overpaying.
+        </p>
+      </Card>
+    );
+  }
+
+  // Both remaining modes are reachable only once the comparison has resolved,
+  // so the threshold below is read from the payload that owns it rather than
+  // re-declared here with a fallback the UI would have no business choosing.
+  if (!data) return null;
+
+  const isClear = mode === INSURANCE_COMPARISON_CARD_MODES.CLEAR;
+
+  return (
+    <Card className="p-0 overflow-hidden">
+      <div
+        className="flex items-center justify-between gap-3 px-6 py-4 border-b"
+        data-testid="insurance-premium-comparison-card"
+      >
+        <h2 className="text-base font-medium">
+          {isClear
+            ? "Premium check"
+            : `Paying above market (${data.total_above_market})`}
+        </h2>
+        <Link
+          to="/insurance-policies"
+          className="text-sm font-medium text-primary hover:underline shrink-0"
+        >
+          View all
+        </Link>
+      </div>
+
+      <div className="px-6 py-2">
+        {isClear ? (
+          <p
+            className="text-sm text-muted-foreground py-2"
+            data-testid="insurance-premium-comparison-card-clear"
+          >
+            No policy costs more than {data.material_gap_pct}% above the market
+            premium you recorded, per $1,000 of coverage.
+          </p>
+        ) : (
+          <ul className="divide-y" data-testid="insurance-premium-comparison-above-list">
+            {data.above_market.map((row) => (
+              <InsurancePremiumComparisonRow key={row.policy.id} row={row} />
+            ))}
+          </ul>
+        )}
+
+        {data.has_stale_benchmark ? (
+          <p
+            className="text-xs text-muted-foreground py-2"
+            data-testid="insurance-premium-comparison-stale-notice"
+          >
+            {isClear
+              ? "This rests on a market premium recorded a while ago — worth checking again."
+              : "These use a market premium recorded a while ago — worth checking again before acting on it."}
+          </p>
+        ) : null}
+
+        {data.not_compared.length > 0 ? (
+          <div
+            className="border-t pt-2 mt-1"
+            data-testid="insurance-premium-comparison-not-compared"
+          >
+            <p className="text-xs font-medium text-muted-foreground py-1">
+              Not checked ({data.not_compared.length})
+            </p>
+            <ul className="divide-y">
+              {data.not_compared.map((row) => (
+                <InsurancePremiumNotComparedRow key={row.policy.id} row={row} />
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePremiumComparisonCardSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePremiumComparisonCardSkeleton.tsx
@@ -1,0 +1,36 @@
+/**
+ * Loading placeholder for the dashboard premium-comparison card.
+ *
+ * Mirrors the loaded card's chrome exactly — ``p-0`` shell, a bordered header
+ * bar carrying the heading and the "View all" link, then two rows each with a
+ * two-line left block and a gap pill on the right. The dashboard's own skeleton
+ * renders this same component rather than re-describing it, so the two cannot
+ * drift apart and then both drift from the card they stand in for.
+ */
+export default function InsurancePremiumComparisonCardSkeleton() {
+  return (
+    <div
+      className="bg-card border rounded-lg p-0 overflow-hidden animate-pulse"
+      aria-busy="true"
+      data-testid="insurance-premium-comparison-card-loading"
+    >
+      <div className="flex items-center justify-between gap-3 px-6 py-4 border-b">
+        <div className="h-5 bg-muted rounded w-56" />
+        <div className="h-4 bg-muted rounded w-16 shrink-0" />
+      </div>
+      <div className="px-6 py-2">
+        <ul className="divide-y">
+          {[1, 2].map((i) => (
+            <li key={i} className="flex items-start justify-between gap-3 py-2">
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="h-4 bg-muted rounded w-1/2" />
+                <div className="h-3 bg-muted rounded w-2/3" />
+              </div>
+              <div className="h-5 w-28 bg-muted rounded-full shrink-0" />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePremiumComparisonRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePremiumComparisonRow.tsx
@@ -1,0 +1,47 @@
+import { formatBenchmarkGap } from "@/shared/lib/benchmark-format";
+import { formatCoverageRate } from "@/shared/lib/insurance-policy-format";
+import type { InsurancePremiumComparisonRow as ComparisonRow } from "@/shared/types/insurance/insurance-premium-comparison-row";
+
+export interface InsurancePremiumComparisonRowProps {
+  row: ComparisonRow;
+}
+
+export default function InsurancePremiumComparisonRow({
+  row,
+}: InsurancePremiumComparisonRowProps) {
+  const { policy } = row;
+  return (
+    <li
+      className="flex items-start justify-between gap-3 py-2"
+      data-testid={`insurance-premium-comparison-${policy.id}`}
+    >
+      <div className="min-w-0">
+        <p className="text-sm font-medium truncate">
+          {policy.policy_name}
+          {policy.carrier ? (
+            <span className="text-muted-foreground font-normal">
+              {" · "}
+              {policy.carrier}
+            </span>
+          ) : null}
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5 truncate">
+          paying {formatCoverageRate(row.policy_rate_cents_per_1000)} vs market{" "}
+          {formatCoverageRate(row.benchmark_rate_cents_per_1000)}
+          {row.benchmark_is_stale ? (
+            <span data-testid={`insurance-premium-comparison-stale-${policy.id}`}>
+              {" "}
+              (recorded a while ago)
+            </span>
+          ) : null}
+        </p>
+      </div>
+      <span
+        className="shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200"
+        data-testid={`insurance-premium-comparison-gap-${policy.id}`}
+      >
+        {formatBenchmarkGap(row.gap_pct)}
+      </span>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePremiumNotComparedRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePremiumNotComparedRow.tsx
@@ -1,0 +1,39 @@
+import { INSURANCE_BENCHMARK_STATUS_LABELS } from "@/shared/types/insurance/insurance-benchmark-status";
+import type { InsurancePremiumComparisonRow as ComparisonRow } from "@/shared/types/insurance/insurance-premium-comparison-row";
+
+export interface InsurancePremiumNotComparedRowProps {
+  row: ComparisonRow;
+}
+
+/**
+ * One policy the comparison could not measure, and why.
+ *
+ * Shown rather than dropped: "nothing was flagged" and "nothing was checked"
+ * look identical from the outside, and only one of them is good news.
+ */
+export default function InsurancePremiumNotComparedRow({
+  row,
+}: InsurancePremiumNotComparedRowProps) {
+  const { policy } = row;
+  return (
+    <li
+      className="flex items-start justify-between gap-3 py-2"
+      data-testid={`insurance-premium-not-compared-${policy.id}`}
+    >
+      <div className="min-w-0">
+        <p className="text-sm truncate">
+          {policy.policy_name}
+          {policy.carrier ? (
+            <span className="text-muted-foreground">
+              {" · "}
+              {policy.carrier}
+            </span>
+          ) : null}
+        </p>
+      </div>
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {INSURANCE_BENCHMARK_STATUS_LABELS[row.status]}
+      </span>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/insurance-policy-input-class.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/insurance-policy-input-class.ts
@@ -1,0 +1,11 @@
+/**
+ * The one input styling the insurance dialogs share.
+ *
+ * Its own module rather than an export off ``InsurancePolicyFormFields`` so the
+ * benchmark form can use it without importing the policy form it has nothing
+ * else to do with.
+ */
+// ``min-h-[44px]`` is the touch target, not decoration: px-3/py-2 at text-sm
+// renders about 36px, which is under the minimum on a phone.
+export const INSURANCE_POLICY_INPUT_CLASS =
+  "w-full min-h-[44px] px-3 py-2 text-sm border rounded-md";

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/useInsuranceBenchmarkForm.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/useInsuranceBenchmarkForm.ts
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { getApiErrorDetail } from "@/shared/lib/api-error-detail";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import {
+  useDeleteInsuranceBenchmarkMutation,
+  useUpsertInsuranceBenchmarkMutation,
+} from "@/shared/store/insuranceBenchmarksApi";
+import type { InsuranceBenchmark } from "@/shared/types/insurance/insurance-benchmark";
+
+interface UseInsuranceBenchmarkFormArgs {
+  existing: InsuranceBenchmark | null | undefined;
+  onSaved: () => void;
+}
+
+/** Today as ``YYYY-MM-DD`` in local time — ``toISOString`` would shift the date. */
+function todayLocalIso(): string {
+  const now = new Date();
+  const month = `${now.getMonth() + 1}`.padStart(2, "0");
+  const day = `${now.getDate()}`.padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+/** Dollars typed into an input → integer cents, or null when unusable. */
+function dollarsToCents(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return Math.round(parsed * 100);
+}
+
+/**
+ * Form state for the organization's single insurance benchmark.
+ *
+ * Both figures are required, and deliberately so: the comparison runs on
+ * premium *per $1,000 of coverage*, so a quoted premium with no coverage
+ * behind it cannot be normalised. Accepting it would store a benchmark that
+ * silently matches nothing — worse than refusing it, because the operator
+ * would believe their policies were being checked.
+ */
+export function useInsuranceBenchmarkForm({
+  existing,
+  onSaved,
+}: UseInsuranceBenchmarkFormArgs) {
+  const [premium, setPremium] = useState(() =>
+    existing ? (existing.annual_premium_cents / 100).toFixed(2) : "",
+  );
+  const [coverage, setCoverage] = useState(() =>
+    existing ? (existing.coverage_amount_cents / 100).toFixed(0) : "",
+  );
+  const [regionLabel, setRegionLabel] = useState(existing?.region_label ?? "");
+  const [source, setSource] = useState(existing?.source ?? "");
+  const [observedOn, setObservedOn] = useState(existing?.observed_on ?? todayLocalIso());
+  const [notes, setNotes] = useState(existing?.notes ?? "");
+
+  const [upsert, { isLoading: isSaving }] = useUpsertInsuranceBenchmarkMutation();
+  const [remove, { isLoading: isRemoving }] = useDeleteInsuranceBenchmarkMutation();
+
+  const premiumCents = dollarsToCents(premium);
+  const coverageCents = dollarsToCents(coverage);
+  const isBusy = isSaving || isRemoving;
+  const canSubmit =
+    premiumCents !== null && coverageCents !== null && observedOn !== "" && !isBusy;
+  const canRemove = Boolean(existing) && !isBusy;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (premiumCents === null || coverageCents === null || !canSubmit) return;
+    try {
+      await upsert({
+        annual_premium_cents: premiumCents,
+        coverage_amount_cents: coverageCents,
+        region_label: regionLabel.trim() === "" ? null : regionLabel.trim(),
+        source: source.trim() === "" ? null : source.trim(),
+        observed_on: observedOn,
+        notes: notes.trim() === "" ? null : notes.trim(),
+      }).unwrap();
+      showSuccess("Market premium saved.");
+      onSaved();
+    } catch (err) {
+      // The backend names the rule the payload broke — a future observation
+      // date, a figure past the cents/dollars sanity cap. A generic "try
+      // again" would send the operator to retype a value rejected identically.
+      showError(
+        getApiErrorDetail(err, "Couldn't save the market premium. Please try again."),
+      );
+    }
+  }
+
+  async function handleRemove() {
+    if (!canRemove) return;
+    try {
+      await remove().unwrap();
+      showSuccess("Market premium removed.");
+      onSaved();
+    } catch (err) {
+      showError(
+        getApiErrorDetail(err, "Couldn't remove the market premium. Please try again."),
+      );
+    }
+  }
+
+  return {
+    premium,
+    setPremium,
+    coverage,
+    setCoverage,
+    regionLabel,
+    setRegionLabel,
+    source,
+    setSource,
+    observedOn,
+    setObservedOn,
+    notes,
+    setNotes,
+    isSaving,
+    isRemoving,
+    canSubmit,
+    canRemove,
+    maxObservedOn: todayLocalIso(),
+    handleSubmit,
+    handleRemove,
+  };
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/useInsuranceComparisonCardMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/useInsuranceComparisonCardMode.ts
@@ -1,0 +1,39 @@
+import {
+  INSURANCE_COMPARISON_CARD_MODES,
+  type InsuranceComparisonCardMode,
+} from "@/shared/types/insurance/insurance-comparison-card-mode";
+
+interface UseInsuranceComparisonCardModeArgs {
+  isLoading: boolean;
+  isError: boolean;
+  /** Undefined until the comparison query resolves. */
+  totalAboveMarket: number | undefined;
+  /** Whether the operator tracks any policies at all. */
+  hasAnyPolicies: boolean;
+  /** Whether a market premium has been recorded to compare against. */
+  hasBenchmark: boolean;
+}
+
+/**
+ * Resolves what the dashboard premium-comparison card should render.
+ *
+ * The ``NO_BENCHMARK`` case is the one that carries the design: without a
+ * recorded market premium the card must not fall through to "nothing to worry
+ * about". Silence there would read as an all-clear when the truth is that
+ * nothing was checked — and insurance is exactly where that gap bites, since a
+ * policy renews itself quietly every year at whatever the carrier decides.
+ */
+export function useInsuranceComparisonCardMode({
+  isLoading,
+  isError,
+  totalAboveMarket,
+  hasAnyPolicies,
+  hasBenchmark,
+}: UseInsuranceComparisonCardModeArgs): InsuranceComparisonCardMode {
+  if (isLoading) return INSURANCE_COMPARISON_CARD_MODES.LOADING;
+  if (isError) return INSURANCE_COMPARISON_CARD_MODES.ERROR;
+  if (!hasAnyPolicies) return INSURANCE_COMPARISON_CARD_MODES.HIDDEN;
+  if (!hasBenchmark) return INSURANCE_COMPARISON_CARD_MODES.NO_BENCHMARK;
+  if ((totalAboveMarket ?? 0) === 0) return INSURANCE_COMPARISON_CARD_MODES.CLEAR;
+  return INSURANCE_COMPARISON_CARD_MODES.ABOVE_MARKET;
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanComparisonRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanComparisonRow.tsx
@@ -1,7 +1,5 @@
-import {
-  formatBenchmarkGap,
-  formatComparisonFigure,
-} from "@/shared/lib/utility-plan-format";
+import { formatBenchmarkGap } from "@/shared/lib/benchmark-format";
+import { formatComparisonFigure } from "@/shared/lib/utility-plan-format";
 import { UTILITY_SERVICE_TYPE_LABELS } from "@/shared/types/utility/utility-service-type";
 import type { UtilityPlanRateComparisonRow } from "@/shared/types/utility/utility-plan-rate-comparison-row";
 

--- a/apps/mybookkeeper/frontend/src/app/pages/Dashboard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Dashboard.tsx
@@ -29,6 +29,7 @@ import PropertyPnLGrid from "@/app/features/attribution/PropertyPnLGrid";
 import PnLDateRangeSelector from "@/app/features/attribution/PnLDateRangeSelector";
 import UtilityPlanRenewalAlertCard from "@/app/features/utility/UtilityPlanRenewalAlertCard";
 import UtilityPlanComparisonCard from "@/app/features/utility/UtilityPlanComparisonCard";
+import InsurancePremiumComparisonCard from "@/app/features/insurance/InsurancePremiumComparisonCard";
 
 function getThisMonthRange(): { since: string; until: string } {
   const now = new Date();
@@ -197,6 +198,11 @@ export default function Dashboard() {
           comfortably inside its term and still be the most expensive line in
           the portfolio, which the renewal card cannot say. */}
       <UtilityPlanComparisonCard />
+
+      {/* Same argument one domain over: a policy can be years from expiry and
+          still cost half again what the same coverage sells for, and the
+          expiration badge on the policy list cannot say so. */}
+      <InsurancePremiumComparisonCard />
 
       {!isEmpty && (filteredSummary?.by_month?.length ?? 0) > 0 && (
         <MonthlyAverageCard byMonth={filteredSummary?.by_month ?? []} />

--- a/apps/mybookkeeper/frontend/src/app/pages/InsurancePolicies.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/InsurancePolicies.tsx
@@ -4,6 +4,8 @@ import { useGetInsurancePoliciesQuery } from "@/shared/store/insurancePoliciesAp
 import SectionHeader from "@/shared/components/ui/SectionHeader";
 import AlertBox from "@/shared/components/ui/AlertBox";
 import { useInsurancePoliciesListMode } from "@/app/features/insurance/useInsurancePoliciesListMode";
+import InsuranceBenchmarkDialog from "@/app/features/insurance/InsuranceBenchmarkDialog";
+import InsuranceBenchmarkSummary from "@/app/features/insurance/InsuranceBenchmarkSummary";
 import InsurancePoliciesListBody from "@/app/features/insurance/InsurancePoliciesListBody";
 
 /**
@@ -12,6 +14,7 @@ import InsurancePoliciesListBody from "@/app/features/insurance/InsurancePolicie
  */
 export default function InsurancePolicies() {
   const [showExpiringSoon, setShowExpiringSoon] = useState(false);
+  const [showBenchmarkDialog, setShowBenchmarkDialog] = useState(false);
 
   const expiringBefore = showExpiringSoon
     ? format(addDays(new Date(), 30), "yyyy-MM-dd")
@@ -44,6 +47,8 @@ export default function InsurancePolicies() {
         </AlertBox>
       ) : null}
 
+      <InsuranceBenchmarkSummary onEdit={() => setShowBenchmarkDialog(true)} />
+
       {/* Expiring soon filter */}
       <div className="flex items-center gap-3">
         <label className="flex items-center gap-2 text-sm cursor-pointer">
@@ -63,6 +68,10 @@ export default function InsurancePolicies() {
         policies={policies}
         showExpiringSoon={showExpiringSoon}
       />
+
+      {showBenchmarkDialog ? (
+        <InsuranceBenchmarkDialog onClose={() => setShowBenchmarkDialog(false)} />
+      ) : null}
     </main>
   );
 }

--- a/apps/mybookkeeper/frontend/src/shared/lib/benchmark-format.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/benchmark-format.ts
@@ -1,0 +1,30 @@
+/**
+ * Display helpers shared by every "how does this compare to the market?"
+ * surface — utility rates today, insurance premiums as of this module.
+ *
+ * The gap is the same quantity in both domains: a signed percentage against a
+ * recorded observation. Keeping one implementation means the two cards can
+ * never disagree about how ``-0.04`` should read.
+ */
+
+/**
+ * Signed gap → ``"+38% above market"`` / ``"12% below market"``.
+ *
+ * The sign is spelled out in words because a bare ``-12%`` reads as bad news
+ * when it is the opposite — the plan is beating the market.
+ */
+export function formatBenchmarkGap(value: string | null): string {
+  if (value === null || value.trim() === "") return "—";
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return "—";
+  // Round first, then decide the wording. Testing the raw value would render
+  // -0.04 as "0% below market" — a direction claimed on a difference the
+  // display has already rounded away.
+  const rounded = Math.round(parsed * 10) / 10;
+  if (rounded === 0) return "level with market";
+  const magnitude = Math.abs(rounded).toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  });
+  return rounded > 0 ? `${magnitude}% above market` : `${magnitude}% below market`;
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/insurance-policy-format.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/insurance-policy-format.ts
@@ -58,6 +58,21 @@ export function formatAnnualPremium(cents: number | null): string {
 }
 
 /**
+ * The comparison unit → ``"$2.69 per $1,000"``.
+ *
+ * Arrives as a Decimal string in *cents* of annual premium per $1,000 of
+ * dwelling coverage. Premiums are never compared raw: $1,400 on a $250,000
+ * house and $1,400 on a $500,000 house are the same number and not remotely
+ * the same deal, so every figure the comparison shows is normalised first.
+ */
+export function formatCoverageRate(value: string | null): string {
+  if (value === null || value.trim() === "") return "—";
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return "—";
+  return `${formatCurrency(parsed / 100)} per $1,000`;
+}
+
+/**
  * Wind/hail deductible → ``"2% of coverage"``, with the dollar figure when the
  * coverage amount is known.
  *

--- a/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-format.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-format.ts
@@ -59,28 +59,6 @@ export function formatPlanDate(value: string | null): string {
 }
 
 /**
- * Signed gap → ``"+38% above market"`` / ``"12% below market"``.
- *
- * The sign is spelled out in words because a bare ``-12%`` reads as bad news
- * when it is the opposite — the plan is beating the market.
- */
-export function formatBenchmarkGap(value: string | null): string {
-  if (value === null || value.trim() === "") return "—";
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) return "—";
-  // Round first, then decide the wording. Testing the raw value would render
-  // -0.04 as "0% below market" — a direction claimed on a difference the
-  // display has already rounded away.
-  const rounded = Math.round(parsed * 10) / 10;
-  if (rounded === 0) return "level with market";
-  const magnitude = Math.abs(rounded).toLocaleString("en-US", {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 1,
-  });
-  return rounded > 0 ? `${magnitude}% above market` : `${magnitude}% below market`;
-}
-
-/**
  * A comparison figure in the unit its service type is priced in.
  *
  * Metered service is quoted per kWh; internet is a flat monthly amount. Both

--- a/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
@@ -4,6 +4,6 @@ import { axiosBaseQuery } from "./baseQuery";
 export const baseApi = createApi({
   reducerPath: "api",
   baseQuery: axiosBaseQuery,
-  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "BookingStatement", "Reconciliation", "TaxReturn", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor", "Screening", "Channel", "ChannelListing", "Calendar", "BlackoutAttachments", "LeaseTemplate", "SignedLease", "ReviewQueue", "InsurancePolicy", "AttributionQueue", "WelcomeManual", "WelcomeManualSend", "UtilityPlan", "MarketRateBenchmark"],
+  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "BookingStatement", "Reconciliation", "TaxReturn", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor", "Screening", "Channel", "ChannelListing", "Calendar", "BlackoutAttachments", "LeaseTemplate", "SignedLease", "ReviewQueue", "InsurancePolicy", "AttributionQueue", "WelcomeManual", "WelcomeManualSend", "UtilityPlan", "MarketRateBenchmark", "InsuranceBenchmark"],
   endpoints: () => ({}),
 });

--- a/apps/mybookkeeper/frontend/src/shared/store/insuranceBenchmarksApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/insuranceBenchmarksApi.ts
@@ -1,0 +1,55 @@
+import { baseApi } from "./baseApi";
+import type { InsuranceBenchmark } from "@/shared/types/insurance/insurance-benchmark";
+import type { InsuranceBenchmarkUpsertRequest } from "@/shared/types/insurance/insurance-benchmark-upsert-request";
+import type { InsurancePremiumComparison } from "@/shared/types/insurance/insurance-premium-comparison";
+
+/**
+ * RTK Query slice for the insurance benchmark and the comparison it drives.
+ *
+ * The benchmark is a singleton per organization, so there is no id in any of
+ * these routes and one cache entry covers the whole slice.
+ *
+ * The comparison is tagged ``InsurancePolicy:COMPARISON`` rather than under
+ * this slice's own tag because it is derived from *both* sides — editing a
+ * policy's premium must refresh it just as recording a new benchmark does.
+ * Benchmark mutations invalidate both tags for that reason.
+ */
+const insuranceBenchmarksApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getInsuranceBenchmark: builder.query<InsuranceBenchmark | null, void>({
+      query: () => ({ url: "/insurance-benchmarks" }),
+      providesTags: [{ type: "InsuranceBenchmark", id: "CURRENT" }],
+    }),
+
+    getInsurancePremiumComparison: builder.query<InsurancePremiumComparison, void>({
+      query: () => ({ url: "/insurance-policies/premium-comparison" }),
+      providesTags: [{ type: "InsurancePolicy", id: "COMPARISON" }],
+    }),
+
+    upsertInsuranceBenchmark: builder.mutation<
+      InsuranceBenchmark,
+      InsuranceBenchmarkUpsertRequest
+    >({
+      query: (data) => ({ url: "/insurance-benchmarks", method: "PUT", data }),
+      invalidatesTags: [
+        { type: "InsuranceBenchmark", id: "CURRENT" },
+        { type: "InsurancePolicy", id: "COMPARISON" },
+      ],
+    }),
+
+    deleteInsuranceBenchmark: builder.mutation<void, void>({
+      query: () => ({ url: "/insurance-benchmarks", method: "DELETE" }),
+      invalidatesTags: [
+        { type: "InsuranceBenchmark", id: "CURRENT" },
+        { type: "InsurancePolicy", id: "COMPARISON" },
+      ],
+    }),
+  }),
+});
+
+export const {
+  useGetInsuranceBenchmarkQuery,
+  useGetInsurancePremiumComparisonQuery,
+  useUpsertInsuranceBenchmarkMutation,
+  useDeleteInsuranceBenchmarkMutation,
+} = insuranceBenchmarksApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-benchmark-status.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-benchmark-status.ts
@@ -1,0 +1,22 @@
+/**
+ * How a policy's premium compares to the recorded market benchmark.
+ *
+ * Mirrors ``BENCHMARK_STATUSES`` in
+ * ``backend/app/core/insurance_benchmark_constants.py``. A value added there
+ * MUST be added here in the same PR.
+ */
+export type InsuranceBenchmarkStatus =
+  | "no_benchmark"
+  | "not_comparable"
+  | "at_or_below_market"
+  | "above_market";
+
+export const INSURANCE_BENCHMARK_STATUS_LABELS: Record<
+  InsuranceBenchmarkStatus,
+  string
+> = {
+  no_benchmark: "No market premium recorded",
+  not_comparable: "Missing premium or coverage",
+  at_or_below_market: "At or below market",
+  above_market: "Above market",
+};

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-benchmark-upsert-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-benchmark-upsert-request.ts
@@ -1,0 +1,15 @@
+/**
+ * Body for ``PUT /insurance-benchmarks``.
+ *
+ * Mirrors ``schemas/insurance/insurance_benchmark_upsert_request.py``. Both
+ * figures are required: a premium without the coverage it buys cannot be
+ * normalised, and a benchmark that cannot be normalised never matches anything.
+ */
+export interface InsuranceBenchmarkUpsertRequest {
+  annual_premium_cents: number;
+  coverage_amount_cents: number;
+  region_label?: string | null;
+  source?: string | null;
+  observed_on: string;
+  notes?: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-benchmark.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-benchmark.ts
@@ -1,0 +1,24 @@
+/**
+ * The organization's recorded market observation for property insurance.
+ *
+ * Mirrors ``schemas/insurance/insurance_benchmark_response.py``. One per
+ * organization — a singleton, so there is no id in the routes that write it.
+ *
+ * ``rate_cents_per_1000_coverage`` arrives as a string: it is a Decimal on the
+ * backend, and JSON numbers are IEEE doubles.
+ */
+export interface InsuranceBenchmark {
+  id: string;
+  annual_premium_cents: number;
+  coverage_amount_cents: number;
+  region_label: string | null;
+  source: string | null;
+  observed_on: string;
+  notes: string | null;
+  /** Cents of annual premium per $1,000 of dwelling coverage. Derived. */
+  rate_cents_per_1000_coverage: string | null;
+  /** Derived server-side from ``observed_on`` — never stored. */
+  is_stale: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-comparison-card-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-comparison-card-mode.ts
@@ -1,0 +1,19 @@
+/**
+ * What the dashboard premium-comparison card should render.
+ *
+ * ``NO_BENCHMARK`` is distinct from ``CLEAR``: with nothing to compare against
+ * the card cannot claim the policies are priced well, so it prompts the
+ * operator to record a market premium instead of implying an all-clear it has
+ * not earned. ``HIDDEN`` covers the operator who tracks no policies at all.
+ */
+export const INSURANCE_COMPARISON_CARD_MODES = {
+  LOADING: "loading",
+  ERROR: "error",
+  HIDDEN: "hidden",
+  NO_BENCHMARK: "no-benchmark",
+  CLEAR: "clear",
+  ABOVE_MARKET: "above-market",
+} as const;
+
+export type InsuranceComparisonCardMode =
+  (typeof INSURANCE_COMPARISON_CARD_MODES)[keyof typeof INSURANCE_COMPARISON_CARD_MODES];

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-premium-comparison-row.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-premium-comparison-row.ts
@@ -1,0 +1,20 @@
+import type { InsuranceBenchmarkStatus } from "@/shared/types/insurance/insurance-benchmark-status";
+import type { InsurancePolicySummary } from "@/shared/types/insurance/insurance-policy-summary";
+
+/**
+ * One policy measured against the organization's insurance benchmark.
+ *
+ * Mirrors ``schemas/insurance/insurance_policy_premium_comparison_row.py``.
+ * Both rate figures are cents of annual premium per $1,000 of dwelling
+ * coverage — raw premiums are never compared, since a $1,400 policy on a
+ * $250,000 house and a $1,400 policy on a $500,000 house are not the same deal.
+ */
+export interface InsurancePremiumComparisonRow {
+  policy: InsurancePolicySummary;
+  status: InsuranceBenchmarkStatus;
+  policy_rate_cents_per_1000: string | null;
+  benchmark_rate_cents_per_1000: string | null;
+  /** Signed — negative means the policy beats the market. */
+  gap_pct: string | null;
+  benchmark_is_stale: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-premium-comparison.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-premium-comparison.ts
@@ -1,0 +1,25 @@
+import type { InsuranceBenchmark } from "@/shared/types/insurance/insurance-benchmark";
+import type { InsurancePremiumComparisonRow } from "@/shared/types/insurance/insurance-premium-comparison-row";
+
+/**
+ * Dashboard payload for policies priced above the market.
+ *
+ * Mirrors ``schemas/insurance/insurance_policy_premium_comparison_response.py``.
+ * ``material_gap_pct`` comes from the backend so the UI can say "more than N%
+ * above" without hardcoding a threshold it does not own.
+ */
+export interface InsurancePremiumComparison {
+  material_gap_pct: number;
+  /** The benchmark every row was measured against; null when none recorded. */
+  benchmark: InsuranceBenchmark | null;
+  above_market: InsurancePremiumComparisonRow[];
+  not_compared: InsurancePremiumComparisonRow[];
+  total_above_market: number;
+  /**
+   * Every unexpired policy that was looked at, including the ones that came
+   * back fine. Zero means "nothing tracked"; non-zero with two empty lists
+   * means "all clear" — the card cannot tell those apart without it.
+   */
+  total_considered: number;
+  has_stale_benchmark: boolean;
+}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -604,22 +604,31 @@
         "backend/app/schemas/insurance/",
         "backend/app/services/insurance/",
         "backend/app/api/insurance_policies.py",
+        "backend/app/api/insurance_benchmarks.py",
         "backend/app/core/insurance_enums.py",
+        "backend/app/core/insurance_benchmark_constants.py",
         "backend/alembic/versions/insur260504_add_insurance_policy_tables.py",
         "backend/alembic/versions/inspremium260812_add_insurance_premium.py",
+        "backend/alembic/versions/insbench260813_add_insurance_benchmarks.py",
         "frontend/src/app/pages/InsurancePolicies.tsx",
         "frontend/src/app/pages/InsurancePolicyDetail.tsx",
         "frontend/src/app/features/insurance/",
         "frontend/src/shared/types/insurance/",
         "frontend/src/shared/lib/insurance-policy-format.ts",
         "frontend/src/shared/lib/insurance-policy-form.ts",
-        "frontend/src/shared/store/insurancePoliciesApi.ts"
+        "frontend/src/shared/lib/benchmark-format.ts",
+        "frontend/src/shared/store/insurancePoliciesApi.ts",
+        "frontend/src/shared/store/insuranceBenchmarksApi.ts"
       ],
       "backend_tests": [
         "test_insurance_policies_api.py",
         "test_insurance_policy_repo.py",
         "test_insurance_policy_validation.py",
-        "test_premium_math.py"
+        "test_premium_math.py",
+        "test_insurance_benchmark_compare.py",
+        "test_insurance_benchmark_repo.py",
+        "test_insurance_benchmark_service.py",
+        "test_insurance_benchmarks_api.py"
       ],
       "frontend_tests": [
         "InsuranceExpirationBadge.test.tsx",
@@ -628,11 +637,18 @@
         "InsurancePolicyDetail.test.tsx",
         "insurance-policy-format.test.ts",
         "insurance-policy-form.test.ts",
-        "usePageListModes.test.ts"
+        "usePageListModes.test.ts",
+        "InsurancePremiumComparisonCard.test.tsx",
+        "InsuranceBenchmarkDialog.test.tsx",
+        "InsuranceBenchmarkSummary.test.tsx",
+        "benchmark-format.test.ts",
+        "Dashboard.test.tsx"
       ],
       "e2e_specs": [
         "insurance-premium.spec.ts",
-        "insurance-policy-detail-layout.spec.ts"
+        "insurance-policy-detail-layout.spec.ts",
+        "insurance-premium-benchmark.spec.ts",
+        "insurance-premium-comparison-layout.spec.ts"
       ]
     },
     "utility_plans": {
@@ -670,6 +686,7 @@
         "frontend/src/shared/lib/utility-plan-form.ts",
         "frontend/src/shared/lib/utility-plan-draft.ts",
         "frontend/src/shared/lib/utility-plan-read-errors.ts",
+        "frontend/src/shared/lib/benchmark-format.ts",
         "backend/app/models/properties/market_rate_benchmark.py",
         "backend/app/repositories/properties/market_rate_benchmark_repo.py",
         "backend/app/schemas/properties/market_rate_benchmark_response.py",
@@ -722,6 +739,7 @@
         "utility-plan-format.test.ts",
         "utility-plan-form.test.ts",
         "utility-plan-draft.test.ts",
+        "benchmark-format.test.ts",
         "Dashboard.test.tsx",
         "UtilityPlanComparisonCard.test.tsx",
         "MarketRateBenchmarkDialog.test.tsx",


### PR DESCRIPTION
Insurance renews itself quietly every year at whatever the carrier decides, and nothing in the app said so. The expiration badge answers *"is a policy about to lapse?"* — it cannot answer *"is this policy half again what the same coverage sells for?"*, which is the question that costs real money.

This is the insurance analogue of the utility market-rate benchmark (#1064).

## What ships

- **`insurance_benchmarks`** — one operator-entered market observation per organization (premium + the dwelling coverage it bought, region, source, `observed_on`). A singleton, so `PUT`/`GET`/`DELETE /insurance-benchmarks` carry no id. `GET` returns `null` rather than 404 — "none recorded" is every org's starting state, not a client error.
- **Comparison normalised to cents of annual premium per $1,000 of coverage.** Raw premiums are never compared: $1,400 on a $250,000 house and $1,400 on a $500,000 house are the same number and not remotely the same deal.
- **`GET /insurance-policies/premium-comparison`** — lives on the policy resource because it returns policies, and is declared *before* `/{policy_id}` so the literal path is not swallowed by the UUID route (pinned by a test).
- **Dashboard card** for policies materially above market, plus a **summary on the policies page** so the figure driving the flag is visible next to the policies it judges. A benchmark the operator cannot see is one they cannot tell has gone stale.

## Design notes

**Both figures are required on the benchmark.** A premium with no coverage behind it cannot be normalised, so it would sit in the database matching nothing while the operator believed their policies were being checked. Refusing it is the point.

**`MATERIAL_GAP_PCT = 25`** (utility uses 10). A county average spans dwellings that legitimately differ on roof age, claim history and distance to a fire station, so a tighter threshold would be mostly false positives. Staleness is **365 days** — TDI publishes annually and policies reprice at renewal.

**`total_considered` on the payload.** Utility needed a second query (`useHasAnyUtilityPlans`) to tell "no policies tracked" from "everything is priced fine" — both render as two empty lists, and only one of them is good news. One extra integer removes the roundtrip.

**No live-quote finder.** There is no insurance equivalent of the Power to Choose fetcher: HelpInsure's rate wizard is a session-based Struts app returning HTTP 000 to a plain client, and TDI's county data sits behind a Tableau viz with no CSV or API. A scraped figure would carry the same confident badge as a real quote while meaning considerably less, so the benchmark is operator-entered by design. Recorded here as *do not re-attempt*.

## Drive-by fix — a latent 500 in shipped utility code

`market_rate_benchmark_repo.upsert` (from #1064) has the same race-recovery branch as the new insurance repo, and building the analogue surfaced a real bug in it. On a concurrent insert the SAVEPOINT rollback has **usually already evicted** the pending instance, so the unconditional `db.expunge(benchmark)` raised `InvalidRequestError` — and that exception *replaced* the `IntegrityError` being handled, turning a recovered race into a 500.

Both repos now expunge only when the instance is still attached:

```python
if inspect(benchmark).session_id is not None:
    db.expunge(benchmark)
```

Each carries a regression test that was verified to fail without the guard.

## Tests

- **58 new backend**: pure comparison math, service (annualisation, expiry filtering, tenant scoping, widest-gap-first ordering), routes (payload validation, permissions, route ordering), repo (singleton invariant, the race path).
- **39 new frontend unit**: all six card modes, the staleness caveat carried into the all-clear, the not-checked list, the both-figures-required gate, the remove path, `formatCoverageRate`.
- **5 new E2E** across a behavioural spec and a layout spec, run live against a real server + DB, with a post-run check confirming zero rows left behind. The behavioural spec seeds two policies at the **same premium on different dwelling amounts** — identical raw, 2× apart normalised — so a comparison that skipped the normalisation would flag both or neither.

`formatBenchmarkGap` moved out of `utility-plan-format.ts` into a shared `benchmark-format.ts` rather than being copied — the gap is the same quantity in both domains, and one implementation means the two cards can never disagree about how `-0.04` should read.

## Operational migration

None. Additive table, no new env vars, no changed defaults; the previous image runs fine without the migration applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us3w1x8DaRELqb4frym5KH
