### PR TITLE
feat(mybookkeeper): watch Texas rate filings for landlord-policy increases

### DIFF
--- a/.github/workflows/ci-mybookkeeper.yml
+++ b/.github/workflows/ci-mybookkeeper.yml
@@ -185,7 +185,8 @@ jobs:
             e2e/welcome-manuals-layout-mock.spec.ts \
             e2e/utility-better-plans.spec.ts \
             e2e/utility-plan-document-upload.spec.ts \
-            e2e/insurance-policy-document-upload.spec.ts
+            e2e/insurance-policy-document-upload.spec.ts \
+            e2e/insurance-rate-watch.spec.ts
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/apps/mybookkeeper/backend/app/api/insurance_market.py
+++ b/apps/mybookkeeper/backend/app/api/insurance_market.py
@@ -1,0 +1,37 @@
+"""HTTP route for the Texas dwelling rate watch.
+
+Route prefix: /insurance-market.
+
+Its own resource rather than a path under ``/insurance-policies``: the response
+is as much about the market as about the operator's policies, and it reaches
+outside the database to the Texas Department of Insurance. Keeping it separate
+means the policy list never inherits a third party's latency.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member
+from app.schemas.insurance.insurance_market_watch_response import (
+    InsuranceMarketWatchResponse,
+)
+from app.services.insurance import insurance_market_watch_service
+
+router = APIRouter(prefix="/insurance-market", tags=["insurance-market"])
+
+
+@router.get("/rate-watch", response_model=InsuranceMarketWatchResponse)
+async def get_rate_watch(
+    ctx: RequestContext = Depends(current_org_member),
+) -> InsuranceMarketWatchResponse:
+    """What Texas carriers have filed that bears on the operator's renewals.
+
+    A read, so org membership is enough — nothing here writes. The TDI feed is
+    public data about companies, not about the operator, so no part of their
+    portfolio leaves the server to fetch it.
+    """
+    return await insurance_market_watch_service.get_market_watch(
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
+    )

--- a/apps/mybookkeeper/backend/app/core/tdi_rate_filings_constants.py
+++ b/apps/mybookkeeper/backend/app/core/tdi_rate_filings_constants.py
@@ -1,0 +1,94 @@
+"""Constants for the TDI rate-filings feed.
+
+Texas requires every property insurer to file a rate change with the Department
+of Insurance before it can charge it, and TDI republishes those filings as a
+public Socrata dataset. It is free, unauthenticated, and covers the whole
+market — the same posture as ``power_to_choose_constants`` for electricity.
+
+Why this feed and not a quote site
+==================================
+
+The obvious candidate, TDI's own HelpInsure.com, returns only owner-occupied
+forms (HO-3, HO-5, HO-A/B/C). A rental property on a dwelling-fire policy has
+no entry point there — its form asks "rent or own" and means the occupant.
+This dataset is filed *by policy subtype*, and ``Dwelling`` is the landlord
+line, so it is the one public Texas source that speaks about investment
+property at all.
+
+What it gives, and what it does not
+===================================
+
+It gives rate *changes*, not rate *levels*: who is raising, by how much, and
+from when. It cannot say what a specific property would be quoted. That turns
+out to be the more actionable half — a renewal quote arrives as a fait
+accompli, whereas a filing is public months before it reaches the operator's
+mailbox, which is enough time to shop.
+"""
+
+# Socrata SODA endpoint. Public, no app token required at this volume; Socrata
+# throttles anonymous callers rather than rejecting them.
+TDI_RATE_FILINGS_URL = "https://data.texas.gov/resource/iubg-btfs.json"
+
+# The subtype that carries landlord / dwelling-fire (DP-1, DP-2, DP-3) paper.
+# Filtered server-side so the app never pulls the ~17k personal-auto rows.
+DWELLING_SUBTYPE = "Dwelling"
+
+# The dataset holds ~700 dwelling filings in total, so this ceiling fetches the
+# entire line in one request while still bounding a runaway response.
+MAX_FILINGS_FETCHED = 1_000
+
+FETCH_TIMEOUT_SECONDS: float = 15.0
+
+# Filings are republished as TDI processes them — daily at most. A short
+# in-process cache spares the host a request per page view.
+FILINGS_CACHE_TTL_SECONDS: int = 3_600
+
+# --- Which filings actually count --------------------------------------------
+#
+# ``status`` is Pending or Closed, and a Closed filing carries a ``closed_type``
+# saying how it closed. Only "Reviewed" means the rate took effect. Reporting a
+# Withdrawn or Rejected filing as an upcoming increase would invent a rise the
+# operator will never be charged — 63 of the 704 dwelling filings are in that
+# state, so this is not a hypothetical.
+
+STATUS_PENDING = "Pending"
+STATUS_CLOSED = "Closed"
+
+# The only ``closed_type`` that means "this rate is in force".
+CLOSED_TYPE_IN_FORCE = "Reviewed"
+
+# Closed dispositions that mean the filing never took effect.
+CLOSED_TYPES_ABANDONED: frozenset[str] = frozenset({"Withdrawn", "Rejected"})
+
+# --- Relevance ----------------------------------------------------------------
+
+# How far back a filing stays interesting. A rate change from four years ago is
+# already baked into what the operator pays today and says nothing about the
+# next renewal.
+FILING_LOOKBACK_DAYS = 730
+
+# A change smaller than this is inside the noise of a reunderwriting and not
+# worth putting in front of anyone as a rate movement.
+MIN_NOTABLE_CHANGE_PCT = 1.0
+
+# Stand-in renewal date for a policy with no expiration recorded, counted from
+# today. Filings are matched against a policy's renewal date, and without one
+# there is nothing to compare to — assuming a renewal roughly a term-quarter
+# out keeps those policies in the outlook instead of silently dropping them.
+RENEWAL_HORIZON_DAYS = 120
+
+# Cap on carriers shown in the market view. One row per carrier, most recently
+# filed first, so this is "the N carriers who last moved their dwelling rates".
+MAX_MARKET_FILINGS = 25
+
+# --- Why an outlook could not be produced -------------------------------------
+#
+# Shown to the operator instead of an empty filing list, so "we could not check"
+# never reads as "nothing is coming".
+
+REASON_NO_CARRIER = "No carrier recorded on this policy."
+REASON_NO_FILINGS = "No dwelling-line filings found under this carrier's name."
+REASON_FEED_DOWN = (
+    "The Texas Department of Insurance filing data could not be reached, so "
+    "nothing was checked."
+)

--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -32,7 +32,7 @@ from app.db.session import AsyncSessionLocal
 from app.schemas.user.user import UserRead, UserCreate, UserUpdate
 from app.services.storage.bucket_initializer import ensure_bucket
 from app.workers.upload_processor_worker import main as worker_main
-from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_benchmarks, insurance_policies, lease_templates, listings, market_rate_benchmarks, properties, public_inquiries, public_welcome_manuals, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, exports, imports, health_dashboard, totp, taxpayer_profiles, utility_plans, welcome_manuals
+from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_benchmarks, insurance_market, insurance_policies, lease_templates, listings, market_rate_benchmarks, properties, public_inquiries, public_welcome_manuals, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, exports, imports, health_dashboard, totp, taxpayer_profiles, utility_plans, welcome_manuals
 
 logging.basicConfig(
     level=logging.INFO,
@@ -206,6 +206,7 @@ app.include_router(lease_templates.router)
 app.include_router(signed_leases.router)
 app.include_router(insurance_policies.router)
 app.include_router(insurance_benchmarks.router)
+app.include_router(insurance_market.router)
 app.include_router(utility_plans.router)
 app.include_router(market_rate_benchmarks.router)
 app.include_router(screening.router)

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_market_watch_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_market_watch_response.py
@@ -1,0 +1,25 @@
+"""Response for the dwelling-market rate watch."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from app.schemas.insurance.insurance_policy_rate_outlook import (
+    InsurancePolicyRateOutlook,
+)
+from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
+
+
+class InsuranceMarketWatchResponse(BaseModel):
+    # One entry per active policy, whether or not a filing was matched.
+    outlooks: list[InsurancePolicyRateOutlook] = []
+    # Recent dwelling-line filings across the whole Texas market, regardless of
+    # whether the operator holds a policy with the carrier. This is the
+    # shortlist to take to an agent: a DP-3 is agent-bound, so "who is holding
+    # rates flat" is the actionable output.
+    market_filings: list[InsuranceRateFiling] = []
+    # True when any policy has an in-force filing landing before its renewal.
+    has_any_increase: bool = False
+    # Set when TDI could not be reached. The policies still list, each carrying
+    # the same explanation, because a silent empty result would read as "no
+    # increases filed" when the truth is "nothing was checked".
+    feed_unavailable_reason: str | None = None

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_rate_outlook.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_rate_outlook.py
@@ -1,0 +1,33 @@
+"""What the dwelling filings say about one policy's next renewal."""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel
+
+from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
+
+
+class InsurancePolicyRateOutlook(BaseModel):
+    policy_id: uuid.UUID
+    policy_name: str
+    property_name: str | None = None
+    carrier: str | None = None
+    expiration_date: _dt.date | None = None
+    current_premium_cents: int | None = None
+    # Filings matched to this policy's carrier that take effect on or before
+    # its renewal, newest first.
+    filings: list[InsuranceRateFiling] = []
+    # Compounded effect of the in-force filings above, as a percentage. None
+    # when nothing in force applies — which is different from 0.0%, meaning a
+    # carrier that filed and held its rates flat.
+    projected_change_pct: float | None = None
+    # ``current_premium_cents`` moved by ``projected_change_pct``. An estimate
+    # of the renewal premium, not a quote: a filing is a statewide average and
+    # an individual property's change depends on its own rating factors.
+    projected_premium_cents: int | None = None
+    # Set when no outlook could be produced — no carrier recorded on the
+    # policy, or no filing found under that carrier's name. Shown instead of an
+    # empty list so "we found nothing" never reads as "nothing is coming".
+    unavailable_reason: str | None = None

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_rate_filing.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_rate_filing.py
@@ -1,0 +1,32 @@
+"""One dwelling-line rate filing a Texas carrier made with TDI."""
+from __future__ import annotations
+
+import datetime as _dt
+
+from pydantic import BaseModel
+
+
+class InsuranceRateFiling(BaseModel):
+    # SERFF tracking id — TDI's stable handle for the filing, and what the
+    # operator would quote if they ever called the department about it.
+    serff_id: str
+    company_name: str
+    # The carrier's own name for the program, e.g. "TX DWO". Two filings from
+    # one company in the same month usually belong to different programs, so
+    # this is what distinguishes them.
+    product_name: str | None = None
+    # Positive is an increase, negative a decrease. None when the filing did
+    # not state one.
+    percent_change: float | None = None
+    filed_date: _dt.date | None = None
+    # When the new rate starts applying to renewing policies. This is the date
+    # that matters to an existing policyholder; the new-business date does not
+    # affect them.
+    effective_date_renewal: _dt.date | None = None
+    # True when the filing has been reviewed and the rate is in force. False
+    # while still pending, or when it was withdrawn or rejected and will never
+    # apply — the distinction the UI needs to avoid announcing a phantom rise.
+    is_in_force: bool = False
+    # True while TDI has yet to rule on it. Shown as "proposed" rather than
+    # "coming", because the commissioner can still disapprove it.
+    is_pending: bool = False

--- a/apps/mybookkeeper/backend/app/services/insurance/_carrier_filing_match.py
+++ b/apps/mybookkeeper/backend/app/services/insurance/_carrier_filing_match.py
@@ -1,0 +1,216 @@
+"""Match a policy's carrier to the filings that carrier made, and do the maths.
+
+Pure functions, no I/O, so the matching rules can be tested against the real
+names both sides use. The two sides never agree on spelling: an operator writes
+"SafePoint" on a policy, TDI publishes "SAFEPOINT INSURANCE COMPANY", and the
+same company appears again as "SafePoint Florida Insurance Co". Comparing the
+strings as typed matches almost nothing.
+
+The rule is deliberately conservative. A filing is attributed to a policy only
+when the policy's distinguishing words are all present in the filing's company
+name. That misses some real matches — it will not connect "Benchmark" to a
+filing made under a parent's name — and the service reports an unmatched
+carrier as unmatched rather than as "no increases coming". A missed match shows
+up as a gap the operator can see; a wrong match would tell them their premium
+is rising when it is not.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import re
+
+from app.core.tdi_rate_filings_constants import FILING_LOOKBACK_DAYS
+from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
+
+# Words that identify a corporate form rather than a company. Left in, every
+# carrier matches every other carrier, because "INSURANCE COMPANY" is the
+# majority of most names.
+_GENERIC_TOKENS: frozenset[str] = frozenset({
+    "INSURANCE",
+    "INSURANCES",
+    "ASSURANCE",
+    "COMPANY",
+    "COMPANIES",
+    "CO",
+    "CORP",
+    "CORPORATION",
+    "INC",
+    "INCORPORATED",
+    "LLC",
+    "LP",
+    "LTD",
+    "GROUP",
+    "HOLDINGS",
+    "MUTUAL",
+    "EXCHANGE",
+    "RECIPROCAL",
+    "UNDERWRITERS",
+    "UNDERWRITING",
+    "SPECIALTY",
+    "CASUALTY",
+    "PROPERTY",
+    "FIRE",
+    "GENERAL",
+    "NATIONAL",
+    "AMERICAN",
+    "AMERICA",
+    "US",
+    "USA",
+    "THE",
+    "OF",
+    "AND",
+    "SERVICES",
+    "AGENCY",
+    "LLOYDS",
+    "LLOYD",
+    "SYNDICATE",
+    "TEXAS",
+    "TX",
+})
+
+_WORD = re.compile(r"[A-Z0-9]+")
+
+# An operator writes a placed-through-two-parties policy as "Benchmark/Swyfft"
+# or "Benchmark (Swyfft)" — the fronting carrier and the MGA that wrote it.
+# Either name may be the one TDI filed under, so both are tried.
+_CARRIER_SPLIT = re.compile(r"[/|,()&]| dba | DBA |\bthrough\b", re.IGNORECASE)
+
+
+def carrier_tokens(name: str | None) -> frozenset[str]:
+    """The words that actually distinguish one carrier from another."""
+    if not name:
+        return frozenset()
+    words = _WORD.findall(name.upper())
+    return frozenset(word for word in words if word not in _GENERIC_TOKENS)
+
+
+def carrier_aliases(name: str | None) -> list[frozenset[str]]:
+    """Each name an operator may have crammed into one carrier field.
+
+    Returns one token set per alias, dropping the ones left empty after generic
+    words are removed — "Texas Insurance Co" alone identifies nothing, and
+    treating it as a match key would attach every dwelling filing in the state
+    to that policy.
+    """
+    if not name:
+        return []
+    parts = [part for part in _CARRIER_SPLIT.split(name) if part and part.strip()]
+    seen: list[frozenset[str]] = []
+    for part in parts or [name]:
+        tokens = carrier_tokens(part)
+        if tokens and tokens not in seen:
+            seen.append(tokens)
+    return seen
+
+
+def matches_carrier(policy_carrier: str | None, filing_company: str) -> bool:
+    """True when this filing was made by the carrier written on the policy.
+
+    Containment in one direction only: every distinguishing word the operator
+    wrote must appear in the filing's company name. "SafePoint" matches
+    "SAFEPOINT INSURANCE COMPANY" because the filing carries the extra words a
+    legal name has and the operator's does not.
+
+    The reverse direction is deliberately not allowed, and the live data shows
+    why. "State Farm Lloyds" reduces to {STATE, FARM}; "STATE NATIONAL
+    INSURANCE COMPANY, INC." reduces to {STATE}, since NATIONAL and INSURANCE
+    are corporate boilerplate. Accepting the filing's tokens as a subset of the
+    policy's would attribute State National's rate filings to a State Farm
+    policy — a different company, and a premium increase the operator will
+    never be charged. Requiring the operator's words to be the ones present
+    costs some real matches, which surface as an explicit "no filings found"
+    rather than as false reassurance.
+    """
+    filing_tokens = carrier_tokens(filing_company)
+    if not filing_tokens:
+        return False
+    return any(alias <= filing_tokens for alias in carrier_aliases(policy_carrier))
+
+
+def is_recent(filing: InsuranceRateFiling, *, today: _dt.date) -> bool:
+    """Filed recently enough to still say something about the next renewal.
+
+    A filing with no recorded date is kept. TDI publishes rows before every
+    field is populated, and discarding them would quietly drop the newest
+    filings — the ones that matter most.
+    """
+    if filing.filed_date is None:
+        return True
+    return (today - filing.filed_date).days <= FILING_LOOKBACK_DAYS
+
+
+def applies_by(filing: InsuranceRateFiling, *, renewal: _dt.date) -> bool:
+    """True when the new rate is in effect by the time the policy renews.
+
+    A filing with no renewal effective date is treated as applying. 310 of the
+    704 dwelling filings leave that column blank, and reading blank as "does
+    not apply" would drop nearly half the dataset — including increases the
+    operator will in fact be charged.
+    """
+    if filing.effective_date_renewal is None:
+        return True
+    return filing.effective_date_renewal <= renewal
+
+
+def compound_change_pct(filings: list[InsuranceRateFiling]) -> float | None:
+    """The change the policy is most likely to see, as a percentage.
+
+    Two rules, and the second is the one that matters. Filings compound rather
+    than sum — two 10% increases are 21%, because the second applies to the
+    already-raised rate. But they only compound *within one rate program*. A
+    carrier files separately for each book it writes, and Foremost's live data
+    shows four at once: Landlord, Owner Occupied, Vacant, and a condominium
+    program. Those are different rate books, the operator's policy sits in
+    exactly one of them, and multiplying all four together would produce a
+    number no policy will ever be charged.
+
+    Which program is the operator's is not recorded anywhere, so the most
+    recently filed one is used — a carrier's newest filing is the one a
+    renewal is most likely to land on. Every matched filing is returned
+    alongside this figure with its program named, so an operator who knows
+    their program can see the rest.
+
+    Only in-force filings that state a change are counted: a pending filing has
+    not been approved, and a withdrawn one never will be.
+
+    Returns None when nothing counted, which is not the same as 0.0%. Zero
+    means the carrier filed and held its rates flat — worth showing, and the
+    signal that puts them on the shortlist to call.
+    """
+    usable = [
+        filing
+        for filing in filings
+        if filing.is_in_force and filing.percent_change is not None
+    ]
+    if not usable:
+        return None
+
+    programs: dict[str, list[InsuranceRateFiling]] = {}
+    for filing in usable:
+        programs.setdefault(filing.product_name or "", []).append(filing)
+
+    def _newest(group: list[InsuranceRateFiling]) -> _dt.date:
+        return max((f.filed_date or _dt.date.min) for f in group)
+
+    chosen = max(programs.values(), key=_newest)
+
+    combined = 1.0
+    for filing in chosen:
+        combined *= 1.0 + (filing.percent_change / 100.0)
+    return round((combined - 1.0) * 100.0, 2)
+
+
+def project_premium_cents(
+    current_premium_cents: int | None, change_pct: float | None,
+) -> int | None:
+    """The current premium moved by the filed change.
+
+    An estimate, not a quote. A rate filing is a statewide average across the
+    carrier's whole book, and an individual property's renewal also moves with
+    its own coverage amount, claims and reunderwriting. It is the right order
+    of magnitude and the right direction, which is what makes it worth acting
+    on months before the renewal notice arrives.
+    """
+    if current_premium_cents is None or change_pct is None:
+        return None
+    return round(current_premium_cents * (1.0 + change_pct / 100.0))

--- a/apps/mybookkeeper/backend/app/services/insurance/insurance_market_watch_service.py
+++ b/apps/mybookkeeper/backend/app/services/insurance/insurance_market_watch_service.py
@@ -1,0 +1,217 @@
+"""Tell the operator what the Texas dwelling market has filed against them.
+
+Orchestration only: load the unexpired policies, pull the dwelling filings,
+and hand both to the pure matcher. All data access goes through repositories;
+this module never imports SQLAlchemy, and the arithmetic lives in
+``_carrier_filing_match``.
+
+Two outputs, answering two different questions. The per-policy outlook answers
+"is my premium about to go up" — a filed increase reaches the operator months
+before the renewal notice does. The market view answers "who should I call" —
+a dwelling policy is agent-bound, so the useful thing to walk into that
+conversation with is the list of carriers that just held their rates flat.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from app.core.tdi_rate_filings_constants import (
+    MAX_MARKET_FILINGS,
+    MIN_NOTABLE_CHANGE_PCT,
+    REASON_FEED_DOWN,
+    REASON_NO_CARRIER,
+    REASON_NO_FILINGS,
+    RENEWAL_HORIZON_DAYS,
+)
+from app.db.session import unit_of_work
+from app.repositories.insurance import insurance_policy_repo
+from app.repositories.properties import property_repo
+from app.schemas.insurance.insurance_market_watch_response import (
+    InsuranceMarketWatchResponse,
+)
+from app.schemas.insurance.insurance_policy_rate_outlook import (
+    InsurancePolicyRateOutlook,
+)
+from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
+from app.services.insurance._carrier_filing_match import (
+    applies_by,
+    compound_change_pct,
+    is_recent,
+    matches_carrier,
+    project_premium_cents,
+)
+from app.services.insurance.premium_math import annual_premium_cents
+from app.services.insurance.tdi_rate_filings_client import (
+    RateFilingFeedUnavailableError,
+    fetch_dwelling_filings,
+)
+
+# Same ceiling the benchmark comparison uses: one operator's insurance
+# portfolio is bounded by their number of properties, so this never pages.
+_POLICY_PAGE_SIZE = 500
+
+
+def _renewal_date(
+    expiration_date: _dt.date | None, *, today: _dt.date,
+) -> _dt.date:
+    """When this policy next renews, assumed if not recorded."""
+    if expiration_date is not None:
+        return expiration_date
+    return today + _dt.timedelta(days=RENEWAL_HORIZON_DAYS)
+
+
+def _filings_for_policy(
+    carrier: str | None,
+    filings: list[InsuranceRateFiling],
+    *,
+    renewal: _dt.date,
+    today: _dt.date,
+) -> list[InsuranceRateFiling]:
+    """This carrier's recent filings that are in effect by the renewal."""
+    matched = [
+        filing
+        for filing in filings
+        if matches_carrier(carrier, filing.company_name)
+        and is_recent(filing, today=today)
+        and applies_by(filing, renewal=renewal)
+    ]
+    matched.sort(key=lambda f: f.filed_date or _dt.date.min, reverse=True)
+    return matched
+
+
+def _build_outlook(
+    row,
+    *,
+    property_name: str | None,
+    filings: list[InsuranceRateFiling],
+    today: _dt.date,
+) -> InsurancePolicyRateOutlook:
+    renewal = _renewal_date(row.expiration_date, today=today)
+    matched = _filings_for_policy(
+        row.carrier, filings, renewal=renewal, today=today,
+    )
+
+    unavailable_reason: str | None = None
+    if not row.carrier:
+        unavailable_reason = REASON_NO_CARRIER
+    elif not matched:
+        unavailable_reason = REASON_NO_FILINGS
+
+    change_pct = compound_change_pct(matched)
+    # Compared against the annualised premium, not the billed one: a monthly
+    # premium projected forward would read as a twelfth of the real number.
+    annual = annual_premium_cents(row.premium_cents, row.premium_frequency)
+
+    return InsurancePolicyRateOutlook(
+        policy_id=row.id,
+        policy_name=row.policy_name,
+        property_name=property_name,
+        carrier=row.carrier,
+        expiration_date=row.expiration_date,
+        current_premium_cents=annual,
+        filings=matched,
+        projected_change_pct=change_pct,
+        projected_premium_cents=project_premium_cents(annual, change_pct),
+        unavailable_reason=unavailable_reason,
+    )
+
+
+def _market_view(
+    filings: list[InsuranceRateFiling], *, today: _dt.date,
+) -> list[InsuranceRateFiling]:
+    """One row per carrier — their latest dwelling filing, newest first.
+
+    Deduped by company because a carrier files several programs a year and the
+    repeats would crowd out every other carrier in the list. Pending filings
+    are kept: a proposed increase is exactly the signal that makes an operator
+    shop early, and the schema flags it as proposed rather than in force.
+    """
+    latest: dict[str, InsuranceRateFiling] = {}
+    for filing in filings:
+        if not is_recent(filing, today=today):
+            continue
+        if not (filing.is_in_force or filing.is_pending):
+            continue
+        key = filing.company_name.upper()
+        existing = latest.get(key)
+        if existing is None or (filing.filed_date or _dt.date.min) > (
+            existing.filed_date or _dt.date.min
+        ):
+            latest[key] = filing
+
+    ordered = sorted(
+        latest.values(),
+        key=lambda f: f.filed_date or _dt.date.min,
+        reverse=True,
+    )
+    return ordered[:MAX_MARKET_FILINGS]
+
+
+def _is_expired(expiration_date: _dt.date | None, today: _dt.date) -> bool:
+    """Matches the benchmark comparison: unknown end date is not a lapse."""
+    return expiration_date is not None and expiration_date < today
+
+
+async def get_market_watch(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    today: _dt.date | None = None,
+) -> InsuranceMarketWatchResponse:
+    """Rate outlook per unexpired policy, plus the recent dwelling market.
+
+    A TDI outage degrades rather than fails, the way the utility offer search
+    does: the policies still list, each saying the check could not be run. The
+    one outcome that must never happen is rendering "no increases filed" when
+    the truth is "nothing was checked".
+    """
+    reference = today or _dt.date.today()
+
+    async with unit_of_work() as db:
+        rows = await insurance_policy_repo.list_for_org(
+            db,
+            user_id=user_id,
+            organization_id=organization_id,
+            limit=_POLICY_PAGE_SIZE,
+            offset=0,
+        )
+        names = await property_repo.get_name_map(db, organization_id)
+
+    feed_unavailable_reason: str | None = None
+    try:
+        filings = await fetch_dwelling_filings()
+    except RateFilingFeedUnavailableError:
+        filings = []
+        feed_unavailable_reason = REASON_FEED_DOWN
+
+    outlooks = [
+        _build_outlook(
+            row,
+            property_name=names.get(row.property_id),
+            filings=filings,
+            today=reference,
+        )
+        for row in rows
+        if not _is_expired(row.expiration_date, reference)
+    ]
+
+    if feed_unavailable_reason is not None:
+        for outlook in outlooks:
+            outlook.unavailable_reason = feed_unavailable_reason
+
+    # Soonest renewal first — the policy the operator can still do something
+    # about reads before the one that renews in eleven months. Policies with no
+    # recorded expiration sort last rather than being treated as overdue.
+    outlooks.sort(key=lambda o: o.expiration_date or _dt.date.max)
+
+    return InsuranceMarketWatchResponse(
+        outlooks=outlooks,
+        market_filings=_market_view(filings, today=reference),
+        has_any_increase=any(
+            outlook.projected_change_pct is not None
+            and outlook.projected_change_pct >= MIN_NOTABLE_CHANGE_PCT
+            for outlook in outlooks
+        ),
+        feed_unavailable_reason=feed_unavailable_reason,
+    )

--- a/apps/mybookkeeper/backend/app/services/insurance/tdi_rate_filings_client.py
+++ b/apps/mybookkeeper/backend/app/services/insurance/tdi_rate_filings_client.py
@@ -1,0 +1,167 @@
+"""Fetch Texas dwelling-line rate filings from the TDI open dataset.
+
+Network boundary only: this module talks to the Socrata host and turns rows
+into ``InsuranceRateFiling`` objects. Which filings matter to which policy is
+decided in ``insurance_market_watch_service`` — nothing here reads the database.
+
+Mirrors ``properties/power_to_choose_client``: same cache shape, and the same
+contract that a failure raises rather than returning an empty list, because
+"TDI is unreachable" and "your carrier has filed nothing" must not render as
+the same sentence.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+from app.core.tdi_rate_filings_constants import (
+    CLOSED_TYPE_IN_FORCE,
+    CLOSED_TYPES_ABANDONED,
+    DWELLING_SUBTYPE,
+    FETCH_TIMEOUT_SECONDS,
+    FILINGS_CACHE_TTL_SECONDS,
+    MAX_FILINGS_FETCHED,
+    STATUS_CLOSED,
+    STATUS_PENDING,
+    TDI_RATE_FILINGS_URL,
+)
+from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
+
+logger = logging.getLogger(__name__)
+
+
+class RateFilingFeedUnavailableError(RuntimeError):
+    """The dataset could not be reached or returned something unusable."""
+
+
+# Process-local, holds nothing user-specific, needs no invalidation story.
+_cache: tuple[float, list[InsuranceRateFiling]] | None = None
+
+
+def _user_agent() -> str:
+    base = settings.app_url or "https://mybookkeeper.app"
+    return f"MyBookkeeper-InsuranceRateWatch/1.0 ({base})"
+
+
+def _parse_date(raw: Any) -> _dt.date | None:
+    """Socrata floating timestamps look like ``2026-09-01T00:00:00.000``."""
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return _dt.date.fromisoformat(raw[:10])
+    except ValueError:
+        return None
+
+
+def _parse_percent(raw: Any) -> float | None:
+    """``"   11.1%"`` -> ``11.1``.
+
+    The column is a padded display string, not a number, and carries a sign for
+    decreases. A filing with no stated change yields None rather than 0.0 —
+    "not stated" and "held flat" are different facts, and only the second is
+    something to tell an operator.
+    """
+    if not isinstance(raw, str):
+        return None
+    cleaned = raw.strip().rstrip("%").strip()
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def _to_filing(row: dict[str, Any]) -> InsuranceRateFiling | None:
+    """Map one dataset row, or None when it is unusable.
+
+    A filing's disposition decides whether it is reported as real. ``Closed`` +
+    ``Reviewed`` means the rate is in force. ``Withdrawn`` and ``Rejected``
+    closed without ever applying, so they are carried with ``is_in_force``
+    false and filtered upstream — dropping them here would leave no way to
+    explain a carrier that filed and then backed down.
+    """
+    serff_id = str(row.get("serff_id") or "").strip()
+    company_name = str(row.get("company_name") or "").strip()
+    if not serff_id or not company_name:
+        return None
+
+    status = str(row.get("status") or "").strip()
+    closed_type = str(row.get("closed_type") or "").strip()
+
+    is_pending = status == STATUS_PENDING
+    is_in_force = (
+        status == STATUS_CLOSED
+        and closed_type == CLOSED_TYPE_IN_FORCE
+        and closed_type not in CLOSED_TYPES_ABANDONED
+    )
+
+    return InsuranceRateFiling(
+        serff_id=serff_id,
+        company_name=company_name,
+        product_name=str(row.get("product_name") or "").strip() or None,
+        percent_change=_parse_percent(row.get("percent_change")),
+        filed_date=_parse_date(row.get("received_date")),
+        effective_date_renewal=_parse_date(row.get("effective_date_renewal")),
+        is_in_force=is_in_force,
+        is_pending=is_pending,
+    )
+
+
+async def fetch_dwelling_filings() -> list[InsuranceRateFiling]:
+    """Every dwelling-line filing TDI publishes, newest first.
+
+    The whole line is ~700 rows, so it is fetched once and filtered in memory:
+    the per-policy carrier match and the market view both read the same list,
+    and splitting them into two queries would double the calls to TDI for no
+    gain.
+    """
+    global _cache
+
+    if _cache is not None and (time.monotonic() - _cache[0]) < FILINGS_CACHE_TTL_SECONDS:
+        return _cache[1]
+
+    params = {
+        "$where": f"state_subtype_of_insurance='{DWELLING_SUBTYPE}'",
+        "$order": "received_date DESC",
+        "$limit": str(MAX_FILINGS_FETCHED),
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=FETCH_TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                TDI_RATE_FILINGS_URL,
+                params=params,
+                headers={"User-Agent": _user_agent(), "Accept": "application/json"},
+                follow_redirects=True,
+            )
+            response.raise_for_status()
+            payload = response.json()
+    except httpx.HTTPStatusError as exc:
+        # Per rules/check-third-party-error-codes.md: Socrata puts the reason a
+        # query was refused in the body, so log it rather than only the status.
+        logger.warning(
+            "TDI rate filings returned HTTP %s: %s",
+            exc.response.status_code,
+            exc.response.text[:200],
+        )
+        raise RateFilingFeedUnavailableError("rate filing feed returned an error") from exc
+    except (httpx.HTTPError, ValueError) as exc:
+        logger.warning("TDI rate filings unreachable: %s", exc)
+        raise RateFilingFeedUnavailableError("rate filing feed is unreachable") from exc
+
+    if not isinstance(payload, list):
+        raise RateFilingFeedUnavailableError("rate filing feed returned an unexpected shape")
+
+    filings = [
+        filing
+        for filing in (_to_filing(row) for row in payload if isinstance(row, dict))
+        if filing is not None
+    ]
+    _cache = (time.monotonic(), filings)
+    return filings

--- a/apps/mybookkeeper/backend/tests/test_insurance_carrier_filing_match.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_carrier_filing_match.py
@@ -1,0 +1,196 @@
+"""Tests for matching a policy's carrier to its TDI dwelling filings.
+
+Every company name here is copied from the live dataset, because the failures
+that matter are all name-shaped and none of them are guessable. Two are
+regressions found by running the matcher against the real feed:
+
+- "State Farm Lloyds" matched "STATE NATIONAL INSURANCE COMPANY, INC." once the
+  boilerplate words were stripped from both, which would have reported a
+  different company's rate increase against the operator's policy.
+- Foremost files four dwelling programs at once, and compounding them together
+  produced a change that applies to no single policy.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
+from app.services.insurance._carrier_filing_match import (
+    applies_by,
+    carrier_aliases,
+    carrier_tokens,
+    compound_change_pct,
+    is_recent,
+    matches_carrier,
+    project_premium_cents,
+)
+
+TODAY = _dt.date(2026, 8, 17)
+
+
+def _filing(
+    *,
+    company: str = "SAFEPOINT INSURANCE COMPANY",
+    product: str | None = "TX DWO",
+    pct: float | None = 11.1,
+    filed: _dt.date | None = _dt.date(2026, 5, 28),
+    renewal: _dt.date | None = _dt.date(2026, 9, 1),
+    in_force: bool = True,
+    pending: bool = False,
+) -> InsuranceRateFiling:
+    return InsuranceRateFiling(
+        serff_id=f"SERFF-{company[:6]}-{product}-{filed}",
+        company_name=company,
+        product_name=product,
+        percent_change=pct,
+        filed_date=filed,
+        effective_date_renewal=renewal,
+        is_in_force=in_force,
+        is_pending=pending,
+    )
+
+
+class TestTokens:
+    def test_strips_corporate_boilerplate(self):
+        assert carrier_tokens("SAFEPOINT INSURANCE COMPANY") == frozenset({"SAFEPOINT"})
+
+    def test_strips_the_texas_lloyds_construction(self):
+        assert carrier_tokens("FOREMOST LLOYDS OF TEXAS") == frozenset({"FOREMOST"})
+
+    def test_a_name_of_pure_boilerplate_identifies_nothing(self):
+        # Left non-empty, "Texas Insurance Co" would key onto every filing in
+        # the state.
+        assert carrier_tokens("Texas Insurance Co") == frozenset()
+
+    def test_splits_a_fronted_policy_into_both_names(self):
+        assert carrier_aliases("Benchmark/Swyfft") == [
+            frozenset({"BENCHMARK"}),
+            frozenset({"SWYFFT"}),
+        ]
+
+    def test_drops_aliases_that_identify_nothing(self):
+        assert carrier_aliases("Texas Insurance Co") == []
+
+
+class TestMatching:
+    def test_short_operator_name_matches_full_legal_name(self):
+        assert matches_carrier("SafePoint", "SAFEPOINT INSURANCE COMPANY")
+
+    def test_case_and_punctuation_are_irrelevant(self):
+        assert matches_carrier("safepoint insurance co.", "SAFEPOINT INSURANCE COMPANY")
+
+    def test_either_half_of_a_fronted_policy_can_match(self):
+        assert matches_carrier("Benchmark/Swyfft", "SWYFFT INSURANCE COMPANY")
+
+    def test_state_farm_does_not_match_state_national(self):
+        # The regression. Both reduce to a set containing STATE; accepting the
+        # filing's tokens as a subset of the policy's would attribute State
+        # National's filings to a State Farm policy.
+        assert not matches_carrier(
+            "State Farm Lloyds", "STATE NATIONAL INSURANCE COMPANY, INC.",
+        )
+
+    def test_unrelated_carriers_do_not_match(self):
+        assert not matches_carrier("SafePoint", "FOREMOST LLOYDS OF TEXAS")
+
+    def test_a_policy_with_no_carrier_matches_nothing(self):
+        assert not matches_carrier(None, "SAFEPOINT INSURANCE COMPANY")
+        assert not matches_carrier("", "SAFEPOINT INSURANCE COMPANY")
+
+    def test_a_boilerplate_only_carrier_matches_nothing(self):
+        assert not matches_carrier("Texas Insurance Co", "SAFEPOINT INSURANCE COMPANY")
+
+
+class TestRelevance:
+    def test_a_filing_from_four_years_ago_is_stale(self):
+        assert not is_recent(_filing(filed=_dt.date(2022, 1, 1)), today=TODAY)
+
+    def test_a_filing_with_no_date_is_kept(self):
+        # TDI publishes rows before every column is populated, and those are
+        # the newest ones.
+        assert is_recent(_filing(filed=None), today=TODAY)
+
+    def test_a_rate_effective_before_renewal_applies(self):
+        assert applies_by(
+            _filing(renewal=_dt.date(2026, 9, 1)), renewal=_dt.date(2026, 9, 24),
+        )
+
+    def test_a_rate_effective_after_renewal_hits_the_next_term(self):
+        assert not applies_by(
+            _filing(renewal=_dt.date(2026, 10, 15)), renewal=_dt.date(2026, 9, 24),
+        )
+
+    def test_a_filing_with_no_effective_date_is_treated_as_applying(self):
+        # 310 of 704 dwelling rows leave this blank. Reading blank as "does not
+        # apply" would drop nearly half the dataset.
+        assert applies_by(_filing(renewal=None), renewal=_dt.date(2026, 9, 24))
+
+
+class TestCompounding:
+    def test_the_safepoint_case(self):
+        # The filing that predicts 6738 Peerless's September renewal.
+        assert compound_change_pct([_filing()]) == 11.1
+
+    def test_successive_filings_on_one_program_compound(self):
+        filings = [
+            _filing(pct=10.0, filed=_dt.date(2026, 5, 1)),
+            _filing(pct=10.0, filed=_dt.date(2026, 1, 1)),
+        ]
+        assert compound_change_pct(filings) == 21.0
+
+    def test_separate_programs_do_not_compound(self):
+        # Foremost's live shape. Multiplying the four together would produce a
+        # 27% rise that no single policy is charged.
+        filings = [
+            _filing(
+                company="FOREMOST LLOYDS OF TEXAS",
+                product="Dwelling Program - Landlord",
+                pct=6.0,
+                filed=_dt.date(2026, 3, 10),
+            ),
+            _filing(
+                company="FOREMOST LLOYDS OF TEXAS",
+                product="Dwelling Program - Owner Occupied",
+                pct=8.0,
+                filed=_dt.date(2026, 1, 5),
+            ),
+            _filing(
+                company="FOREMOST LLOYDS OF TEXAS",
+                product="Dwelling Program - Vacant or Unoccupied",
+                pct=11.0,
+                filed=_dt.date(2025, 11, 14),
+            ),
+        ]
+        # The most recently filed program, not the sum and not the worst.
+        assert compound_change_pct(filings) == 6.0
+
+    def test_pending_filings_are_not_counted(self):
+        assert compound_change_pct([_filing(in_force=False, pending=True)]) is None
+
+    def test_withdrawn_filings_are_not_counted(self):
+        # Closed without ever applying — 63 of the 704 dwelling rows. Counting
+        # these would invent an increase the operator will never be charged.
+        assert compound_change_pct([_filing(in_force=False)]) is None
+
+    def test_a_carrier_holding_flat_reports_zero_not_none(self):
+        # Zero is the signal that puts a carrier on the shortlist to call, so
+        # it must not collapse into "nothing found".
+        assert compound_change_pct([_filing(pct=0.0)]) == 0.0
+
+    def test_no_filings_reports_none(self):
+        assert compound_change_pct([]) is None
+
+    def test_a_decrease_stays_negative(self):
+        assert compound_change_pct([_filing(pct=-5.0)]) == -5.0
+
+
+class TestProjection:
+    def test_applies_the_change_to_the_current_premium(self):
+        # $2,410 at 11.1% — the 6738 Peerless renewal.
+        assert project_premium_cents(241_000, 11.1) == 267_751
+
+    def test_an_unknown_premium_projects_nothing(self):
+        assert project_premium_cents(None, 11.1) is None
+
+    def test_an_unknown_change_projects_nothing(self):
+        assert project_premium_cents(241_000, None) is None

--- a/apps/mybookkeeper/backend/tests/test_insurance_market_api.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_market_api.py
@@ -1,0 +1,125 @@
+"""HTTP route test for /insurance-market/rate-watch.
+
+The service is mocked — its behaviour is covered in
+``test_insurance_market_watch_service.py``. What this pins is the contract the
+route owns: the path, the permission dependency it hangs off, and that a feed
+outage still returns 200 with the reason attached rather than an error the SPA
+would render as an empty section.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member
+from app.core.tdi_rate_filings_constants import REASON_FEED_DOWN
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.insurance.insurance_market_watch_response import (
+    InsuranceMarketWatchResponse,
+)
+from app.schemas.insurance.insurance_policy_rate_outlook import (
+    InsurancePolicyRateOutlook,
+)
+from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
+
+ORG_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+POLICY_ID = uuid.uuid4()
+
+_SERVICE = "app.api.insurance_market.insurance_market_watch_service"
+_PATH = "/insurance-market/rate-watch"
+
+
+def _ctx(role: OrgRole = OrgRole.OWNER) -> RequestContext:
+    return RequestContext(organization_id=ORG_ID, user_id=USER_ID, org_role=role)
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[current_org_member] = lambda: _ctx()
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _response(**overrides) -> InsuranceMarketWatchResponse:
+    filing = InsuranceRateFiling(
+        serff_id="SFPT-134523456",
+        company_name="SAFEPOINT INSURANCE COMPANY",
+        product_name="TX DWO",
+        percent_change=11.1,
+        filed_date=_dt.date(2026, 5, 28),
+        effective_date_renewal=_dt.date(2026, 9, 1),
+        is_in_force=True,
+    )
+    base = {
+        "outlooks": [
+            InsurancePolicyRateOutlook(
+                policy_id=POLICY_ID,
+                policy_name="Dwelling DP-3",
+                property_name="6738 Peerless St",
+                carrier="SafePoint",
+                expiration_date=_dt.date(2026, 9, 24),
+                current_premium_cents=241_000,
+                filings=[filing],
+                projected_change_pct=11.1,
+                projected_premium_cents=267_751,
+            ),
+        ],
+        "market_filings": [filing],
+        "has_any_increase": True,
+    }
+    base.update(overrides)
+    return InsuranceMarketWatchResponse(**base)
+
+
+def test_returns_the_rate_watch(client):
+    with patch(f"{_SERVICE}.get_market_watch", AsyncMock(return_value=_response())):
+        response = client.get(_PATH)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["has_any_increase"] is True
+    assert body["outlooks"][0]["projected_premium_cents"] == 267_751
+    assert body["market_filings"][0]["company_name"] == "SAFEPOINT INSURANCE COMPANY"
+    assert body["feed_unavailable_reason"] is None
+
+
+def test_scopes_the_read_to_the_caller_organization(client):
+    mock = AsyncMock(return_value=_response())
+    with patch(f"{_SERVICE}.get_market_watch", mock):
+        client.get(_PATH)
+
+    assert mock.await_args.kwargs["organization_id"] == ORG_ID
+    assert mock.await_args.kwargs["user_id"] == USER_ID
+
+
+def test_a_feed_outage_still_returns_the_policies_with_a_reason(client):
+    degraded = _response(
+        outlooks=[],
+        market_filings=[],
+        has_any_increase=False,
+        feed_unavailable_reason=REASON_FEED_DOWN,
+    )
+    with patch(f"{_SERVICE}.get_market_watch", AsyncMock(return_value=degraded)):
+        response = client.get(_PATH)
+
+    assert response.status_code == 200
+    assert response.json()["feed_unavailable_reason"] == REASON_FEED_DOWN
+
+
+def test_a_non_member_is_refused():
+    def _deny():
+        raise HTTPException(status_code=403, detail="Not a member")
+
+    app.dependency_overrides[current_org_member] = _deny
+    try:
+        assert TestClient(app).get(_PATH).status_code == 403
+    finally:
+        app.dependency_overrides.clear()

--- a/apps/mybookkeeper/backend/tests/test_insurance_market_watch_service.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_market_watch_service.py
@@ -1,0 +1,383 @@
+"""Tests for the dwelling rate watch's orchestration.
+
+The matching arithmetic is covered in
+``test_insurance_carrier_filing_match.py``; the feed reader in
+``test_tdi_rate_filings_client.py``. What these pin is what the service does
+around them: which policies are looked at, how an unmatchable one is explained
+instead of dropped, what the market view deduplicates, and the outage
+behaviour — a TDI failure must degrade into a visible "nothing was checked",
+never into a silent "no increases filed".
+
+The service opens its own session via ``unit_of_work()``; ``_make_fake_uow``
+patches it to yield the in-memory SQLite test session instead.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.tdi_rate_filings_constants import (
+    MAX_MARKET_FILINGS,
+    REASON_FEED_DOWN,
+    REASON_NO_CARRIER,
+    REASON_NO_FILINGS,
+)
+from app.models.organization.organization import Organization
+from app.models.properties.property import Property
+from app.models.user.user import User
+from app.repositories.insurance import insurance_policy_repo
+from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
+from app.services.insurance import insurance_market_watch_service
+from app.services.insurance.tdi_rate_filings_client import (
+    RateFilingFeedUnavailableError,
+)
+
+pytestmark = pytest.mark.asyncio
+
+TODAY = _dt.date(2026, 8, 17)
+
+_UOW = "app.services.insurance.insurance_market_watch_service.unit_of_work"
+_FETCH = "app.services.insurance.insurance_market_watch_service.fetch_dwelling_filings"
+
+# 6738 Peerless: SafePoint, $2,410 annual, renews 23 days after the carrier's
+# filed increase reaches renewing policies.
+SAFEPOINT_PREMIUM_CENTS = 241_000
+SAFEPOINT_RENEWAL = _dt.date(2026, 9, 24)
+
+
+def _make_fake_uow(session: AsyncSession):
+    @asynccontextmanager
+    async def _fake_uow():
+        yield session
+
+    return _fake_uow
+
+
+def _fetching(filings: list[InsuranceRateFiling]):
+    async def _fetch():
+        return filings
+
+    return _fetch
+
+
+def _failing_fetch():
+    async def _fetch():
+        raise RateFilingFeedUnavailableError("feed is unreachable")
+
+    return _fetch
+
+
+def _filing(
+    *,
+    company: str = "SAFEPOINT INSURANCE COMPANY",
+    product: str | None = "TX DWO",
+    pct: float | None = 11.1,
+    filed: _dt.date = _dt.date(2026, 5, 28),
+    renewal: _dt.date | None = _dt.date(2026, 9, 1),
+    in_force: bool = True,
+    pending: bool = False,
+) -> InsuranceRateFiling:
+    return InsuranceRateFiling(
+        serff_id=f"SERFF-{company[:8]}-{filed}-{product}",
+        company_name=company,
+        product_name=product,
+        percent_change=pct,
+        filed_date=filed,
+        effective_date_renewal=renewal,
+        is_in_force=in_force,
+        is_pending=pending,
+    )
+
+
+async def _make_property(
+    db: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID, name: str,
+) -> Property:
+    prop = Property(
+        id=uuid.uuid4(), organization_id=org_id, user_id=user_id, name=name,
+    )
+    db.add(prop)
+    await db.flush()
+    return prop
+
+
+async def _make_policy(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    property_id: uuid.UUID,
+    policy_name: str = "Dwelling DP-3",
+    carrier: str | None = "SafePoint",
+    premium_cents: int | None = SAFEPOINT_PREMIUM_CENTS,
+    premium_frequency: str | None = "annual",
+    expiration_date: _dt.date | None = SAFEPOINT_RENEWAL,
+):
+    return await insurance_policy_repo.create(
+        db,
+        user_id=user_id,
+        organization_id=org_id,
+        property_id=property_id,
+        policy_name=policy_name,
+        carrier=carrier,
+        premium_cents=premium_cents,
+        premium_frequency=premium_frequency,
+        expiration_date=expiration_date,
+    )
+
+
+async def _watch(db: AsyncSession, org: Organization, user: User, filings):
+    fetch = filings if callable(filings) else _fetching(filings)
+    with patch(_UOW, _make_fake_uow(db)), patch(_FETCH, fetch):
+        return await insurance_market_watch_service.get_market_watch(
+            user_id=user.id, organization_id=org.id, today=TODAY,
+        )
+
+
+class TestPolicyOutlook:
+    async def test_projects_the_safepoint_increase_onto_the_renewal(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The case the feature exists for: an increase filed before renewal."""
+        prop = await _make_property(db, test_org.id, test_user.id, "6738 Peerless St")
+        await _make_policy(
+            db, org_id=test_org.id, user_id=test_user.id, property_id=prop.id,
+        )
+
+        result = await _watch(db, test_org, test_user, [_filing()])
+
+        assert len(result.outlooks) == 1
+        outlook = result.outlooks[0]
+        assert outlook.property_name == "6738 Peerless St"
+        assert outlook.projected_change_pct == 11.1
+        assert outlook.current_premium_cents == SAFEPOINT_PREMIUM_CENTS
+        assert outlook.projected_premium_cents == 267_751
+        assert outlook.unavailable_reason is None
+        assert result.has_any_increase is True
+
+    async def test_a_filing_effective_after_renewal_hits_the_next_term(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        prop = await _make_property(db, test_org.id, test_user.id, "6738 Peerless St")
+        await _make_policy(
+            db, org_id=test_org.id, user_id=test_user.id, property_id=prop.id,
+        )
+
+        result = await _watch(
+            db, test_org, test_user, [_filing(renewal=_dt.date(2026, 12, 1))],
+        )
+
+        assert result.outlooks[0].projected_change_pct is None
+        assert result.outlooks[0].unavailable_reason == REASON_NO_FILINGS
+        assert result.has_any_increase is False
+
+    async def test_an_unmatched_carrier_says_so_rather_than_looking_clear(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Swyfft files nothing under that name — silence would misread."""
+        prop = await _make_property(db, test_org.id, test_user.id, "6734 Peerless St")
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            property_id=prop.id,
+            carrier="Benchmark/Swyfft",
+        )
+
+        result = await _watch(db, test_org, test_user, [_filing()])
+
+        assert result.outlooks[0].filings == []
+        assert result.outlooks[0].unavailable_reason == REASON_NO_FILINGS
+
+    async def test_a_policy_with_no_carrier_says_which_field_is_missing(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        prop = await _make_property(db, test_org.id, test_user.id, "6732 Peerless St")
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            property_id=prop.id,
+            carrier=None,
+        )
+
+        result = await _watch(db, test_org, test_user, [_filing()])
+
+        assert result.outlooks[0].unavailable_reason == REASON_NO_CARRIER
+
+    async def test_a_monthly_premium_is_annualised_before_projection(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Projecting the billed figure would report a twelfth of the truth."""
+        prop = await _make_property(db, test_org.id, test_user.id, "6738 Peerless St")
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            property_id=prop.id,
+            premium_cents=20_000,
+            premium_frequency="monthly",
+        )
+
+        result = await _watch(db, test_org, test_user, [_filing()])
+
+        assert result.outlooks[0].current_premium_cents == 240_000
+        assert result.outlooks[0].projected_premium_cents == 266_640
+
+    async def test_an_expired_policy_is_not_measured(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        prop = await _make_property(db, test_org.id, test_user.id, "Sold house")
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            property_id=prop.id,
+            expiration_date=_dt.date(2025, 1, 1),
+        )
+
+        result = await _watch(db, test_org, test_user, [_filing()])
+
+        assert result.outlooks == []
+
+    async def test_a_policy_with_no_expiration_is_kept(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """An unknown end date is not evidence the policy lapsed."""
+        prop = await _make_property(db, test_org.id, test_user.id, "6738 Peerless St")
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            property_id=prop.id,
+            expiration_date=None,
+        )
+
+        result = await _watch(db, test_org, test_user, [_filing()])
+
+        assert len(result.outlooks) == 1
+
+    async def test_soonest_renewal_reads_first(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        prop = await _make_property(db, test_org.id, test_user.id, "6738 Peerless St")
+        for name, expires in [
+            ("Later policy", _dt.date(2027, 6, 1)),
+            ("Sooner policy", _dt.date(2026, 9, 24)),
+            ("Undated policy", None),
+        ]:
+            await _make_policy(
+                db,
+                org_id=test_org.id,
+                user_id=test_user.id,
+                property_id=prop.id,
+                policy_name=name,
+                expiration_date=expires,
+            )
+
+        result = await _watch(db, test_org, test_user, [_filing()])
+
+        assert [o.policy_name for o in result.outlooks] == [
+            "Sooner policy",
+            "Later policy",
+            "Undated policy",
+        ]
+
+
+class TestMarketView:
+    async def test_shows_one_row_per_carrier_newest_first(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """A carrier files several programs a year; repeats crowd out the rest."""
+        filings = [
+            _filing(product="TX DWO", filed=_dt.date(2026, 5, 28)),
+            _filing(product="TX Business Advantage", filed=_dt.date(2026, 2, 19)),
+            _filing(
+                company="FOREMOST LLOYDS OF TEXAS",
+                product="Dwelling Program - Landlord",
+                pct=0.0,
+                filed=_dt.date(2026, 7, 24),
+            ),
+        ]
+
+        result = await _watch(db, test_org, test_user, filings)
+
+        assert [(f.company_name, f.filed_date) for f in result.market_filings] == [
+            ("FOREMOST LLOYDS OF TEXAS", _dt.date(2026, 7, 24)),
+            ("SAFEPOINT INSURANCE COMPANY", _dt.date(2026, 5, 28)),
+        ]
+
+    async def test_keeps_a_carrier_holding_rates_flat(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Zero percent is the shortlist to call, not noise to filter out."""
+        result = await _watch(
+            db, test_org, test_user, [_filing(company="FLAT CARRIER", pct=0.0)],
+        )
+
+        assert [f.percent_change for f in result.market_filings] == [0.0]
+
+    async def test_keeps_pending_filings_flagged_as_proposed(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        result = await _watch(
+            db, test_org, test_user, [_filing(in_force=False, pending=True)],
+        )
+
+        assert len(result.market_filings) == 1
+        assert result.market_filings[0].is_pending is True
+        assert result.market_filings[0].is_in_force is False
+
+    async def test_drops_a_withdrawn_filing(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Closed without ever applying — it is not market activity."""
+        result = await _watch(
+            db, test_org, test_user, [_filing(in_force=False, pending=False)],
+        )
+
+        assert result.market_filings == []
+
+    async def test_drops_a_stale_filing(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        result = await _watch(
+            db, test_org, test_user, [_filing(filed=_dt.date(2017, 5, 1))],
+        )
+
+        assert result.market_filings == []
+
+    async def test_caps_the_market_list(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        filings = [
+            _filing(company=f"CARRIER {index} GROUP", filed=_dt.date(2026, 6, 1))
+            for index in range(MAX_MARKET_FILINGS + 10)
+        ]
+
+        result = await _watch(db, test_org, test_user, filings)
+
+        assert len(result.market_filings) == MAX_MARKET_FILINGS
+
+
+class TestFeedOutage:
+    async def test_an_outage_explains_itself_on_every_policy(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The one failure mode that must never look like good news."""
+        prop = await _make_property(db, test_org.id, test_user.id, "6738 Peerless St")
+        await _make_policy(
+            db, org_id=test_org.id, user_id=test_user.id, property_id=prop.id,
+        )
+
+        result = await _watch(db, test_org, test_user, _failing_fetch())
+
+        assert result.feed_unavailable_reason == REASON_FEED_DOWN
+        assert result.outlooks[0].unavailable_reason == REASON_FEED_DOWN
+        assert result.outlooks[0].projected_change_pct is None
+        assert result.market_filings == []
+        assert result.has_any_increase is False

--- a/apps/mybookkeeper/backend/tests/test_tdi_rate_filings_client.py
+++ b/apps/mybookkeeper/backend/tests/test_tdi_rate_filings_client.py
@@ -1,0 +1,176 @@
+"""Tests for reading the TDI rate-filings feed.
+
+The row fixtures are copied from live responses, quirks included: the percent
+column is a space-padded display string rather than a number, timestamps carry
+a time part that is always midnight, and roughly half the dwelling rows have no
+renewal effective date at all.
+
+The disposition rules are the ones worth pinning. A filing is only in force if
+it closed as Reviewed; Withdrawn and Rejected closed without ever applying, and
+reporting one as an upcoming increase would tell an operator their premium is
+rising when it never will.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+import httpx
+import pytest
+
+from app.services.insurance import tdi_rate_filings_client as client
+from app.services.insurance.tdi_rate_filings_client import (
+    RateFilingFeedUnavailableError,
+    _parse_date,
+    _parse_percent,
+    _to_filing,
+    fetch_dwelling_filings,
+)
+
+_ROW = {
+    "serff_id": "SFPT-134523456",
+    "company_name": "SAFEPOINT INSURANCE COMPANY",
+    "product_name": "TX DWO",
+    "percent_change": "  11.1%",
+    "received_date": "2026-05-28T00:00:00.000",
+    "effective_date_new_business": "2026-09-01T00:00:00.000",
+    "effective_date_renewal": "2026-09-01T00:00:00.000",
+    "state_type_of_insurance": "Property",
+    "state_subtype_of_insurance": "Dwelling",
+    "status": "Closed",
+    "closed_type": "Reviewed",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    client._cache = None
+    yield
+    client._cache = None
+
+
+class TestParsing:
+    def test_reads_the_padded_percent_string(self):
+        assert _parse_percent("  11.1%") == 11.1
+
+    def test_reads_a_flat_filing_as_zero(self):
+        assert _parse_percent("   0.0%") == 0.0
+
+    def test_reads_a_decrease(self):
+        assert _parse_percent(" -4.2%") == -4.2
+
+    def test_an_unstated_change_is_none_not_zero(self):
+        # 296 of the 704 dwelling rows state no change. Reading those as 0.0%
+        # would claim the carrier held rates flat, which is a different fact.
+        assert _parse_percent("") is None
+        assert _parse_percent(None) is None
+
+    def test_reads_the_date_out_of_a_socrata_timestamp(self):
+        assert _parse_date("2026-09-01T00:00:00.000") == _dt.date(2026, 9, 1)
+
+    def test_a_blank_date_is_none(self):
+        assert _parse_date("") is None
+        assert _parse_date(None) is None
+
+    def test_an_unparseable_date_is_none(self):
+        assert _parse_date("not a date") is None
+
+
+class TestRowMapping:
+    def test_maps_a_reviewed_filing_as_in_force(self):
+        filing = _to_filing(_ROW)
+        assert filing is not None
+        assert filing.company_name == "SAFEPOINT INSURANCE COMPANY"
+        assert filing.product_name == "TX DWO"
+        assert filing.percent_change == 11.1
+        assert filing.filed_date == _dt.date(2026, 5, 28)
+        assert filing.effective_date_renewal == _dt.date(2026, 9, 1)
+        assert filing.is_in_force is True
+        assert filing.is_pending is False
+
+    @pytest.mark.parametrize("closed_type", ["Withdrawn", "Rejected"])
+    def test_an_abandoned_filing_is_not_in_force(self, closed_type):
+        filing = _to_filing({**_ROW, "closed_type": closed_type})
+        assert filing is not None
+        assert filing.is_in_force is False
+        assert filing.is_pending is False
+
+    def test_a_pending_filing_is_neither_in_force_nor_dropped(self):
+        # Kept, because a proposed increase is exactly the signal that makes an
+        # operator shop early — but flagged so it never reads as decided.
+        filing = _to_filing({**_ROW, "status": "Pending", "closed_type": ""})
+        assert filing is not None
+        assert filing.is_in_force is False
+        assert filing.is_pending is True
+
+    def test_a_row_with_no_renewal_date_still_maps(self):
+        filing = _to_filing({**_ROW, "effective_date_renewal": ""})
+        assert filing is not None
+        assert filing.effective_date_renewal is None
+
+    def test_a_row_with_no_company_is_unusable(self):
+        assert _to_filing({**_ROW, "company_name": ""}) is None
+
+    def test_a_row_with_no_serff_id_is_unusable(self):
+        assert _to_filing({**_ROW, "serff_id": ""}) is None
+
+
+class TestFetch:
+    @pytest.mark.asyncio
+    async def test_returns_mapped_filings(self, monkeypatch):
+        monkeypatch.setattr(
+            client.httpx.AsyncClient,
+            "get",
+            _stub_get(httpx.Response(200, json=[_ROW])),
+        )
+        filings = await fetch_dwelling_filings()
+        assert [f.company_name for f in filings] == ["SAFEPOINT INSURANCE COMPANY"]
+
+    @pytest.mark.asyncio
+    async def test_caches_between_calls(self, monkeypatch):
+        calls: list[int] = []
+
+        async def _get(self, url, **kwargs):
+            calls.append(1)
+            return httpx.Response(200, json=[_ROW], request=httpx.Request("GET", url))
+
+        monkeypatch.setattr(client.httpx.AsyncClient, "get", _get)
+        await fetch_dwelling_filings()
+        await fetch_dwelling_filings()
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_an_http_error_raises_rather_than_returning_empty(self, monkeypatch):
+        # An empty list would render as "no increases filed", which is the one
+        # thing an outage must never look like.
+        monkeypatch.setattr(
+            client.httpx.AsyncClient, "get", _stub_get(httpx.Response(503, text="down")),
+        )
+        with pytest.raises(RateFilingFeedUnavailableError):
+            await fetch_dwelling_filings()
+
+    @pytest.mark.asyncio
+    async def test_a_network_failure_raises(self, monkeypatch):
+        async def _get(self, url, **kwargs):
+            raise httpx.ConnectError("no route to host")
+
+        monkeypatch.setattr(client.httpx.AsyncClient, "get", _get)
+        with pytest.raises(RateFilingFeedUnavailableError):
+            await fetch_dwelling_filings()
+
+    @pytest.mark.asyncio
+    async def test_an_unexpected_shape_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            client.httpx.AsyncClient,
+            "get",
+            _stub_get(httpx.Response(200, json={"error": "bad query"})),
+        )
+        with pytest.raises(RateFilingFeedUnavailableError):
+            await fetch_dwelling_filings()
+
+
+def _stub_get(response: httpx.Response):
+    async def _get(self, url, **kwargs):
+        response.request = httpx.Request("GET", url)
+        return response
+
+    return _get

--- a/apps/mybookkeeper/frontend/e2e/insurance-rate-watch.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/insurance-rate-watch.spec.ts
@@ -1,0 +1,339 @@
+/**
+ * No-backend E2E for the "Check for rate increases" section.
+ *
+ * Fully mocks the API surface via page.route() so it runs under
+ * playwright.layout.config.ts in the `frontend-layout-e2e` CI job (no backend,
+ * no globalSetup) — the same shape utility-better-plans.spec.ts uses.
+ *
+ * Mocking is not a compromise here: the upstream source is the Texas
+ * Department of Insurance filing dataset, which changes as carriers file.
+ * Asserting against whatever it happens to hold the morning the suite runs
+ * would test the Texas insurance market, not this code. What is exercised is
+ * ours — the check is explicit, the skeleton matches the loaded shape, an
+ * unmatched carrier is named rather than left blank, a filing that never took
+ * effect is labelled, and an outage reads as an outage.
+ *
+ * Verifies:
+ *   - Loading the page does not call the department; only a click does.
+ *   - Skeleton card/row counts mirror the loaded section (no layout shift).
+ *   - The projected renewal reads as a movement from today's premium, marked
+ *     as an estimate.
+ *   - A carrier with no filings says so instead of rendering as "all clear".
+ *   - A withdrawn filing is labelled "Not approved".
+ *   - No horizontal scroll across mobile / tablet / desktop; 44px touch target.
+ *   - A feed outage renders the reason rather than an empty section.
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const ORG_ID = "00000000-0000-0000-0000-000000000010";
+const POLICY_ID = "00000000-0000-0000-0000-0000000000d1";
+const UNMATCHED_POLICY_ID = "00000000-0000-0000-0000-0000000000d2";
+
+/** Matches ``RateWatchSkeleton``: two policy cards, two filing rows each. */
+const SKELETON_CARD_COUNT = 2;
+
+const FEED_DOWN_REASON =
+  "The Texas Department of Insurance filing data could not be reached, so nothing was checked.";
+
+function plantAuth(page: Page): Promise<void> {
+  return page.addInitScript(
+    ([orgId]) => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+      const payload = btoa(JSON.stringify({ sub: "test-user", exp: futureExp }));
+      window.localStorage.setItem("token", `${header}.${payload}.fake-signature`);
+      window.localStorage.setItem("v1_activeOrgId", orgId);
+    },
+    [ORG_ID],
+  );
+}
+
+function json(body: unknown) {
+  return { status: 200, contentType: "application/json", body: JSON.stringify(body) };
+}
+
+async function stubShell(page: Page): Promise<void> {
+  await page.route("**/api/users/me", (route) =>
+    route.fulfill(
+      json({
+        id: "00000000-0000-0000-0000-000000000001",
+        email: "test@example.com",
+        name: "Test User",
+        is_active: true,
+        is_superuser: false,
+        is_verified: true,
+        role: "owner",
+      }),
+    ),
+  );
+  await page.route("**/api/organizations", (route) =>
+    route.fulfill(json([{ id: ORG_ID, name: "Test Workspace", role: "owner" }])),
+  );
+  await page.route("**/api/version", (route) => route.fulfill(json({ version: "test" })));
+  await page.route("**/api/tax-profile", (route) =>
+    route.fulfill(
+      json({
+        onboarding_completed: true,
+        tax_situations: [],
+        filing_status: null,
+        dependents_count: 0,
+      }),
+    ),
+  );
+  await page.route("**/api/properties", (route) => route.fulfill(json([])));
+  // Shell-level polls. Unstubbed they 401 against the dev proxy, and the axios
+  // interceptor logs the session out mid-test — which shows up as the section
+  // detaching from the DOM rather than as an auth failure.
+  await page.route("**/api/integrations", (route) => route.fulfill(json([])));
+  await page.route("**/api/transactions/attribution-review-queue*", (route) =>
+    route.fulfill(json({ items: [], total: 0, has_more: false })),
+  );
+}
+
+/**
+ * The rest of the Insurance page. `**\/api/insurance-policies*` stops at the
+ * next `/`, so it never swallows `/insurance-market/rate-watch`.
+ */
+async function stubInsurancePage(page: Page): Promise<void> {
+  await page.route("**/api/insurance-policies/premium-comparison*", (route) =>
+    route.fulfill(
+      json({
+        material_gap_pct: 15,
+        benchmark: null,
+        above_market: [],
+        not_compared: [],
+        total_above_market: 0,
+        total_considered: 0,
+        has_stale_benchmark: false,
+      }),
+    ),
+  );
+  await page.route("**/api/insurance-benchmarks*", (route) => route.fulfill(json(null)));
+  await page.route("**/api/insurance-policies?*", (route) =>
+    route.fulfill(json({ items: [], total: 0, has_more: false })),
+  );
+  await page.route("**/api/insurance-policies", (route) =>
+    route.fulfill(json({ items: [], total: 0, has_more: false })),
+  );
+}
+
+const APPROVED_FILING = {
+  serff_id: "SFPT-134523456",
+  company_name: "SAFEPOINT INSURANCE COMPANY",
+  product_name: "TX DWO",
+  percent_change: 11.1,
+  filed_date: "2026-05-28",
+  effective_date_renewal: "2026-09-01",
+  is_in_force: true,
+  is_pending: false,
+};
+
+const WITHDRAWN_FILING = {
+  serff_id: "SFPT-134523099",
+  company_name: "SAFEPOINT INSURANCE COMPANY",
+  product_name: "TX Business Advantage Program",
+  percent_change: 24.0,
+  filed_date: "2026-02-19",
+  effective_date_renewal: "2026-05-01",
+  is_in_force: false,
+  is_pending: false,
+};
+
+const FLAT_FILING = {
+  serff_id: "FRMT-260724001",
+  company_name: "FOREMOST LLOYDS OF TEXAS",
+  product_name: "Dwelling Program - Landlord",
+  percent_change: 0.0,
+  filed_date: "2026-07-24",
+  effective_date_renewal: "2026-10-14",
+  is_in_force: true,
+  is_pending: false,
+};
+
+const RATE_WATCH_RESPONSE = {
+  outlooks: [
+    {
+      policy_id: POLICY_ID,
+      policy_name: "Dwelling DP-3",
+      property_name: "E2E Peerless",
+      carrier: "SafePoint",
+      expiration_date: "2026-09-24",
+      current_premium_cents: 241_000,
+      filings: [APPROVED_FILING, WITHDRAWN_FILING],
+      projected_change_pct: 11.1,
+      projected_premium_cents: 267_751,
+      unavailable_reason: null,
+    },
+    {
+      policy_id: UNMATCHED_POLICY_ID,
+      policy_name: "Dwelling DP-3",
+      property_name: "E2E Second Peerless",
+      carrier: "Benchmark/Swyfft",
+      expiration_date: "2027-02-01",
+      current_premium_cents: 180_000,
+      filings: [],
+      projected_change_pct: null,
+      projected_premium_cents: null,
+      unavailable_reason: "No dwelling-line filings found under this carrier's name.",
+    },
+  ],
+  market_filings: [FLAT_FILING, APPROVED_FILING],
+  has_any_increase: true,
+  feed_unavailable_reason: null,
+};
+
+async function hasHorizontalOverflow(page: Page): Promise<boolean> {
+  return page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+  );
+}
+
+test.beforeEach(async ({ page }) => {
+  await plantAuth(page);
+  await stubShell(page);
+  await stubInsurancePage(page);
+});
+
+test.describe("Check for rate increases", () => {
+  test("checks only when asked, then shows the outlook with its caveats", async ({
+    page,
+  }) => {
+    let watchRequests = 0;
+    await page.route("**/api/insurance-market/rate-watch*", async (route) => {
+      watchRequests += 1;
+      // Held long enough for the skeleton to be observable on the one click.
+      await new Promise((r) => setTimeout(r, 1200));
+      await route.fulfill(json(RATE_WATCH_RESPONSE));
+    });
+
+    await page.goto("/insurance-policies");
+
+    // Loading the page must not reach the department on its own.
+    await expect(page.getByTestId("rate-watch-idle")).toBeVisible({ timeout: 15000 });
+    expect(watchRequests, "feed was hit before the operator asked").toBe(0);
+
+    await page.getByTestId("check-rate-filings-button").click();
+
+    const skeleton = page.getByTestId("rate-watch-loading");
+    await expect(skeleton).toBeVisible({ timeout: 5000 });
+    await expect(skeleton.locator("ul > li")).toHaveCount(SKELETON_CARD_COUNT);
+
+    const results = page.getByTestId("rate-watch-results");
+    await expect(results).toBeVisible({ timeout: 15000 });
+    expect(watchRequests).toBe(1);
+
+    // The projection reads as a movement from today's premium, and never as a
+    // quote: a filing is a statewide average, not this house's renewal.
+    const projection = page.getByTestId("rate-watch-outlook-projection");
+    await expect(projection).toContainText("$2,410/yr");
+    await expect(projection).toContainText("$2,678/yr");
+    await expect(projection).toContainText("+11.1%");
+    await expect(projection).toContainText("estimated");
+
+    // The bigger number on the card is one the carrier asked for and did not
+    // get. Unlabelled, it would read as the coming increase.
+    const cards = page.getByTestId("rate-watch-outlook-card");
+    await expect(cards.first()).toContainText("Not approved");
+    await expect(cards.first()).toContainText("Approved");
+
+    // A carrier the department publishes nothing for says so. Silence here
+    // would read as "no increase coming".
+    await expect(page.getByTestId("rate-watch-outlook-unavailable")).toContainText(
+      "No dwelling-line filings found under this carrier's name.",
+    );
+
+    // The market half: who to ask an agent about.
+    const market = page.getByTestId("rate-watch-market-list");
+    await expect(market).toContainText("FOREMOST LLOYDS OF TEXAS");
+    await expect(market).toContainText("no change");
+
+    // A projection is arithmetic on a statewide average, not a bill promise.
+    await expect(results).toContainText("statewide average");
+  });
+
+  test("the section fits every viewport and keeps a 44px touch target", async ({
+    page,
+  }) => {
+    await page.route("**/api/insurance-market/rate-watch*", (route) =>
+      route.fulfill(json(RATE_WATCH_RESPONSE)),
+    );
+
+    for (const size of [
+      { width: 375, height: 800 },
+      { width: 768, height: 900 },
+      { width: 1440, height: 900 },
+    ]) {
+      await page.setViewportSize(size);
+      await page.goto("/insurance-policies");
+
+      const button = page.getByTestId("check-rate-filings-button");
+      await expect(button).toBeVisible({ timeout: 15000 });
+      await button.click();
+      await expect(page.getByTestId("rate-watch-results")).toBeVisible({
+        timeout: 15000,
+      });
+
+      expect(
+        await hasHorizontalOverflow(page),
+        `horizontal overflow at ${size.width}px`,
+      ).toBe(false);
+    }
+
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto("/insurance-policies");
+    const button = page.getByTestId("check-rate-filings-button");
+    await expect(button).toBeVisible({ timeout: 15000 });
+    const box = await button.boundingBox();
+    expect(box, "check button has no box").not.toBeNull();
+    expect(box!.height, "check button height").toBeGreaterThanOrEqual(44);
+  });
+
+  test("a feed outage reads as an outage, not as good news", async ({ page }) => {
+    await page.route("**/api/insurance-market/rate-watch*", (route) =>
+      route.fulfill(
+        json({
+          ...RATE_WATCH_RESPONSE,
+          outlooks: [
+            {
+              ...RATE_WATCH_RESPONSE.outlooks[0],
+              filings: [],
+              projected_change_pct: null,
+              projected_premium_cents: null,
+              unavailable_reason: FEED_DOWN_REASON,
+            },
+          ],
+          market_filings: [],
+          has_any_increase: false,
+          feed_unavailable_reason: FEED_DOWN_REASON,
+        }),
+      ),
+    );
+
+    await page.goto("/insurance-policies");
+    await page.getByTestId("check-rate-filings-button").click();
+
+    const results = page.getByTestId("rate-watch-results");
+    await expect(results).toContainText("could not be reached");
+    // The absence of a projection must be explained, never left blank.
+    await expect(page.getByTestId("rate-watch-outlook-unavailable")).toContainText(
+      "nothing was checked",
+    );
+  });
+
+  test("a request failure keeps the blame off the policies", async ({ page }) => {
+    await page.route("**/api/insurance-market/rate-watch*", (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "rate_filing_feed_unavailable" }),
+      }),
+    );
+
+    await page.goto("/insurance-policies");
+    await page.getByTestId("check-rate-filings-button").click();
+
+    await expect(page.getByTestId("rate-watch-error")).toContainText(
+      "Nothing is wrong with your policies",
+    );
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/RateWatchSection.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/RateWatchSection.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for the "Check for rate increases" section.
+ *
+ * Three behaviours matter, and all three are about not overstating what the
+ * filing data says:
+ *
+ * 1. A carrier with no filings under its name says so. Swyfft — the carrier on
+ *    one of the operator's own policies — files nothing TDI publishes under
+ *    that name, and an empty card would read as "no increases coming".
+ * 2. A filing that was withdrawn or rejected is labelled "Not approved". As a
+ *    bare percentage it is indistinguishable from one that took effect, and
+ *    only one of them will ever appear on a bill.
+ * 3. A feed outage is stated. The one thing this section must never do is
+ *    render silence as good news.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RateWatchSection from "@/app/features/insurance/RateWatchSection";
+import type { InsuranceMarketWatch } from "@/shared/types/insurance/insurance-market-watch";
+import type { InsurancePolicyRateOutlook } from "@/shared/types/insurance/insurance-policy-rate-outlook";
+import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rate-filing";
+
+const mockCheck = vi.fn();
+let mockData: InsuranceMarketWatch | undefined;
+let mockFetching = false;
+let mockError = false;
+let mockUninitialized = true;
+
+vi.mock("@/shared/store/insuranceMarketApi", () => ({
+  useLazyGetInsuranceRateWatchQuery: () => [
+    mockCheck,
+    {
+      data: mockData,
+      isFetching: mockFetching,
+      isError: mockError,
+      isUninitialized: mockUninitialized,
+    },
+  ],
+}));
+
+function filing(overrides: Partial<InsuranceRateFiling> = {}): InsuranceRateFiling {
+  return {
+    serff_id: "SFPT-134523456",
+    company_name: "SAFEPOINT INSURANCE COMPANY",
+    product_name: "TX DWO",
+    percent_change: 11.1,
+    filed_date: "2026-05-28",
+    effective_date_renewal: "2026-09-01",
+    is_in_force: true,
+    is_pending: false,
+    ...overrides,
+  };
+}
+
+function outlook(
+  overrides: Partial<InsurancePolicyRateOutlook> = {},
+): InsurancePolicyRateOutlook {
+  return {
+    policy_id: "policy-1",
+    policy_name: "Dwelling DP-3",
+    property_name: "6738 Peerless St",
+    carrier: "SafePoint",
+    expiration_date: "2026-09-24",
+    current_premium_cents: 241_000,
+    filings: [filing()],
+    projected_change_pct: 11.1,
+    projected_premium_cents: 267_751,
+    unavailable_reason: null,
+    ...overrides,
+  };
+}
+
+function watch(overrides: Partial<InsuranceMarketWatch> = {}): InsuranceMarketWatch {
+  return {
+    outlooks: [outlook()],
+    market_filings: [filing()],
+    has_any_increase: true,
+    feed_unavailable_reason: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockData = undefined;
+  mockFetching = false;
+  mockError = false;
+  mockUninitialized = true;
+});
+
+describe("RateWatchSection", () => {
+  it("does not reach the department until asked", async () => {
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-idle")).toBeInTheDocument();
+    expect(mockCheck).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByTestId("check-rate-filings-button"));
+    expect(mockCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("names both the property and the policy on every card", () => {
+    // A property can carry a dwelling policy and a separate wind-only one.
+    // Headed by property alone the two cards read as duplicates.
+    mockUninitialized = false;
+    mockData = watch({
+      outlooks: [
+        outlook({ policy_id: "policy-1", policy_name: "Dwelling DP-3" }),
+        outlook({ policy_id: "policy-2", policy_name: "Wind and hail" }),
+      ],
+    });
+    render(<RateWatchSection />);
+
+    const cards = screen.getAllByTestId("rate-watch-outlook-card");
+    expect(cards[0]).toHaveTextContent("6738 Peerless St · Dwelling DP-3");
+    expect(cards[1]).toHaveTextContent("6738 Peerless St · Wind and hail");
+  });
+
+  it("shows a skeleton, not text, while checking", () => {
+    mockFetching = true;
+    mockUninitialized = false;
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("rate-watch-results")).not.toBeInTheDocument();
+  });
+
+  it("projects the renewal premium from the filed increase", () => {
+    mockUninitialized = false;
+    mockData = watch();
+    render(<RateWatchSection />);
+
+    const projection = screen.getByTestId("rate-watch-outlook-projection");
+    expect(projection).toHaveTextContent("$2,410/yr");
+    expect(projection).toHaveTextContent("$2,678/yr");
+    expect(projection).toHaveTextContent("+11.1%");
+    // Never presented as a quote.
+    expect(projection).toHaveTextContent("estimated");
+  });
+
+  it("says when a carrier has no filings rather than looking clear", () => {
+    mockUninitialized = false;
+    mockData = watch({
+      outlooks: [
+        outlook({
+          carrier: "Benchmark/Swyfft",
+          filings: [],
+          projected_change_pct: null,
+          projected_premium_cents: null,
+          unavailable_reason:
+            "No dwelling-line filings found under this carrier's name.",
+        }),
+      ],
+    });
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-outlook-unavailable")).toHaveTextContent(
+      "No dwelling-line filings found under this carrier's name.",
+    );
+    expect(
+      screen.queryByTestId("rate-watch-outlook-projection"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reads a flat carrier as holding rates, not as plus zero", () => {
+    mockUninitialized = false;
+    mockData = watch({
+      outlooks: [
+        outlook({
+          carrier: "Foremost",
+          projected_change_pct: 0,
+          projected_premium_cents: 241_000,
+          filings: [filing({ percent_change: 0 })],
+        }),
+      ],
+    });
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-outlook-headline")).toHaveTextContent(
+      "Foremost is holding rates flat",
+    );
+    expect(
+      screen.queryByTestId("rate-watch-outlook-projection"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("labels a filing that never took effect", () => {
+    mockUninitialized = false;
+    mockData = watch({
+      outlooks: [
+        outlook({
+          filings: [filing({ is_in_force: false, is_pending: false })],
+        }),
+      ],
+      market_filings: [],
+    });
+    render(<RateWatchSection />);
+
+    expect(screen.getAllByTestId("rate-watch-filing-row")[0]).toHaveTextContent(
+      "Not approved",
+    );
+  });
+
+  it("labels a filing the regulator has not ruled on", () => {
+    mockUninitialized = false;
+    mockData = watch({
+      market_filings: [filing({ is_in_force: false, is_pending: true })],
+    });
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-market-list")).toHaveTextContent(
+      "Proposed",
+    );
+  });
+
+  it("states a feed outage instead of rendering silence", () => {
+    mockUninitialized = false;
+    mockData = watch({
+      outlooks: [
+        outlook({
+          filings: [],
+          projected_change_pct: null,
+          projected_premium_cents: null,
+          unavailable_reason:
+            "The Texas Department of Insurance filing data could not be reached, so nothing was checked.",
+        }),
+      ],
+      market_filings: [],
+      has_any_increase: false,
+      feed_unavailable_reason:
+        "The Texas Department of Insurance filing data could not be reached, so nothing was checked.",
+    });
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-results")).toHaveTextContent(
+      "could not be reached",
+    );
+  });
+
+  it("explains an empty portfolio rather than showing a blank section", () => {
+    mockUninitialized = false;
+    mockData = watch({ outlooks: [] });
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-empty")).toBeInTheDocument();
+  });
+
+  it("keeps a request failure away from the policy list", () => {
+    mockUninitialized = false;
+    mockError = true;
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-error")).toHaveTextContent(
+      "Nothing is wrong with your policies",
+    );
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/rate-filing-format.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/rate-filing-format.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the rate-filing display helpers.
+ *
+ * The distinction these protect is between "the carrier held rates flat" and
+ * "no approved change was found". Both are quiet outcomes, only one is good
+ * news, and collapsing them into the same dash is how a page tells an operator
+ * nothing is coming when in fact nothing was found.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  formatChangePct,
+  formatFilingDate,
+  formatFilingStatus,
+  formatOutlookHeadline,
+} from "@/shared/lib/rate-filing-format";
+import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rate-filing";
+
+function filing(overrides: Partial<InsuranceRateFiling> = {}): InsuranceRateFiling {
+  return {
+    serff_id: "SFPT-134523456",
+    company_name: "SAFEPOINT INSURANCE COMPANY",
+    product_name: "TX DWO",
+    percent_change: 11.1,
+    filed_date: "2026-05-28",
+    effective_date_renewal: "2026-09-01",
+    is_in_force: true,
+    is_pending: false,
+    ...overrides,
+  };
+}
+
+describe("formatChangePct", () => {
+  it("signs an increase", () => {
+    expect(formatChangePct(11.1)).toBe("+11.1%");
+  });
+
+  it("keeps a decrease negative", () => {
+    expect(formatChangePct(-4.2)).toBe("-4.2%");
+  });
+
+  it("spells out a flat filing rather than showing a signed zero", () => {
+    expect(formatChangePct(0)).toBe("no change");
+  });
+
+  it("shows an unstated change as missing, not as zero", () => {
+    expect(formatChangePct(null)).toBe("—");
+  });
+});
+
+describe("formatFilingDate", () => {
+  it("reads an ISO date", () => {
+    expect(formatFilingDate("2026-09-01")).toBe("Sep 1, 2026");
+  });
+
+  it("handles a missing date", () => {
+    expect(formatFilingDate(null)).toBe("—");
+  });
+
+  it("handles an unparseable date", () => {
+    expect(formatFilingDate("not a date")).toBe("—");
+  });
+});
+
+describe("formatFilingStatus", () => {
+  it("calls an in-force filing approved", () => {
+    expect(formatFilingStatus(filing())).toBe("Approved");
+  });
+
+  it("calls a pending filing proposed", () => {
+    expect(
+      formatFilingStatus(filing({ is_in_force: false, is_pending: true })),
+    ).toBe("Proposed");
+  });
+
+  it("calls a withdrawn filing not approved", () => {
+    // Neither in force nor pending — the carrier asked and did not get it.
+    expect(
+      formatFilingStatus(filing({ is_in_force: false, is_pending: false })),
+    ).toBe("Not approved");
+  });
+});
+
+describe("formatOutlookHeadline", () => {
+  it("names the carrier raising rates", () => {
+    expect(formatOutlookHeadline(11.1, "SafePoint")).toBe(
+      "SafePoint filed an increase",
+    );
+  });
+
+  it("distinguishes holding flat from finding nothing", () => {
+    expect(formatOutlookHeadline(0, "Foremost")).toBe(
+      "Foremost is holding rates flat",
+    );
+    expect(formatOutlookHeadline(null, "Foremost")).toBe(
+      "Foremost — no approved change found",
+    );
+  });
+
+  it("reports a decrease as such", () => {
+    expect(formatOutlookHeadline(-4.2, "Foremost")).toBe(
+      "Foremost filed a decrease",
+    );
+  });
+
+  it("falls back when the policy records no carrier", () => {
+    expect(formatOutlookHeadline(11.1, null)).toBe(
+      "This carrier filed an increase",
+    );
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchBody.tsx
@@ -1,0 +1,68 @@
+import AlertBox from "@/shared/components/ui/AlertBox";
+import RateWatchMarketList from "@/app/features/insurance/RateWatchMarketList";
+import RateWatchOutlookCard from "@/app/features/insurance/RateWatchOutlookCard";
+import RateWatchSkeleton from "@/app/features/insurance/RateWatchSkeleton";
+import type { InsuranceMarketWatch } from "@/shared/types/insurance/insurance-market-watch";
+import type { RateWatchMode } from "@/shared/types/insurance/rate-watch-mode";
+
+export interface RateWatchBodyProps {
+  mode: RateWatchMode;
+  data: InsuranceMarketWatch | undefined;
+}
+
+export default function RateWatchBody({ mode, data }: RateWatchBodyProps) {
+  switch (mode) {
+    case "loading":
+      return <RateWatchSkeleton />;
+
+    case "idle":
+      return (
+        <p className="text-sm text-muted-foreground" data-testid="rate-watch-idle">
+          Texas carriers must file a rate change with the state before they can
+          charge it, months before the renewal notice reaches you. This checks
+          the landlord-policy filings against every policy you hold.
+        </p>
+      );
+
+    case "error":
+      return (
+        <p className="text-sm text-muted-foreground" data-testid="rate-watch-error">
+          Couldn't reach the filing data. Nothing is wrong with your policies —
+          try again shortly.
+        </p>
+      );
+
+    case "empty":
+      return (
+        <p className="text-sm text-muted-foreground" data-testid="rate-watch-empty">
+          No active insurance policies on file yet. Add one and we'll have
+          something to check the filings against.
+        </p>
+      );
+
+    case "results":
+      return (
+        <div className="space-y-4" data-testid="rate-watch-results">
+          {data?.feed_unavailable_reason ? (
+            <AlertBox variant="warning">{data.feed_unavailable_reason}</AlertBox>
+          ) : null}
+
+          <ul className="space-y-3">
+            {(data?.outlooks ?? []).map((outlook) => (
+              <RateWatchOutlookCard key={outlook.policy_id} outlook={outlook} />
+            ))}
+          </ul>
+
+          <RateWatchMarketList filings={data?.market_filings ?? []} />
+
+          {/* Stated once, at the bottom. Every figure above is a carrier's
+              statewide average, not a quote on a specific house. */}
+          <p className="text-xs text-muted-foreground">
+            Filings come from the Texas Department of Insurance. A filed change
+            is a statewide average across the carrier's whole book — your own
+            renewal also moves with your coverage amount and claims history.
+          </p>
+        </div>
+      );
+  }
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchFilingRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchFilingRow.tsx
@@ -1,0 +1,52 @@
+import Badge, { type BadgeColor } from "@/shared/components/ui/Badge";
+import {
+  formatChangePct,
+  formatFilingDate,
+  formatFilingStatus,
+} from "@/shared/lib/rate-filing-format";
+import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rate-filing";
+
+/** Green for a decrease, orange for a rise, grey for flat or unstated. */
+function changeColor(pct: number | null): BadgeColor {
+  if (pct === null || pct === 0) return "gray";
+  return pct > 0 ? "orange" : "green";
+}
+
+export interface RateWatchFilingRowProps {
+  filing: InsuranceRateFiling;
+}
+
+/**
+ * One filing, as a line.
+ *
+ * The status badge is not decoration. A carrier that asked for 15% and was
+ * refused reads identically to one that got it unless the disposition is on
+ * the row, and only one of those changes what the operator will pay.
+ */
+export default function RateWatchFilingRow({ filing }: RateWatchFilingRowProps) {
+  return (
+    <li
+      className="flex flex-wrap items-baseline gap-x-3 gap-y-1 py-2 border-b border-border last:border-0"
+      data-testid="rate-watch-filing-row"
+    >
+      <span className="text-sm font-medium min-w-0 flex-1 truncate">
+        {filing.company_name}
+      </span>
+
+      <Badge
+        label={formatChangePct(filing.percent_change)}
+        color={changeColor(filing.percent_change)}
+      />
+
+      <Badge
+        label={formatFilingStatus(filing)}
+        color={filing.is_in_force ? "gray" : "yellow"}
+      />
+
+      <span className="text-xs text-muted-foreground w-full sm:w-auto">
+        {filing.product_name ?? "Unnamed program"} · renewals from{" "}
+        {formatFilingDate(filing.effective_date_renewal)}
+      </span>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchMarketList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchMarketList.tsx
@@ -1,0 +1,37 @@
+import RateWatchFilingRow from "@/app/features/insurance/RateWatchFilingRow";
+import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rate-filing";
+
+export interface RateWatchMarketListProps {
+  filings: InsuranceRateFiling[];
+}
+
+/**
+ * The dwelling market: who last moved their landlord rates, and by how much.
+ *
+ * This is the half the operator can act on. A dwelling policy is written
+ * through an agent rather than bought online, so the useful thing to walk into
+ * that conversation with is the list of carriers currently holding flat — and
+ * the ones to avoid asking about.
+ */
+export default function RateWatchMarketList({ filings }: RateWatchMarketListProps) {
+  if (filings.length === 0) return null;
+
+  return (
+    <section
+      className="rounded-lg border border-border p-4"
+      data-testid="rate-watch-market-list"
+    >
+      <h3 className="text-sm font-semibold">Recent landlord-policy filings</h3>
+      <p className="text-xs text-muted-foreground mt-0.5">
+        One row per carrier, most recent first. A carrier holding flat is worth
+        asking your agent about.
+      </p>
+
+      <ul className="mt-3">
+        {filings.map((filing) => (
+          <RateWatchFilingRow key={filing.serff_id} filing={filing} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchOutlookCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchOutlookCard.tsx
@@ -1,0 +1,92 @@
+import RateWatchFilingRow from "@/app/features/insurance/RateWatchFilingRow";
+import {
+  formatChangePct,
+  formatFilingDate,
+  formatOutlookHeadline,
+} from "@/shared/lib/rate-filing-format";
+import { formatAnnualPremium } from "@/shared/lib/insurance-policy-format";
+import type { InsurancePolicyRateOutlook } from "@/shared/types/insurance/insurance-policy-rate-outlook";
+
+export interface RateWatchOutlookCardProps {
+  outlook: InsurancePolicyRateOutlook;
+}
+
+/**
+ * One policy's renewal outlook.
+ *
+ * The projection is stated as an estimate every time it appears. A rate filing
+ * is a statewide average across a carrier's whole book, and the operator's own
+ * renewal also moves with their coverage amount and claims history — showing it
+ * as a firm number would invite them to treat it as a quote.
+ */
+export default function RateWatchOutlookCard({ outlook }: RateWatchOutlookCardProps) {
+  const { projected_change_pct: pct, unavailable_reason: reason } = outlook;
+
+  return (
+    <li
+      className="rounded-lg border border-border p-4"
+      data-testid="rate-watch-outlook-card"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+        {/* Both names, always. A property can carry more than one policy — a
+            dwelling policy and a separate wind-only one is the common Texas
+            shape — and headed by property alone the two cards are
+            indistinguishable. */}
+        <h3 className="text-sm font-semibold min-w-0">
+          {outlook.property_name ? (
+            <>
+              {outlook.property_name}
+              <span className="font-normal text-muted-foreground">
+                {" · "}
+                {outlook.policy_name}
+              </span>
+            </>
+          ) : (
+            outlook.policy_name
+          )}
+        </h3>
+        <span className="text-xs text-muted-foreground">
+          Renews {formatFilingDate(outlook.expiration_date)}
+        </span>
+      </div>
+
+      {reason ? (
+        <p
+          className="text-sm text-muted-foreground mt-2"
+          data-testid="rate-watch-outlook-unavailable"
+        >
+          {reason}
+        </p>
+      ) : (
+        <>
+          <p className="text-sm mt-2" data-testid="rate-watch-outlook-headline">
+            {formatOutlookHeadline(pct, outlook.carrier)}
+          </p>
+
+          {pct !== null && pct !== 0 ? (
+            <p
+              className="text-lg font-semibold mt-1"
+              data-testid="rate-watch-outlook-projection"
+            >
+              {formatAnnualPremium(outlook.current_premium_cents)}
+              {" → "}
+              {formatAnnualPremium(outlook.projected_premium_cents)}
+              <span className="text-sm font-normal text-muted-foreground">
+                {" "}
+                ({formatChangePct(pct)}, estimated)
+              </span>
+            </p>
+          ) : null}
+        </>
+      )}
+
+      {outlook.filings.length > 0 ? (
+        <ul className="mt-3">
+          {outlook.filings.map((filing) => (
+            <RateWatchFilingRow key={filing.serff_id} filing={filing} />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchSection.tsx
@@ -1,0 +1,54 @@
+import { LoadingButton } from "@platform/ui";
+import RateWatchBody from "@/app/features/insurance/RateWatchBody";
+import { useRateWatchMode } from "@/app/features/insurance/useRateWatchMode";
+import { useLazyGetInsuranceRateWatchQuery } from "@/shared/store/insuranceMarketApi";
+
+/**
+ * "Is my premium about to go up" — the market side of the insurance feature.
+ *
+ * The counterpart to the utility page's better-plans search, and it has to be
+ * shaped differently. There is no marketplace to shop a landlord policy on;
+ * what Texas publishes instead is the rate change every carrier must file
+ * before charging it. So this reports what is coming rather than what to
+ * switch to, which is the more useful half — a renewal quote arrives as a fait
+ * accompli, while a filing is public months ahead.
+ *
+ * The check is explicit rather than automatic: it reaches out to the
+ * Department of Insurance, and a page view is not a reason to hit an external
+ * service.
+ */
+export default function RateWatchSection() {
+  const [check, { data, isFetching, isError, isUninitialized }] =
+    useLazyGetInsuranceRateWatchQuery();
+
+  const mode = useRateWatchMode({
+    hasChecked: !isUninitialized,
+    isFetching,
+    isError,
+    outlookCount: data?.outlooks.length ?? 0,
+  });
+
+  return (
+    <section className="space-y-3" data-testid="rate-watch-section">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold">Check for rate increases</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Landlord-policy rate filings from the Texas Department of Insurance,
+            matched to the policies you hold.
+          </p>
+        </div>
+        <LoadingButton
+          isLoading={isFetching}
+          loadingText="Checking filings..."
+          onClick={() => void check()}
+          data-testid="check-rate-filings-button"
+        >
+          Check filings
+        </LoadingButton>
+      </div>
+
+      <RateWatchBody mode={mode} data={data} />
+    </section>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchSkeleton.tsx
@@ -1,0 +1,52 @@
+/**
+ * Loading placeholder for the rate-watch check.
+ *
+ * Mirrors the loaded section: two bordered policy cards, each with a heading
+ * row, a headline line, a projection line and two filing rows, then the market
+ * list with its heading and five rows. Same shape means no layout shift when
+ * the department answers.
+ */
+export default function RateWatchSkeleton() {
+  return (
+    <div
+      className="space-y-4 animate-pulse"
+      aria-busy="true"
+      data-testid="rate-watch-loading"
+    >
+      <ul className="space-y-3">
+        {[1, 2].map((card) => (
+          <li key={card} className="rounded-lg border border-border p-4">
+            <div className="flex items-baseline justify-between gap-3">
+              <div className="h-4 bg-muted rounded w-40" />
+              <div className="h-3 bg-muted rounded w-28" />
+            </div>
+            <div className="h-4 bg-muted rounded w-56 mt-2" />
+            <div className="h-6 bg-muted rounded w-64 mt-1" />
+            <div className="mt-3 space-y-2">
+              {[1, 2].map((row) => (
+                <div key={row} className="flex items-center gap-3 py-1">
+                  <div className="h-4 bg-muted rounded flex-1" />
+                  <div className="h-4 w-16 bg-muted rounded" />
+                  <div className="h-4 w-20 bg-muted rounded" />
+                </div>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <section className="rounded-lg border border-border p-4">
+        <div className="h-4 bg-muted rounded w-48" />
+        <div className="mt-3 space-y-2">
+          {[1, 2, 3, 4, 5].map((row) => (
+            <div key={row} className="flex items-center gap-3 py-1">
+              <div className="h-4 bg-muted rounded flex-1" />
+              <div className="h-4 w-16 bg-muted rounded" />
+              <div className="h-4 w-20 bg-muted rounded" />
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/useRateWatchMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/useRateWatchMode.ts
@@ -1,0 +1,28 @@
+import type { RateWatchMode } from "@/shared/types/insurance/rate-watch-mode";
+
+export interface UseRateWatchModeArgs {
+  hasChecked: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  outlookCount: number;
+}
+
+/**
+ * Resolves the rate-watch render mode.
+ *
+ * Single source of truth so the body is a flat switch rather than a ternary
+ * chain, and so the skeleton and the results can never disagree about which
+ * state is showing.
+ */
+export function useRateWatchMode({
+  hasChecked,
+  isFetching,
+  isError,
+  outlookCount,
+}: UseRateWatchModeArgs): RateWatchMode {
+  if (isFetching) return "loading";
+  if (!hasChecked) return "idle";
+  if (isError) return "error";
+  if (outlookCount === 0) return "empty";
+  return "results";
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/InsurancePolicies.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/InsurancePolicies.tsx
@@ -9,6 +9,7 @@ import AddInsurancePolicyDialog from "@/app/features/insurance/AddInsurancePolic
 import InsuranceBenchmarkDialog from "@/app/features/insurance/InsuranceBenchmarkDialog";
 import InsuranceBenchmarkSummary from "@/app/features/insurance/InsuranceBenchmarkSummary";
 import InsurancePoliciesListBody from "@/app/features/insurance/InsurancePoliciesListBody";
+import RateWatchSection from "@/app/features/insurance/RateWatchSection";
 
 /**
  * All-policies view: lists insurance policies across all properties.
@@ -82,6 +83,10 @@ export default function InsurancePolicies() {
         policies={policies}
         showExpiringSoon={showExpiringSoon}
       />
+
+      {/* Below the policy list, mirroring the utility page: what you hold
+          first, then what the market is doing to it. */}
+      <RateWatchSection />
 
       {showAddDialog ? (
         <AddInsurancePolicyDialog onClose={() => setShowAddDialog(false)} />

--- a/apps/mybookkeeper/frontend/src/shared/lib/rate-filing-format.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/rate-filing-format.ts
@@ -1,0 +1,62 @@
+import { format, parseISO } from "date-fns";
+import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rate-filing";
+
+/**
+ * Display helpers for TDI rate filings.
+ *
+ * The thing these exist to prevent is a filing reading as more settled than it
+ * is. A withdrawn filing and an approved one look identical as a percentage,
+ * and only one of them will ever appear on a bill.
+ */
+
+/** `11.1` → `"+11.1%"`, `0` → `"no change"`, `null` → `"—"`. */
+export function formatChangePct(pct: number | null): string {
+  if (pct === null) return "—";
+  if (pct === 0) return "no change";
+  const sign = pct > 0 ? "+" : "";
+  return `${sign}${pct.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })}%`;
+}
+
+/** `"2026-09-01"` → `"Sep 1, 2026"`. */
+export function formatFilingDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return format(parseISO(iso), "MMM d, yyyy");
+  } catch {
+    return "—";
+  }
+}
+
+/**
+ * Where a filing stands with the regulator, in the operator's words.
+ *
+ * "Approved" is the only label that means the rate will be charged. A filing
+ * that is neither in force nor pending closed as withdrawn or rejected — the
+ * carrier asked and did not get it — and saying so is the difference between
+ * an accurate picture and a phantom increase.
+ */
+export function formatFilingStatus(filing: InsuranceRateFiling): string {
+  if (filing.is_in_force) return "Approved";
+  if (filing.is_pending) return "Proposed";
+  return "Not approved";
+}
+
+/**
+ * How the projected renewal reads in one line.
+ *
+ * Zero gets its own sentence rather than "+0%": a carrier holding rates flat is
+ * the good news on this page, and a signed zero buries it.
+ */
+export function formatOutlookHeadline(
+  pct: number | null,
+  carrier: string | null,
+): string {
+  const who = carrier ?? "This carrier";
+  if (pct === null) return `${who} — no approved change found`;
+  if (pct === 0) return `${who} is holding rates flat`;
+  if (pct < 0) return `${who} filed a decrease`;
+  return `${who} filed an increase`;
+}

--- a/apps/mybookkeeper/frontend/src/shared/store/insuranceMarketApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/insuranceMarketApi.ts
@@ -1,0 +1,27 @@
+import { baseApi } from "./baseApi";
+import type { InsuranceMarketWatch } from "@/shared/types/insurance/insurance-market-watch";
+
+/**
+ * RTK Query slice for the Texas dwelling rate watch.
+ *
+ * Tagged under `InsurancePolicy:RATE_WATCH` because every outlook is measured
+ * against a policy on file — changing a policy's carrier or expiration changes
+ * which filings apply to it, so policy mutations must be able to invalidate
+ * this.
+ *
+ * The query is lazy: it reaches out to the Department of Insurance, and a page
+ * view is not a reason to hit an external service.
+ */
+const insuranceMarketApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getInsuranceRateWatch: builder.query<InsuranceMarketWatch, void>({
+      query: () => ({ url: "/insurance-market/rate-watch" }),
+      providesTags: [{ type: "InsurancePolicy", id: "RATE_WATCH" }],
+    }),
+  }),
+});
+
+export const {
+  useGetInsuranceRateWatchQuery,
+  useLazyGetInsuranceRateWatchQuery,
+} = insuranceMarketApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-market-watch.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-market-watch.ts
@@ -1,0 +1,12 @@
+import type { InsurancePolicyRateOutlook } from "@/shared/types/insurance/insurance-policy-rate-outlook";
+import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rate-filing";
+
+/** Response for the dwelling-market rate watch. */
+export interface InsuranceMarketWatch {
+  outlooks: InsurancePolicyRateOutlook[];
+  /** Recent filings across the whole market — the shortlist to call. */
+  market_filings: InsuranceRateFiling[];
+  has_any_increase: boolean;
+  /** Set when the TDI feed could not be reached, so nothing was checked. */
+  feed_unavailable_reason: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-rate-outlook.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-rate-outlook.ts
@@ -1,0 +1,21 @@
+import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rate-filing";
+
+/** What the dwelling filings say about one policy's next renewal. */
+export interface InsurancePolicyRateOutlook {
+  policy_id: string;
+  policy_name: string;
+  property_name: string | null;
+  carrier: string | null;
+  expiration_date: string | null;
+  /** Annualised, so a monthly policy is comparable to the projection. */
+  current_premium_cents: number | null;
+  filings: InsuranceRateFiling[];
+  /**
+   * Null means nothing in force applied — which is not 0.0%. Zero means the
+   * carrier filed and held its rates flat, and that is worth showing.
+   */
+  projected_change_pct: number | null;
+  projected_premium_cents: number | null;
+  /** Why no outlook could be produced. Shown instead of an empty list. */
+  unavailable_reason: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-rate-filing.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-rate-filing.ts
@@ -1,0 +1,20 @@
+/**
+ * One dwelling-line rate filing a Texas carrier made with the Department of
+ * Insurance.
+ *
+ * `is_in_force` and `is_pending` are both false for a filing that was withdrawn
+ * or rejected — it closed without ever applying. The UI must never present one
+ * of those as a coming increase.
+ */
+export interface InsuranceRateFiling {
+  serff_id: string;
+  company_name: string;
+  product_name: string | null;
+  /** Positive is an increase, negative a decrease, null if unstated. */
+  percent_change: number | null;
+  filed_date: string | null;
+  /** When the new rate reaches renewing policies — the date that matters. */
+  effective_date_renewal: string | null;
+  is_in_force: boolean;
+  is_pending: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/rate-watch-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/rate-watch-mode.ts
@@ -1,0 +1,12 @@
+/**
+ * What the rate-watch section is currently showing.
+ *
+ * `idle` is the pre-search state — the check reaches out to the Texas
+ * Department of Insurance, so it runs when asked rather than on page load.
+ */
+export type RateWatchMode =
+  | "idle"
+  | "loading"
+  | "error"
+  | "empty"
+  | "results";

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -605,6 +605,10 @@
         "backend/app/services/insurance/",
         "backend/app/api/insurance_policies.py",
         "backend/app/api/insurance_benchmarks.py",
+        "backend/app/api/insurance_market.py",
+        "backend/app/core/tdi_rate_filings_constants.py",
+        "frontend/src/shared/lib/rate-filing-format.ts",
+        "frontend/src/shared/store/insuranceMarketApi.ts",
         "backend/app/core/insurance_enums.py",
         "backend/app/core/insurance_benchmark_constants.py",
         "backend/alembic/versions/insur260504_add_insurance_policy_tables.py",
@@ -639,6 +643,10 @@
         "test_insurance_benchmark_repo.py",
         "test_insurance_benchmark_service.py",
         "test_insurance_benchmarks_api.py",
+        "test_insurance_market_watch_service.py",
+        "test_insurance_market_api.py",
+        "test_insurance_carrier_filing_match.py",
+        "test_tdi_rate_filings_client.py",
         "test_document_draft_reader.py"
       ],
       "frontend_tests": [
@@ -655,6 +663,8 @@
         "InsurancePremiumComparisonCard.test.tsx",
         "InsuranceBenchmarkDialog.test.tsx",
         "InsuranceBenchmarkSummary.test.tsx",
+        "RateWatchSection.test.tsx",
+        "rate-filing-format.test.ts",
         "benchmark-format.test.ts",
         "Dashboard.test.tsx"
       ],
@@ -663,7 +673,8 @@
         "insurance-policy-detail-layout.spec.ts",
         "insurance-premium-benchmark.spec.ts",
         "insurance-premium-comparison-layout.spec.ts",
-        "insurance-policy-document-upload.spec.ts"
+        "insurance-policy-document-upload.spec.ts",
+        "insurance-rate-watch.spec.ts"
       ]
     },
     "utility_plans": {


### PR DESCRIPTION
The utility page can shop the market because Texas runs Power to Choose. Insurance has no equivalent for a rental. TDI's own comparison site, HelpInsure, has a free unauthenticated API — but every policy form it returns is owner-occupied (HO-3, HO-5, HO-A/B/C), and its ownership question offers only "rent" or "own". A dwelling-fire policy on an investment property has no entry point there. Every landlord quote API that does exist (Steadily, Obie, Honeycomb) is partner-gated, so live rental quotes need an API key I can't apply for on your behalf.

What Texas *does* publish is every rate change a carrier must file before it can charge it — a free unauthenticated Socrata dataset, filed by subtype, with **Dwelling** as the landlord line. That is the more actionable half anyway: a renewal quote arrives as a fait accompli, while a filing is public months ahead.

So this reports what's coming rather than what to switch to.

## What it does

**Insurance → "Check for rate increases"** (lazy — nothing is fetched until you click).

- **Per policy.** Matched to its carrier's dwelling filings that take effect by its renewal, with the projected premium shown as a movement from today's.
- **Across the market.** One row per carrier. The ones holding flat are the shortlist to take to an agent, since a DP-3 is agent-bound.

Your real data, from the live feed:

> **6738 Peerless St · Dwelling DP-3** — Renews Sep 24, 2026
> SafePoint filed an increase
> **$2,410/yr → $2,678/yr** (+11.1%, estimated)
> `SFPT-134523456 · TX DWO · +11.1% · filed May 28, 2026 · Approved`

That filing is effective Sep 1 and your renewal is Sep 24, so it lands on this policy.

## Three correctness findings, all from running against the live feed

**Only a filing that closed as `Reviewed` is in force.** 63 of the 704 dwelling filings were withdrawn or rejected and will never be charged. They still render, labelled *Not approved*, because as a bare percentage they're indistinguishable from one that took effect — SafePoint's withdrawn +24% is a bigger number than its approved +11.1%.

**Carrier matching is one-directional containment.** "State Farm Lloyds" and "STATE NATIONAL INSURANCE COMPANY" both reduce to a set containing `STATE` once corporate boilerplate is stripped, and a two-way subset test attributed State National's filings to a State Farm policy. Matching now requires *your* words to be the ones present. That misses some real matches, and those surface as "No dwelling-line filings found under this carrier's name" rather than as silence that reads like all-clear. Your Benchmark/Swyfft policy lands there — Swyfft files under a fronting carrier TDI publishes under a different name.

**Filings compound within one rate program only.** Foremost files four dwelling programs at once (Landlord, Owner Occupied, Vacant, Condominium); multiplying them together produced a change no single policy is charged.

## Outage behaviour

A TDI outage degrades rather than fails, the way the utility offer search does — the policies still list, each carrying the reason. Rendering "no increases filed" when the truth is "nothing was checked" is the one outcome this must never produce.

## Verification

- Backend 123 passed (66 new across 4 files), frontend 49 passed, `tsc --noEmit` and eslint clean.
- Layout E2E `e2e/insurance-rate-watch.spec.ts` — 4 passed, added to the CI spec list.
- **Real path**: real backend, real dev DB, live TDI feed, real browser. Caught a fourth defect no mocked test would have — two policies on one property rendered identical card headings; cards now read `property · policy`. Test data removed afterwards (0 policy rows, 0 `TMP %` properties).

No migration. No new env var. No operational migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeNqUHKsZEa3imipsgb2AN
