### PR TITLE
fix(mbk): give the rate-watch section a verdict instead of a filing table

### DIFF
--- a/apps/mybookkeeper/backend/app/core/tdi_rate_filings_constants.py
+++ b/apps/mybookkeeper/backend/app/core/tdi_rate_filings_constants.py
@@ -77,17 +77,63 @@ MIN_NOTABLE_CHANGE_PCT = 1.0
 # out keeps those policies in the outlook instead of silently dropping them.
 RENEWAL_HORIZON_DAYS = 120
 
-# Cap on carriers shown in the market view. One row per carrier, most recently
-# filed first, so this is "the N carriers who last moved their dwelling rates".
+# Cap on carriers shown in the market view. One row per carrier, soonest
+# effective first, so this is "the N carriers whose next dwelling rate lands
+# earliest". Each of the two groups below is capped separately.
 MAX_MARKET_FILINGS = 25
+
+# How many rows of each market group are shown before the operator has to
+# expand. Twenty undifferentiated rows is what the first cut shipped, and it
+# read as a wall rather than a shortlist.
+MARKET_GROUP_PREVIEW = 5
+
+# --- Who the operator can actually buy from -----------------------------------
+#
+# These file dwelling rates with TDI and so appear in the raw feed, but none of
+# them is a carrier an ordinary landlord can place a policy with. Listing them
+# under "worth asking your agent about" is not merely noise — it is wrong, and
+# it sends the operator to ask for something that cannot be sold to them.
+#
+# Matched on a token-subset basis (same helper as carrier matching) so that
+# legal-name drift — "TEXAS WINDSTORM INSURANCE ASSN" vs "...ASSOCIATION" —
+# does not quietly let one back in.
+
+NON_PURCHASABLE_CARRIERS: tuple[str, ...] = (
+    # State-run residual market, sold only where no admitted carrier will write.
+    "TEXAS WINDSTORM INSURANCE ASSOCIATION",
+    # The FAIR Plan: last-resort pool, eligibility requires prior declinations.
+    "TEXAS FAIR PLAN ASSOCIATION",
+    # An advisory rating bureau. Licenses loss-cost data to insurers; sells no
+    # policies to anyone.
+    "INSURANCE SERVICES OFFICE",
+    # Membership limited to military personnel and their families.
+    "ARMED FORCES INSURANCE EXCHANGE",
+    # Files on behalf of member insurers; not itself a market.
+    "AMERICAN ASSOCIATION OF INSURANCE SERVICES",
+)
 
 # --- Why an outlook could not be produced -------------------------------------
 #
 # Shown to the operator instead of an empty filing list, so "we could not check"
-# never reads as "nothing is coming".
+# never reads as "nothing is coming". These are three genuinely different
+# situations and collapsing them into one string is what made the first cut
+# claim it had searched for a homeowners policy it never looked at.
 
-REASON_NO_CARRIER = "No carrier recorded on this policy."
-REASON_NO_FILINGS = "No dwelling-line filings found under this carrier's name."
+REASON_NO_CARRIER = "No carrier recorded on this policy — add one to check it."
+
+REASON_NO_FILINGS = (
+    "No landlord-policy rate filing found under this carrier's name in the "
+    "last two years. Either they have not filed one, or the name on this "
+    "policy does not match how they file with the state."
+)
+
+# Not a failure to find anything — this dataset was never going to apply.
+# Saying "no filings found" here implies a search happened, and none did.
+REASON_NOT_DWELLING = (
+    "Texas publishes rate filings for landlord (dwelling-fire) policies only, "
+    "so there is nothing to check against a homeowners policy."
+)
+
 REASON_FEED_DOWN = (
     "The Texas Department of Insurance filing data could not be reached, so "
     "nothing was checked."

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_market_watch_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_market_watch_response.py
@@ -12,13 +12,22 @@ from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
 class InsuranceMarketWatchResponse(BaseModel):
     # One entry per active policy, whether or not a filing was matched.
     outlooks: list[InsurancePolicyRateOutlook] = []
-    # Recent dwelling-line filings across the whole Texas market, regardless of
-    # whether the operator holds a policy with the carrier. This is the
-    # shortlist to take to an agent: a DP-3 is agent-bound, so "who is holding
-    # rates flat" is the actionable output.
-    market_filings: list[InsuranceRateFiling] = []
+    # The market, split rather than pooled. A single ranked list left the
+    # operator to sort twenty carriers by hand to find the two useful groups;
+    # these are the two groups. Both cover the whole Texas dwelling line
+    # regardless of who the operator is insured with, because a DP-3 is
+    # agent-bound and the point is knowing which names to raise.
+    #
+    # Carriers whose next dwelling rate goes up — who not to move to.
+    market_rising: list[InsuranceRateFiling] = []
+    # Carriers holding flat or cutting — the shortlist worth an agent call.
+    market_flat: list[InsuranceRateFiling] = []
     # True when any policy has an in-force filing landing before its renewal.
     has_any_increase: bool = False
+    # Policies actually checked against the feed — excludes those on a form the
+    # dwelling line does not cover. "No increases across your 2 policies" has to
+    # count the ones that were looked at, or it overstates the all-clear.
+    checked_policy_count: int = 0
     # Set when TDI could not be reached. The policies still list, each carrying
     # the same explanation, because a silent empty result would read as "no
     # increases filed" when the truth is "nothing was checked".

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_rate_outlook.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_rate_outlook.py
@@ -12,8 +12,17 @@ from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
 class InsurancePolicyRateOutlook(BaseModel):
     policy_id: uuid.UUID
     policy_name: str
+    # ``policy_name`` with the property address removed, for a card heading that
+    # already names the property. A declarations-page reader fills the name with
+    # the whole descriptor off the page, address included.
+    policy_label: str
     property_name: str | None = None
     carrier: str | None = None
+    # False when this policy is written on a form the dwelling feed does not
+    # cover (a homeowners policy). The distinction matters: "we searched and
+    # found nothing" and "this was never in scope" are different statements, and
+    # the first cut made only the former.
+    is_checkable: bool = True
     expiration_date: _dt.date | None = None
     current_premium_cents: int | None = None
     # Filings matched to this policy's carrier that take effect on or before

--- a/apps/mybookkeeper/backend/app/services/insurance/_policy_form.py
+++ b/apps/mybookkeeper/backend/app/services/insurance/_policy_form.py
@@ -1,0 +1,115 @@
+"""Read the policy form out of a policy's free-text name.
+
+The TDI feed covers the dwelling-fire line only. A homeowners policy can never
+match it, so telling the operator "no filings found under this carrier's name"
+for an HO-3 is a false statement — it implies a search that never happened.
+Separating the two needs to know which form a policy is written on.
+
+Nothing in the schema records that today: ``policy_name`` is free text the
+operator typed or a declarations-page reader extracted, and the form code lives
+inside it ("Dwelling Fire DP-3, 6738 Peerless St", "Homeowners Policy (HO-3)").
+So this reads it back out.
+
+That is a presentation-layer inference, and it is deliberately not treated as
+authoritative. An unrecognised name resolves to ``UNKNOWN`` and is **checked
+anyway** rather than declared out of scope — a wrong "nothing to check here"
+silently hides a real increase, while a wrong check merely finds nothing. The
+durable fix is a ``policy_type`` column set at entry; it needs a migration, a
+backfill and a field on the policy form, so it is its own change.
+"""
+from __future__ import annotations
+
+import re
+from enum import Enum
+
+
+class PolicyForm(str, Enum):
+    """Which standard form a policy is written on."""
+
+    DWELLING_FIRE = "dwelling_fire"
+    HOMEOWNERS = "homeowners"
+    UNKNOWN = "unknown"
+
+
+# Form codes are the strong signal: DP-1/2/3 are the dwelling-fire series and
+# HO-1..HO-8 the homeowners series. Hyphen optional, since operators type both.
+# The trailing (?!\d) stops "DP-30" being read as DP-3.
+_DWELLING_CODE = re.compile(r"\bDP[-\s]?[1-3](?!\d)", re.IGNORECASE)
+_HOMEOWNERS_CODE = re.compile(r"\bHO[-\s]?[1-8](?!\d)", re.IGNORECASE)
+
+# Weaker fallback for names carrying no form code at all.
+_DWELLING_WORDS = re.compile(r"\b(dwelling|landlord|rental dwelling)\b", re.IGNORECASE)
+_HOMEOWNERS_WORDS = re.compile(r"\bhomeowner'?s?\b", re.IGNORECASE)
+
+
+def policy_form(policy_name: str | None) -> PolicyForm:
+    """Best reading of the form from the policy's name.
+
+    Codes beat words: a name saying "Homeowners Policy (DP-3)" is contradictory,
+    and the code is the part that came off the declarations page.
+    """
+    if not policy_name:
+        return PolicyForm.UNKNOWN
+
+    if _DWELLING_CODE.search(policy_name):
+        return PolicyForm.DWELLING_FIRE
+    if _HOMEOWNERS_CODE.search(policy_name):
+        return PolicyForm.HOMEOWNERS
+
+    has_dwelling_word = bool(_DWELLING_WORDS.search(policy_name))
+    has_homeowners_word = bool(_HOMEOWNERS_WORDS.search(policy_name))
+    # Both words present and no code to break the tie: not confident enough to
+    # rule the policy out, so let it be checked.
+    if has_dwelling_word and not has_homeowners_word:
+        return PolicyForm.DWELLING_FIRE
+    if has_homeowners_word and not has_dwelling_word:
+        return PolicyForm.HOMEOWNERS
+
+    return PolicyForm.UNKNOWN
+
+
+def is_out_of_scope(form: PolicyForm) -> bool:
+    """Whether the dwelling feed could never say anything about this policy.
+
+    Only a confident homeowners reading is out of scope. ``UNKNOWN`` is checked,
+    because a missed increase is the costlier error.
+    """
+    return form is PolicyForm.HOMEOWNERS
+
+
+def strip_property_from_name(
+    policy_name: str, property_name: str | None,
+) -> str:
+    """The policy name with the property address removed.
+
+    A declarations-page reader fills ``policy_name`` with the whole descriptor
+    off the page — "Dwelling Fire DP-3, 6738 Peerless St, Houston, TX 77021" —
+    and the card heading already names the property, so rendering both prints
+    the address twice in one line.
+    """
+    if not property_name:
+        return policy_name
+
+    # Matched as a token sequence rather than as a literal substring. The two
+    # fields come from different places — the property record and whatever a
+    # declarations-page reader pulled off the PDF — so they disagree on
+    # punctuation constantly ("Peerless St," vs "Peerless St."). Comparing
+    # token-by-token with a permissive separator absorbs that; comparing
+    # normalised strings by index does not, and mis-slices the moment the two
+    # differ in length.
+    tokens = re.findall(r"[A-Za-z0-9]+", property_name)
+    if not tokens:
+        return policy_name
+
+    pattern = re.compile(
+        r"\b" + r"[\s,.]+".join(re.escape(token) for token in tokens) + r"\b",
+        re.IGNORECASE,
+    )
+    match = pattern.search(policy_name)
+    if match is None:
+        return policy_name
+
+    before = policy_name[: match.start()].strip(" ,-–—")
+    after = policy_name[match.end() :].strip(" ,-–—")
+    combined = " ".join(part for part in (before, after) if part).strip(" ,-–—")
+    return combined or policy_name

--- a/apps/mybookkeeper/backend/app/services/insurance/insurance_market_watch_service.py
+++ b/apps/mybookkeeper/backend/app/services/insurance/insurance_market_watch_service.py
@@ -19,8 +19,10 @@ import uuid
 from app.core.tdi_rate_filings_constants import (
     MAX_MARKET_FILINGS,
     MIN_NOTABLE_CHANGE_PCT,
+    NON_PURCHASABLE_CARRIERS,
     REASON_FEED_DOWN,
     REASON_NO_CARRIER,
+    REASON_NOT_DWELLING,
     REASON_NO_FILINGS,
     RENEWAL_HORIZON_DAYS,
 )
@@ -36,10 +38,16 @@ from app.schemas.insurance.insurance_policy_rate_outlook import (
 from app.schemas.insurance.insurance_rate_filing import InsuranceRateFiling
 from app.services.insurance._carrier_filing_match import (
     applies_by,
+    carrier_tokens,
     compound_change_pct,
     is_recent,
     matches_carrier,
     project_premium_cents,
+)
+from app.services.insurance._policy_form import (
+    is_out_of_scope,
+    policy_form,
+    strip_property_from_name,
 )
 from app.services.insurance.premium_math import annual_premium_cents
 from app.services.insurance.tdi_rate_filings_client import (
@@ -87,13 +95,22 @@ def _build_outlook(
     filings: list[InsuranceRateFiling],
     today: _dt.date,
 ) -> InsurancePolicyRateOutlook:
+    checkable = not is_out_of_scope(policy_form(row.policy_name))
+
     renewal = _renewal_date(row.expiration_date, today=today)
-    matched = _filings_for_policy(
-        row.carrier, filings, renewal=renewal, today=today,
+    matched = (
+        _filings_for_policy(row.carrier, filings, renewal=renewal, today=today)
+        if checkable
+        else []
     )
 
+    # Ordered by what is true, not by what is missing. A homeowners policy is
+    # not a carrier-matching failure, and saying so first stops the card
+    # claiming a search it never ran.
     unavailable_reason: str | None = None
-    if not row.carrier:
+    if not checkable:
+        unavailable_reason = REASON_NOT_DWELLING
+    elif not row.carrier:
         unavailable_reason = REASON_NO_CARRIER
     elif not matched:
         unavailable_reason = REASON_NO_FILINGS
@@ -106,8 +123,10 @@ def _build_outlook(
     return InsurancePolicyRateOutlook(
         policy_id=row.id,
         policy_name=row.policy_name,
+        policy_label=strip_property_from_name(row.policy_name, property_name),
         property_name=property_name,
         carrier=row.carrier,
+        is_checkable=checkable,
         expiration_date=row.expiration_date,
         current_premium_cents=annual,
         filings=matched,
@@ -117,21 +136,86 @@ def _build_outlook(
     )
 
 
+def _is_purchasable(company_name: str) -> bool:
+    """Whether an ordinary landlord could actually place a policy here.
+
+    Residual-market pools, advisory rating bureaus and eligibility-restricted
+    exchanges all file dwelling rates and so appear in the feed. Listing them
+    under "worth asking your agent about" sends the operator to ask for
+    something nobody can sell them.
+    """
+    tokens = carrier_tokens(company_name)
+    if not tokens:
+        return True
+    return not any(
+        carrier_tokens(excluded) <= tokens for excluded in NON_PURCHASABLE_CARRIERS
+    )
+
+
+def _still_ahead(filing: InsuranceRateFiling, *, today: _dt.date) -> bool:
+    """Whether this filing's increase is still to come.
+
+    ``is_recent`` bounds when a filing was *submitted*; this bounds when it
+    takes *effect*. An increase that landed eighteen months ago is already
+    inside what a carrier quotes today, so it is not a warning to shop early.
+    A filing with no recorded renewal date is kept, matching ``applies_by``.
+
+    Only meaningful for an increase. A carrier that filed *no change* said
+    nothing that expires, so this is not applied to the flat list — doing so
+    dropped six of the seven names off the shortlist against live TDI data.
+    """
+    return (
+        filing.effective_date_renewal is None
+        or filing.effective_date_renewal >= today
+    )
+
+
+def _by_effective_date(
+    filings: list[InsuranceRateFiling], *, newest_first: bool,
+) -> list[InsuranceRateFiling]:
+    """Ordered on the date the row actually displays.
+
+    The first cut sorted on ``filed_date`` and rendered
+    ``effective_date_renewal``, which made a correctly ordered list look
+    shuffled. Undated filings sort last either way — there is no date to plan
+    around, so they are the weakest row in either group.
+    """
+
+    dated = sorted(
+        (f for f in filings if f.effective_date_renewal is not None),
+        key=lambda f: f.effective_date_renewal or _dt.date.min,
+        reverse=newest_first,
+    )
+    undated = sorted(
+        (f for f in filings if f.effective_date_renewal is None),
+        key=lambda f: f.company_name,
+    )
+    return dated + undated
+
+
 def _market_view(
     filings: list[InsuranceRateFiling], *, today: _dt.date,
-) -> list[InsuranceRateFiling]:
-    """One row per carrier — their latest dwelling filing, newest first.
+) -> tuple[list[InsuranceRateFiling], list[InsuranceRateFiling]]:
+    """The dwelling market as two lists: carriers rising, carriers holding.
 
-    Deduped by company because a carrier files several programs a year and the
-    repeats would crowd out every other carrier in the list. Pending filings
-    are kept: a proposed increase is exactly the signal that makes an operator
-    shop early, and the schema flags it as proposed rather than in force.
+    One row per carrier — a carrier files several programs a year and the
+    repeats would crowd out every other name. Pending filings are kept: a
+    proposed increase is exactly the signal that makes an operator shop early,
+    and the schema flags it as proposed rather than in force.
+
+    The two lists answer different questions, so they are filtered and ordered
+    differently. "Raising" is a warning, so it carries only increases that have
+    not reached renewals yet, soonest first. "Holding flat" is a shortlist to
+    raise on a call with an agent, so it carries every carrier whose most
+    recent filing was no change, most recently confirmed first.
     """
     latest: dict[str, InsuranceRateFiling] = {}
     for filing in filings:
         if not is_recent(filing, today=today):
             continue
         if not (filing.is_in_force or filing.is_pending):
+            continue
+        if not _is_purchasable(filing.company_name):
             continue
         key = filing.company_name.upper()
         existing = latest.get(key)
@@ -140,12 +224,24 @@ def _market_view(
         ):
             latest[key] = filing
 
-    ordered = sorted(
-        latest.values(),
-        key=lambda f: f.filed_date or _dt.date.min,
-        reverse=True,
+    # A null percentage is not a flat rate — the carrier filed without stating
+    # one — so it belongs in neither group and is dropped from the market view.
+    rising = [
+        f
+        for f in latest.values()
+        if f.percent_change is not None
+        and f.percent_change > 0
+        and _still_ahead(f, today=today)
+    ]
+    flat = [
+        f
+        for f in latest.values()
+        if f.percent_change is not None and f.percent_change <= 0
+    ]
+    return (
+        _by_effective_date(rising, newest_first=False)[:MAX_MARKET_FILINGS],
+        _by_effective_date(flat, newest_first=True)[:MAX_MARKET_FILINGS],
     )
-    return ordered[:MAX_MARKET_FILINGS]
 
 
 def _is_expired(expiration_date: _dt.date | None, today: _dt.date) -> bool:
@@ -198,20 +294,35 @@ async def get_market_watch(
 
     if feed_unavailable_reason is not None:
         for outlook in outlooks:
-            outlook.unavailable_reason = feed_unavailable_reason
+            # An out-of-scope policy keeps its own reason. The feed being down
+            # changes nothing for a homeowners policy that the dwelling line
+            # would not have covered either way.
+            if outlook.is_checkable:
+                outlook.unavailable_reason = feed_unavailable_reason
 
     # Soonest renewal first — the policy the operator can still do something
     # about reads before the one that renews in eleven months. Policies with no
     # recorded expiration sort last rather than being treated as overdue.
     outlooks.sort(key=lambda o: o.expiration_date or _dt.date.max)
 
+    rising, flat = _market_view(filings, today=reference)
+
     return InsuranceMarketWatchResponse(
         outlooks=outlooks,
-        market_filings=_market_view(filings, today=reference),
+        market_rising=rising,
+        market_flat=flat,
         has_any_increase=any(
             outlook.projected_change_pct is not None
             and outlook.projected_change_pct >= MIN_NOTABLE_CHANGE_PCT
             for outlook in outlooks
+        ),
+        # Counted from what was actually looked at. A homeowners policy was
+        # never checked, so folding it into "no increases across 3 policies"
+        # would claim reassurance the data does not support.
+        checked_policy_count=sum(
+            1
+            for outlook in outlooks
+            if outlook.is_checkable and feed_unavailable_reason is None
         ),
         feed_unavailable_reason=feed_unavailable_reason,
     )

--- a/apps/mybookkeeper/backend/tests/test_insurance_market_api.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_market_api.py
@@ -62,7 +62,8 @@ def _response(**overrides) -> InsuranceMarketWatchResponse:
         "outlooks": [
             InsurancePolicyRateOutlook(
                 policy_id=POLICY_ID,
-                policy_name="Dwelling DP-3",
+                policy_name="Dwelling DP-3, 6738 Peerless St",
+                policy_label="Dwelling DP-3",
                 property_name="6738 Peerless St",
                 carrier="SafePoint",
                 expiration_date=_dt.date(2026, 9, 24),
@@ -72,8 +73,10 @@ def _response(**overrides) -> InsuranceMarketWatchResponse:
                 projected_premium_cents=267_751,
             ),
         ],
-        "market_filings": [filing],
+        "market_rising": [filing],
+        "market_flat": [],
         "has_any_increase": True,
+        "checked_policy_count": 1,
     }
     base.update(overrides)
     return InsuranceMarketWatchResponse(**base)
@@ -87,7 +90,10 @@ def test_returns_the_rate_watch(client):
     body = response.json()
     assert body["has_any_increase"] is True
     assert body["outlooks"][0]["projected_premium_cents"] == 267_751
-    assert body["market_filings"][0]["company_name"] == "SAFEPOINT INSURANCE COMPANY"
+    assert body["outlooks"][0]["policy_label"] == "Dwelling DP-3"
+    assert body["market_rising"][0]["company_name"] == "SAFEPOINT INSURANCE COMPANY"
+    assert body["market_flat"] == []
+    assert body["checked_policy_count"] == 1
     assert body["feed_unavailable_reason"] is None
 
 
@@ -103,8 +109,10 @@ def test_scopes_the_read_to_the_caller_organization(client):
 def test_a_feed_outage_still_returns_the_policies_with_a_reason(client):
     degraded = _response(
         outlooks=[],
-        market_filings=[],
+        market_rising=[],
+        market_flat=[],
         has_any_increase=False,
+        checked_policy_count=0,
         feed_unavailable_reason=REASON_FEED_DOWN,
     )
     with patch(f"{_SERVICE}.get_market_watch", AsyncMock(return_value=degraded)):

--- a/apps/mybookkeeper/backend/tests/test_insurance_market_watch_service.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_market_watch_service.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.tdi_rate_filings_constants import (
     MAX_MARKET_FILINGS,
     REASON_FEED_DOWN,
+    REASON_NOT_DWELLING,
     REASON_NO_CARRIER,
     REASON_NO_FILINGS,
 )
@@ -289,7 +290,7 @@ class TestPolicyOutlook:
 
 
 class TestMarketView:
-    async def test_shows_one_row_per_carrier_newest_first(
+    async def test_shows_one_row_per_carrier(
         self, db: AsyncSession, test_user: User, test_org: Organization,
     ) -> None:
         """A carrier files several programs a year; repeats crowd out the rest."""
@@ -306,9 +307,68 @@ class TestMarketView:
 
         result = await _watch(db, test_org, test_user, filings)
 
-        assert [(f.company_name, f.filed_date) for f in result.market_filings] == [
-            ("FOREMOST LLOYDS OF TEXAS", _dt.date(2026, 7, 24)),
-            ("SAFEPOINT INSURANCE COMPANY", _dt.date(2026, 5, 28)),
+        assert [f.company_name for f in result.market_rising] == [
+            "SAFEPOINT INSURANCE COMPANY",
+        ]
+        assert [f.company_name for f in result.market_flat] == [
+            "FOREMOST LLOYDS OF TEXAS",
+        ]
+        # The newest of SafePoint's two, not the first one seen.
+        assert result.market_rising[0].filed_date == _dt.date(2026, 5, 28)
+
+    async def test_rising_reads_soonest_first(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Sorting on filed_date while displaying the effective date read as
+        shuffled — the list looked unordered to the operator reading it."""
+        filings = [
+            _filing(
+                company="LATE CARRIER",
+                filed=_dt.date(2026, 7, 1),
+                renewal=_dt.date(2026, 12, 1),
+            ),
+            _filing(
+                company="EARLY CARRIER",
+                filed=_dt.date(2026, 1, 5),
+                renewal=_dt.date(2026, 9, 1),
+            ),
+            _filing(company="UNDATED CARRIER", filed=_dt.date(2026, 6, 1), renewal=None),
+        ]
+
+        result = await _watch(db, test_org, test_user, filings)
+
+        assert [f.company_name for f in result.market_rising] == [
+            "EARLY CARRIER",
+            "LATE CARRIER",
+            # No date to plan around, so it sorts last rather than first.
+            "UNDATED CARRIER",
+        ]
+
+    async def test_flat_reads_most_recently_confirmed_first(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """A different question, so a different order: the shortlist to call
+        leads with the carrier that confirmed no change most recently."""
+        filings = [
+            _filing(
+                company="OLD FLAT CARRIER",
+                pct=0.0,
+                filed=_dt.date(2026, 1, 5),
+                renewal=_dt.date(2026, 2, 1),
+            ),
+            _filing(
+                company="RECENT FLAT CARRIER",
+                pct=0.0,
+                filed=_dt.date(2026, 7, 1),
+                renewal=_dt.date(2026, 8, 1),
+            ),
+        ]
+
+        result = await _watch(db, test_org, test_user, filings)
+
+        assert [f.company_name for f in result.market_flat] == [
+            "RECENT FLAT CARRIER",
+            "OLD FLAT CARRIER",
         ]
 
     async def test_keeps_a_carrier_holding_rates_flat(
@@ -319,7 +379,19 @@ class TestMarketView:
             db, test_org, test_user, [_filing(company="FLAT CARRIER", pct=0.0)],
         )
 
-        assert [f.percent_change for f in result.market_filings] == [0.0]
+        assert [f.percent_change for f in result.market_flat] == [0.0]
+        assert result.market_rising == []
+
+    async def test_drops_a_filing_that_states_no_percentage(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """No stated change is not a flat rate — it belongs in neither list."""
+        result = await _watch(
+            db, test_org, test_user, [_filing(company="SILENT CARRIER", pct=None)],
+        )
+
+        assert result.market_rising == []
+        assert result.market_flat == []
 
     async def test_keeps_pending_filings_flagged_as_proposed(
         self, db: AsyncSession, test_user: User, test_org: Organization,
@@ -328,9 +400,9 @@ class TestMarketView:
             db, test_org, test_user, [_filing(in_force=False, pending=True)],
         )
 
-        assert len(result.market_filings) == 1
-        assert result.market_filings[0].is_pending is True
-        assert result.market_filings[0].is_in_force is False
+        assert len(result.market_rising) == 1
+        assert result.market_rising[0].is_pending is True
+        assert result.market_rising[0].is_in_force is False
 
     async def test_drops_a_withdrawn_filing(
         self, db: AsyncSession, test_user: User, test_org: Organization,
@@ -340,7 +412,8 @@ class TestMarketView:
             db, test_org, test_user, [_filing(in_force=False, pending=False)],
         )
 
-        assert result.market_filings == []
+        assert result.market_rising == []
+        assert result.market_flat == []
 
     async def test_drops_a_stale_filing(
         self, db: AsyncSession, test_user: User, test_org: Organization,
@@ -349,19 +422,140 @@ class TestMarketView:
             db, test_org, test_user, [_filing(filed=_dt.date(2017, 5, 1))],
         )
 
-        assert result.market_filings == []
+        assert result.market_rising == []
 
-    async def test_caps_the_market_list(
+    async def test_drops_an_increase_that_already_took_effect(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Filed recently but effective a year ago: it is already inside what
+        the carrier quotes today, so it is not a warning to shop early."""
+        result = await _watch(
+            db,
+            test_org,
+            test_user,
+            [_filing(filed=_dt.date(2025, 9, 1), renewal=_dt.date(2025, 10, 1))],
+        )
+
+        assert result.market_rising == []
+
+    async def test_keeps_a_flat_filing_that_already_took_effect(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The bug the live feed exposed: applying the still-ahead rule to the
+        flat list dropped six of its seven names. A carrier that filed *no
+        change* said nothing that expires — it is still the shortlist to call.
+        """
+        result = await _watch(
+            db,
+            test_org,
+            test_user,
+            [
+                _filing(
+                    company="AMICA MUTUAL INSURANCE COMPANY",
+                    pct=0.0,
+                    filed=_dt.date(2025, 11, 3),
+                    renewal=_dt.date(2026, 1, 1),
+                ),
+            ],
+        )
+
+        assert [f.company_name for f in result.market_flat] == [
+            "AMICA MUTUAL INSURANCE COMPANY",
+        ]
+
+    async def test_drops_carriers_an_operator_cannot_buy_from(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The residual pool and the advisory bureau both file dwelling rates.
+        Listing them sends the operator to ask for something nobody sells."""
+        filings = [
+            _filing(company="TEXAS WINDSTORM INSURANCE ASSOCIATION"),
+            _filing(company="INSURANCE SERVICES OFFICE INC"),
+            _filing(company="ARMED FORCES INSURANCE EXCHANGE"),
+            _filing(company="SAFEPOINT INSURANCE COMPANY"),
+        ]
+
+        result = await _watch(db, test_org, test_user, filings)
+
+        assert [f.company_name for f in result.market_rising] == [
+            "SAFEPOINT INSURANCE COMPANY",
+        ]
+
+    async def test_caps_each_market_list(
         self, db: AsyncSession, test_user: User, test_org: Organization,
     ) -> None:
         filings = [
-            _filing(company=f"CARRIER {index} GROUP", filed=_dt.date(2026, 6, 1))
+            _filing(company=f"RISING {index} GROUP", filed=_dt.date(2026, 6, 1))
+            for index in range(MAX_MARKET_FILINGS + 10)
+        ] + [
+            _filing(company=f"FLAT {index} GROUP", pct=0.0, filed=_dt.date(2026, 6, 1))
             for index in range(MAX_MARKET_FILINGS + 10)
         ]
 
         result = await _watch(db, test_org, test_user, filings)
 
-        assert len(result.market_filings) == MAX_MARKET_FILINGS
+        assert len(result.market_rising) == MAX_MARKET_FILINGS
+        assert len(result.market_flat) == MAX_MARKET_FILINGS
+
+
+class TestOutOfScopePolicies:
+    async def test_a_homeowners_policy_is_not_a_matching_failure(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The dwelling feed could never have matched an HO-3. Saying "no
+        filings found under this carrier" asserts a search that never ran."""
+        prop = await _make_property(db, test_org.id, test_user.id, "6734 Peerless St")
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            property_id=prop.id,
+            policy_name="Homeowners Policy (HO-3), 6734 Peerless St",
+        )
+
+        result = await _watch(db, test_org, test_user, [_filing()])
+
+        assert result.outlooks[0].is_checkable is False
+        assert result.outlooks[0].unavailable_reason == REASON_NOT_DWELLING
+        assert result.outlooks[0].filings == []
+        assert result.checked_policy_count == 0
+
+    async def test_the_card_heading_does_not_repeat_the_address(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """A dec-page reader fills policy_name with the whole descriptor; the
+        heading already names the property."""
+        prop = await _make_property(db, test_org.id, test_user.id, "6738 Peerless St")
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            property_id=prop.id,
+            policy_name="Dwelling Fire DP-3, 6738 Peerless St",
+        )
+
+        result = await _watch(db, test_org, test_user, [_filing()])
+
+        assert result.outlooks[0].policy_label == "Dwelling Fire DP-3"
+
+    async def test_counts_only_the_policies_actually_checked(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """"No increases across 3 policies" must not include one never looked at."""
+        prop = await _make_property(db, test_org.id, test_user.id, "6738 Peerless St")
+        for name in ["Dwelling Fire DP-3", "Homeowners Policy HO-3"]:
+            await _make_policy(
+                db,
+                org_id=test_org.id,
+                user_id=test_user.id,
+                property_id=prop.id,
+                policy_name=name,
+            )
+
+        result = await _watch(db, test_org, test_user, [_filing()])
+
+        assert len(result.outlooks) == 2
+        assert result.checked_policy_count == 1
 
 
 class TestFeedOutage:
@@ -379,5 +573,26 @@ class TestFeedOutage:
         assert result.feed_unavailable_reason == REASON_FEED_DOWN
         assert result.outlooks[0].unavailable_reason == REASON_FEED_DOWN
         assert result.outlooks[0].projected_change_pct is None
-        assert result.market_filings == []
+        assert result.market_rising == []
+        assert result.market_flat == []
         assert result.has_any_increase is False
+        # Nothing was checked, so the frontend has nothing to give a verdict on.
+        assert result.checked_policy_count == 0
+
+    async def test_an_out_of_scope_policy_keeps_its_own_reason(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The feed being down changes nothing for a policy the dwelling line
+        would not have covered either way."""
+        prop = await _make_property(db, test_org.id, test_user.id, "6734 Peerless St")
+        await _make_policy(
+            db,
+            org_id=test_org.id,
+            user_id=test_user.id,
+            property_id=prop.id,
+            policy_name="Homeowners Policy (HO-3)",
+        )
+
+        result = await _watch(db, test_org, test_user, _failing_fetch())
+
+        assert result.outlooks[0].unavailable_reason == REASON_NOT_DWELLING

--- a/apps/mybookkeeper/backend/tests/test_insurance_policy_form.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_policy_form.py
@@ -1,0 +1,105 @@
+"""The dwelling feed covers one policy form. Knowing which is which matters.
+
+Telling an operator "no filings found under this carrier's name" about a
+homeowners policy asserts a search that never happened — the dwelling dataset
+could not have matched it under any carrier. These pin the reading, and pin the
+deliberate bias: an unrecognised name is checked rather than ruled out, because
+a missed increase costs more than a fruitless lookup.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.insurance._policy_form import (
+    PolicyForm,
+    is_out_of_scope,
+    policy_form,
+    strip_property_from_name,
+)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Dwelling Fire DP-3, 6738 Peerless St, Houston, TX 77021",
+        "DP-1 Basic Form",
+        "dp 2 landlord",
+        "Landlord dwelling policy",
+    ],
+)
+def test_reads_the_dwelling_forms(name: str) -> None:
+    assert policy_form(name) is PolicyForm.DWELLING_FIRE
+    assert is_out_of_scope(policy_form(name)) is False
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Homeowners Policy (HO-3) – 6734 Peerless St, Houston, TX 77021",
+        "HO-5 Comprehensive",
+        "ho8 modified coverage",
+        "Homeowner's policy",
+    ],
+)
+def test_reads_the_homeowners_forms(name: str) -> None:
+    assert policy_form(name) is PolicyForm.HOMEOWNERS
+    assert is_out_of_scope(policy_form(name)) is True
+
+
+def test_form_code_beats_the_word() -> None:
+    # Contradictory name; the code is the part that came off the dec page.
+    assert policy_form("Homeowners Program DP-3") is PolicyForm.DWELLING_FIRE
+
+
+def test_dp30_is_not_read_as_dp3() -> None:
+    assert policy_form("Program DP-30") is PolicyForm.UNKNOWN
+
+
+@pytest.mark.parametrize("name", ["", None, "Umbrella", "Flood policy"])
+def test_unrecognised_names_are_checked_not_excluded(name: str | None) -> None:
+    # The bias that matters: unknown is checked. Wrongly declaring a policy out
+    # of scope hides a real increase; wrongly checking one merely finds nothing.
+    form = policy_form(name)
+    assert form is PolicyForm.UNKNOWN
+    assert is_out_of_scope(form) is False
+
+
+def test_both_words_and_no_code_stays_unknown() -> None:
+    assert policy_form("Homeowners and dwelling package") is PolicyForm.UNKNOWN
+
+
+class TestStripPropertyFromName:
+    def test_removes_the_address_the_heading_already_shows(self) -> None:
+        assert (
+            strip_property_from_name(
+                "Dwelling Fire DP-3, 6738 Peerless St, Houston, TX 77021",
+                "6738 Peerless St, Houston, TX 77021",
+            )
+            == "Dwelling Fire DP-3"
+        )
+
+    def test_slices_the_original_not_the_normalised_string(self) -> None:
+        # The bug this pins: normalising by DELETING punctuation shifts every
+        # index past the first comma, so the slice cuts in the wrong place.
+        assert (
+            strip_property_from_name(
+                "Dwelling Fire DP-3, 6738 Peerless St., Houston, TX 77021, renewal",
+                "6738 Peerless St, Houston, TX 77021",
+            )
+            == "Dwelling Fire DP-3 renewal"
+        )
+
+    def test_leaves_a_name_that_does_not_contain_the_address(self) -> None:
+        assert (
+            strip_property_from_name("Dwelling Fire DP-3", "6738 Peerless St")
+            == "Dwelling Fire DP-3"
+        )
+
+    def test_keeps_the_name_when_stripping_would_empty_it(self) -> None:
+        assert (
+            strip_property_from_name("6738 Peerless St", "6738 Peerless St")
+            == "6738 Peerless St"
+        )
+
+    def test_no_property_name_is_a_no_op(self) -> None:
+        assert strip_property_from_name("Dwelling DP-3", None) == "Dwelling DP-3"

--- a/apps/mybookkeeper/frontend/e2e/insurance-rate-watch.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/insurance-rate-watch.spec.ts
@@ -15,19 +15,23 @@
  *
  * Verifies:
  *   - Loading the page does not call the department; only a click does.
+ *   - The verdict leads, in dollars per year, above any evidence.
  *   - Skeleton card/row counts mirror the loaded section (no layout shift).
  *   - The projected renewal reads as a movement from today's premium, marked
  *     as an estimate.
  *   - A carrier with no filings says so instead of rendering as "all clear".
+ *   - A policy the feed never covered is a footnote, not a card.
+ *   - Carriers holding rates flat are separated from carriers raising them.
  *   - A withdrawn filing is labelled "Not approved".
  *   - No horizontal scroll across mobile / tablet / desktop; 44px touch target.
- *   - A feed outage renders the reason rather than an empty section.
+ *   - A feed outage renders the reason and offers no verdict at all.
  */
 import { test, expect, type Page } from "@playwright/test";
 
 const ORG_ID = "00000000-0000-0000-0000-000000000010";
 const POLICY_ID = "00000000-0000-0000-0000-0000000000d1";
 const UNMATCHED_POLICY_ID = "00000000-0000-0000-0000-0000000000d2";
+const OUT_OF_SCOPE_POLICY_ID = "00000000-0000-0000-0000-0000000000d3";
 
 /** Matches ``RateWatchSkeleton``: two policy cards, two filing rows each. */
 const SKELETON_CARD_COUNT = 2;
@@ -154,9 +158,11 @@ const RATE_WATCH_RESPONSE = {
   outlooks: [
     {
       policy_id: POLICY_ID,
-      policy_name: "Dwelling DP-3",
+      policy_name: "Dwelling DP-3, E2E Peerless",
+      policy_label: "Dwelling DP-3",
       property_name: "E2E Peerless",
       carrier: "SafePoint",
+      is_checkable: true,
       expiration_date: "2026-09-24",
       current_premium_cents: 241_000,
       filings: [APPROVED_FILING, WITHDRAWN_FILING],
@@ -167,8 +173,10 @@ const RATE_WATCH_RESPONSE = {
     {
       policy_id: UNMATCHED_POLICY_ID,
       policy_name: "Dwelling DP-3",
+      policy_label: "Dwelling DP-3",
       property_name: "E2E Second Peerless",
       carrier: "Benchmark/Swyfft",
+      is_checkable: true,
       expiration_date: "2027-02-01",
       current_premium_cents: 180_000,
       filings: [],
@@ -176,9 +184,26 @@ const RATE_WATCH_RESPONSE = {
       projected_premium_cents: null,
       unavailable_reason: "No dwelling-line filings found under this carrier's name.",
     },
+    {
+      policy_id: OUT_OF_SCOPE_POLICY_ID,
+      policy_name: "Homeowners Policy (HO-3), E2E Home",
+      policy_label: "Homeowners Policy (HO-3)",
+      property_name: "E2E Home",
+      carrier: "State Farm",
+      is_checkable: false,
+      expiration_date: "2027-04-01",
+      current_premium_cents: 310_000,
+      filings: [],
+      projected_change_pct: null,
+      projected_premium_cents: null,
+      unavailable_reason:
+        "Texas publishes rate filings for landlord (dwelling-fire) policies only.",
+    },
   ],
-  market_filings: [FLAT_FILING, APPROVED_FILING],
+  market_rising: [APPROVED_FILING],
+  market_flat: [FLAT_FILING],
   has_any_increase: true,
+  checked_policy_count: 2,
   feed_unavailable_reason: null,
 };
 
@@ -222,6 +247,15 @@ test.describe("Check for rate increases", () => {
     await expect(results).toBeVisible({ timeout: 15000 });
     expect(watchRequests).toBe(1);
 
+    // The answer comes first, in the operator's own unit. Without it the
+    // section is a filing table the reader has to interpret themselves.
+    const verdict = page.getByTestId("rate-watch-verdict");
+    await expect(verdict).toContainText("E2E Peerless");
+    await expect(verdict).toContainText("+$268/yr");
+    await expect(page.getByTestId("rate-watch-verdict-detail")).toContainText(
+      "SafePoint filed +11.1%",
+    );
+
     // The projection reads as a movement from today's premium, and never as a
     // quote: a filing is a statewide average, not this house's renewal.
     const projection = page.getByTestId("rate-watch-outlook-projection");
@@ -242,10 +276,19 @@ test.describe("Check for rate increases", () => {
       "No dwelling-line filings found under this carrier's name.",
     );
 
-    // The market half: who to ask an agent about.
-    const market = page.getByTestId("rate-watch-market-list");
-    await expect(market).toContainText("FOREMOST LLOYDS OF TEXAS");
-    await expect(market).toContainText("no change");
+    // A policy on a form this feed never covered is a footnote, not a card
+    // claiming a search that never ran.
+    await expect(page.getByTestId("rate-watch-outlook-card")).toHaveCount(2);
+    await expect(page.getByTestId("rate-watch-out-of-scope")).toContainText("E2E Home");
+
+    // The market half: who to ask an agent about. Carriers holding rates flat
+    // are the shortlist to call, so they are separated from the ones raising.
+    await expect(page.getByTestId("rate-watch-market-flat")).toContainText(
+      "FOREMOST LLOYDS OF TEXAS",
+    );
+    await expect(page.getByTestId("rate-watch-market-rising")).toContainText(
+      "SAFEPOINT INSURANCE COMPANY",
+    );
 
     // A projection is arithmetic on a statewide average, not a bill promise.
     await expect(results).toContainText("statewide average");
@@ -302,8 +345,10 @@ test.describe("Check for rate increases", () => {
               unavailable_reason: FEED_DOWN_REASON,
             },
           ],
-          market_filings: [],
+          market_rising: [],
+          market_flat: [],
           has_any_increase: false,
+          checked_policy_count: 0,
           feed_unavailable_reason: FEED_DOWN_REASON,
         }),
       ),
@@ -318,6 +363,9 @@ test.describe("Check for rate increases", () => {
     await expect(page.getByTestId("rate-watch-outlook-unavailable")).toContainText(
       "nothing was checked",
     );
+    // And no verdict at all — an all-clear here would be a claim about a
+    // search that never ran.
+    await expect(page.getByTestId("rate-watch-verdict")).toHaveCount(0);
   });
 
   test("a request failure keeps the blame off the policies", async ({ page }) => {

--- a/apps/mybookkeeper/frontend/src/__tests__/RateWatchSection.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/RateWatchSection.test.tsx
@@ -1,17 +1,15 @@
 /**
  * Unit tests for the "Check for rate increases" section.
  *
- * Three behaviours matter, and all three are about not overstating what the
- * filing data says:
+ * The shape here changed after the operator loaded the first cut in production
+ * and said "i don't know what i'm looking at". These tests pin the fixes, and
+ * every one of them is about the screen answering before it explains:
  *
- * 1. A carrier with no filings under its name says so. Swyfft — the carrier on
- *    one of the operator's own policies — files nothing TDI publishes under
- *    that name, and an empty card would read as "no increases coming".
- * 2. A filing that was withdrawn or rejected is labelled "Not approved". As a
- *    bare percentage it is indistinguishable from one that took effect, and
- *    only one of them will ever appear on a bill.
- * 3. A feed outage is stated. The one thing this section must never do is
- *    render silence as good news.
+ * 1. There is a verdict, in dollars, above the evidence.
+ * 2. Silence is never the answer — an unmatched carrier, a policy the feed does
+ *    not cover, and an outage each say which of the three they are.
+ * 3. A filing that was withdrawn is labelled, because as a bare percentage it
+ *    is indistinguishable from one that took effect.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
@@ -58,9 +56,11 @@ function outlook(
 ): InsurancePolicyRateOutlook {
   return {
     policy_id: "policy-1",
-    policy_name: "Dwelling DP-3",
+    policy_name: "Dwelling Fire DP-3, 6738 Peerless St",
+    policy_label: "Dwelling Fire DP-3",
     property_name: "6738 Peerless St",
     carrier: "SafePoint",
+    is_checkable: true,
     expiration_date: "2026-09-24",
     current_premium_cents: 241_000,
     filings: [filing()],
@@ -74,8 +74,10 @@ function outlook(
 function watch(overrides: Partial<InsuranceMarketWatch> = {}): InsuranceMarketWatch {
   return {
     outlooks: [outlook()],
-    market_filings: [filing()],
+    market_rising: [filing()],
+    market_flat: [],
     has_any_increase: true,
+    checked_policy_count: 1,
     feed_unavailable_reason: null,
     ...overrides,
   };
@@ -100,20 +102,65 @@ describe("RateWatchSection", () => {
     expect(mockCheck).toHaveBeenCalledTimes(1);
   });
 
+  it("leads with the verdict in dollars, before any evidence", () => {
+    // The whole point of the redesign. The percentage is the insurer's unit;
+    // dollars per year is the one that changes the operator's budget.
+    mockUninitialized = false;
+    mockData = watch();
+    render(<RateWatchSection />);
+
+    const verdict = screen.getByTestId("rate-watch-verdict");
+    expect(verdict).toHaveTextContent("6738 Peerless St");
+    expect(verdict).toHaveTextContent("+$268/yr");
+    expect(screen.getByTestId("rate-watch-verdict-detail")).toHaveTextContent(
+      "SafePoint filed +11.1%",
+    );
+  });
+
+  it("says so plainly when nothing is going up", () => {
+    mockUninitialized = false;
+    mockData = watch({
+      outlooks: [
+        outlook({ projected_change_pct: 0, projected_premium_cents: 241_000 }),
+      ],
+      has_any_increase: false,
+      market_rising: [],
+      market_flat: [filing({ percent_change: 0 })],
+      checked_policy_count: 2,
+    });
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-verdict")).toHaveTextContent(
+      "No rate increases filed against your 2 policies.",
+    );
+  });
+
+  it("does not print the property address twice in one heading", () => {
+    // policy_name carries the whole descriptor off the declarations page; the
+    // heading already names the property, so it renders the stripped label.
+    mockUninitialized = false;
+    mockData = watch();
+    render(<RateWatchSection />);
+
+    const card = screen.getByTestId("rate-watch-outlook-card");
+    expect(card).toHaveTextContent("6738 Peerless St · Dwelling Fire DP-3");
+    expect(card.textContent?.match(/6738 Peerless St/g)).toHaveLength(1);
+  });
+
   it("names both the property and the policy on every card", () => {
     // A property can carry a dwelling policy and a separate wind-only one.
     // Headed by property alone the two cards read as duplicates.
     mockUninitialized = false;
     mockData = watch({
       outlooks: [
-        outlook({ policy_id: "policy-1", policy_name: "Dwelling DP-3" }),
-        outlook({ policy_id: "policy-2", policy_name: "Wind and hail" }),
+        outlook({ policy_id: "policy-1", policy_label: "Dwelling Fire DP-3" }),
+        outlook({ policy_id: "policy-2", policy_label: "Wind and hail" }),
       ],
     });
     render(<RateWatchSection />);
 
     const cards = screen.getAllByTestId("rate-watch-outlook-card");
-    expect(cards[0]).toHaveTextContent("6738 Peerless St · Dwelling DP-3");
+    expect(cards[0]).toHaveTextContent("6738 Peerless St · Dwelling Fire DP-3");
     expect(cards[1]).toHaveTextContent("6738 Peerless St · Wind and hail");
   });
 
@@ -126,7 +173,7 @@ describe("RateWatchSection", () => {
     expect(screen.queryByTestId("rate-watch-results")).not.toBeInTheDocument();
   });
 
-  it("projects the renewal premium from the filed increase", () => {
+  it("projects the renewal premium with the dollar movement", () => {
     mockUninitialized = false;
     mockData = watch();
     render(<RateWatchSection />);
@@ -134,6 +181,7 @@ describe("RateWatchSection", () => {
     const projection = screen.getByTestId("rate-watch-outlook-projection");
     expect(projection).toHaveTextContent("$2,410/yr");
     expect(projection).toHaveTextContent("$2,678/yr");
+    expect(projection).toHaveTextContent("+$268/yr");
     expect(projection).toHaveTextContent("+11.1%");
     // Never presented as a quote.
     expect(projection).toHaveTextContent("estimated");
@@ -149,18 +197,46 @@ describe("RateWatchSection", () => {
           projected_change_pct: null,
           projected_premium_cents: null,
           unavailable_reason:
-            "No dwelling-line filings found under this carrier's name.",
+            "No landlord-policy rate filing found under this carrier's name in the last two years.",
+        }),
+      ],
+      has_any_increase: false,
+    });
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-outlook-unavailable")).toHaveTextContent(
+      "No landlord-policy rate filing found under this carrier's name",
+    );
+    expect(
+      screen.queryByTestId("rate-watch-outlook-projection"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("footnotes a policy the feed never covered instead of giving it a card", () => {
+    // An HO-3 is not a carrier-matching failure. The first cut gave it a
+    // full-size card claiming a search that never ran.
+    mockUninitialized = false;
+    mockData = watch({
+      outlooks: [
+        outlook(),
+        outlook({
+          policy_id: "policy-ho3",
+          policy_label: "Homeowners Policy (HO-3)",
+          property_name: "6734 Peerless St",
+          is_checkable: false,
+          filings: [],
+          projected_change_pct: null,
+          projected_premium_cents: null,
+          unavailable_reason: "Texas publishes rate filings for landlord policies only.",
         }),
       ],
     });
     render(<RateWatchSection />);
 
-    expect(screen.getByTestId("rate-watch-outlook-unavailable")).toHaveTextContent(
-      "No dwelling-line filings found under this carrier's name.",
+    expect(screen.getAllByTestId("rate-watch-outlook-card")).toHaveLength(1);
+    expect(screen.getByTestId("rate-watch-out-of-scope")).toHaveTextContent(
+      "6734 Peerless St",
     );
-    expect(
-      screen.queryByTestId("rate-watch-outlook-projection"),
-    ).not.toBeInTheDocument();
   });
 
   it("reads a flat carrier as holding rates, not as plus zero", () => {
@@ -174,6 +250,7 @@ describe("RateWatchSection", () => {
           filings: [filing({ percent_change: 0 })],
         }),
       ],
+      has_any_increase: false,
     });
     render(<RateWatchSection />);
 
@@ -193,7 +270,7 @@ describe("RateWatchSection", () => {
           filings: [filing({ is_in_force: false, is_pending: false })],
         }),
       ],
-      market_filings: [],
+      market_rising: [],
     });
     render(<RateWatchSection />);
 
@@ -205,16 +282,39 @@ describe("RateWatchSection", () => {
   it("labels a filing the regulator has not ruled on", () => {
     mockUninitialized = false;
     mockData = watch({
-      market_filings: [filing({ is_in_force: false, is_pending: true })],
+      market_rising: [filing({ is_in_force: false, is_pending: true })],
     });
     render(<RateWatchSection />);
 
-    expect(screen.getByTestId("rate-watch-market-list")).toHaveTextContent(
+    expect(screen.getByTestId("rate-watch-market-rising")).toHaveTextContent(
       "Proposed",
     );
   });
 
-  it("states a feed outage instead of rendering silence", () => {
+  it("separates carriers holding flat from carriers raising", () => {
+    mockUninitialized = false;
+    mockData = watch({
+      market_flat: [
+        filing({
+          serff_id: "FRMT-1",
+          company_name: "FOREMOST LLOYDS OF TEXAS",
+          percent_change: 0,
+        }),
+      ],
+      market_rising: [filing()],
+    });
+    render(<RateWatchSection />);
+
+    expect(screen.getByTestId("rate-watch-market-flat")).toHaveTextContent(
+      "FOREMOST LLOYDS OF TEXAS",
+    );
+    expect(screen.getByTestId("rate-watch-market-rising")).toHaveTextContent(
+      "SAFEPOINT INSURANCE COMPANY",
+    );
+  });
+
+  it("states a feed outage and offers no verdict at all", () => {
+    // The one outcome this must never produce: silence rendered as good news.
     mockUninitialized = false;
     mockData = watch({
       outlooks: [
@@ -226,8 +326,10 @@ describe("RateWatchSection", () => {
             "The Texas Department of Insurance filing data could not be reached, so nothing was checked.",
         }),
       ],
-      market_filings: [],
+      market_rising: [],
+      market_flat: [],
       has_any_increase: false,
+      checked_policy_count: 0,
       feed_unavailable_reason:
         "The Texas Department of Insurance filing data could not be reached, so nothing was checked.",
     });
@@ -236,6 +338,7 @@ describe("RateWatchSection", () => {
     expect(screen.getByTestId("rate-watch-results")).toHaveTextContent(
       "could not be reached",
     );
+    expect(screen.queryByTestId("rate-watch-verdict")).not.toBeInTheDocument();
   });
 
   it("explains an empty portfolio rather than showing a blank section", () => {

--- a/apps/mybookkeeper/frontend/src/__tests__/rate-filing-format.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/rate-filing-format.test.ts
@@ -12,6 +12,7 @@ import {
   formatFilingDate,
   formatFilingStatus,
   formatOutlookHeadline,
+  formatPremiumDelta,
 } from "@/shared/lib/rate-filing-format";
 import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rate-filing";
 
@@ -106,5 +107,26 @@ describe("formatOutlookHeadline", () => {
     expect(formatOutlookHeadline(11.1, null)).toBe(
       "This carrier filed an increase",
     );
+  });
+});
+
+describe("formatPremiumDelta", () => {
+  it("gives the yearly dollar movement, which is the operator's unit", () => {
+    expect(formatPremiumDelta(241_000, 267_751)).toBe("+$268/yr");
+  });
+
+  it("marks a decrease with a minus", () => {
+    expect(formatPremiumDelta(241_000, 220_000)).toBe("−$210/yr");
+  });
+
+  it("returns null when there is no movement to report", () => {
+    // Not "+$0/yr" — a carrier holding flat is said in words elsewhere, and a
+    // zero dollar figure reads as a rounding artefact.
+    expect(formatPremiumDelta(241_000, 241_000)).toBeNull();
+  });
+
+  it("returns null when either premium is unknown", () => {
+    expect(formatPremiumDelta(null, 267_751)).toBeNull();
+    expect(formatPremiumDelta(241_000, null)).toBeNull();
   });
 });

--- a/apps/mybookkeeper/frontend/src/__tests__/rate-watch-verdict.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/rate-watch-verdict.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The verdict is the sentence the section leads with, so the failure modes that
+ * matter are the ones where it would overstate what the data supports.
+ */
+import { describe, it, expect } from "vitest";
+import { buildRateWatchVerdict } from "@/shared/lib/rate-watch-verdict";
+import type { InsuranceMarketWatch } from "@/shared/types/insurance/insurance-market-watch";
+import type { InsurancePolicyRateOutlook } from "@/shared/types/insurance/insurance-policy-rate-outlook";
+
+function outlook(
+  overrides: Partial<InsurancePolicyRateOutlook> = {},
+): InsurancePolicyRateOutlook {
+  return {
+    policy_id: "policy-1",
+    policy_name: "Dwelling Fire DP-3, 6738 Peerless St",
+    policy_label: "Dwelling Fire DP-3",
+    property_name: "6738 Peerless St",
+    carrier: "SafePoint",
+    is_checkable: true,
+    expiration_date: "2026-09-24",
+    current_premium_cents: 241_000,
+    filings: [],
+    projected_change_pct: 11.1,
+    projected_premium_cents: 267_751,
+    unavailable_reason: null,
+    ...overrides,
+  };
+}
+
+function watch(overrides: Partial<InsuranceMarketWatch> = {}): InsuranceMarketWatch {
+  return {
+    outlooks: [outlook()],
+    market_rising: [],
+    market_flat: [],
+    has_any_increase: true,
+    checked_policy_count: 1,
+    feed_unavailable_reason: null,
+    ...overrides,
+  };
+}
+
+describe("buildRateWatchVerdict", () => {
+  it("names the property and the dollar movement", () => {
+    const verdict = buildRateWatchVerdict(watch());
+
+    expect(verdict?.tone).toBe("alert");
+    expect(verdict?.headline).toBe(
+      "Your 6738 Peerless St renewal is going up about +$268/yr.",
+    );
+    expect(verdict?.detail).toContain("SafePoint filed +11.1%");
+    expect(verdict?.detail).toContain("Sep 24, 2026");
+  });
+
+  it("picks the worst policy when several have increases", () => {
+    const verdict = buildRateWatchVerdict(
+      watch({
+        outlooks: [
+          outlook({ policy_id: "a", projected_change_pct: 4 }),
+          outlook({
+            policy_id: "b",
+            property_name: "6732 Peerless St",
+            projected_change_pct: 19,
+            current_premium_cents: 200_000,
+            projected_premium_cents: 238_000,
+          }),
+        ],
+      }),
+    );
+
+    expect(verdict?.headline).toContain("6732 Peerless St");
+    expect(verdict?.headline).toContain("+$380/yr");
+  });
+
+  it("gives a plain all-clear, counting only what was checked", () => {
+    const verdict = buildRateWatchVerdict(
+      watch({ has_any_increase: false, checked_policy_count: 3 }),
+    );
+
+    expect(verdict?.tone).toBe("clear");
+    expect(verdict?.headline).toBe(
+      "No rate increases filed against your 3 policies.",
+    );
+  });
+
+  it("uses the singular for one policy", () => {
+    const verdict = buildRateWatchVerdict(
+      watch({ has_any_increase: false, checked_policy_count: 1 }),
+    );
+
+    expect(verdict?.headline).toBe("No rate increases filed against your policy.");
+  });
+
+  it("refuses to give a verdict when the feed was unreachable", () => {
+    // The failure this exists to prevent: an outage rendering as an all-clear.
+    expect(
+      buildRateWatchVerdict(
+        watch({
+          has_any_increase: false,
+          checked_policy_count: 0,
+          feed_unavailable_reason: "could not be reached",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("refuses to give a verdict when nothing was in scope to check", () => {
+    // Every policy is a homeowners policy: "no increases" would be a claim
+    // about a search that never ran.
+    expect(
+      buildRateWatchVerdict(
+        watch({
+          outlooks: [outlook({ is_checkable: false })],
+          has_any_increase: false,
+          checked_policy_count: 0,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to a wording that needs no premium when none is recorded", () => {
+    const verdict = buildRateWatchVerdict(
+      watch({
+        outlooks: [
+          outlook({ current_premium_cents: null, projected_premium_cents: null }),
+        ],
+      }),
+    );
+
+    expect(verdict?.tone).toBe("alert");
+    expect(verdict?.headline).toBe(
+      "A rate increase is filed against your 6738 Peerless St policy.",
+    );
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchBody.tsx
@@ -1,6 +1,4 @@
-import AlertBox from "@/shared/components/ui/AlertBox";
-import RateWatchMarketList from "@/app/features/insurance/RateWatchMarketList";
-import RateWatchOutlookCard from "@/app/features/insurance/RateWatchOutlookCard";
+import RateWatchResults from "@/app/features/insurance/RateWatchResults";
 import RateWatchSkeleton from "@/app/features/insurance/RateWatchSkeleton";
 import type { InsuranceMarketWatch } from "@/shared/types/insurance/insurance-market-watch";
 import type { RateWatchMode } from "@/shared/types/insurance/rate-watch-mode";
@@ -41,28 +39,6 @@ export default function RateWatchBody({ mode, data }: RateWatchBodyProps) {
       );
 
     case "results":
-      return (
-        <div className="space-y-4" data-testid="rate-watch-results">
-          {data?.feed_unavailable_reason ? (
-            <AlertBox variant="warning">{data.feed_unavailable_reason}</AlertBox>
-          ) : null}
-
-          <ul className="space-y-3">
-            {(data?.outlooks ?? []).map((outlook) => (
-              <RateWatchOutlookCard key={outlook.policy_id} outlook={outlook} />
-            ))}
-          </ul>
-
-          <RateWatchMarketList filings={data?.market_filings ?? []} />
-
-          {/* Stated once, at the bottom. Every figure above is a carrier's
-              statewide average, not a quote on a specific house. */}
-          <p className="text-xs text-muted-foreground">
-            Filings come from the Texas Department of Insurance. A filed change
-            is a statewide average across the carrier's whole book — your own
-            renewal also moves with your coverage amount and claims history.
-          </p>
-        </div>
-      );
+      return data ? <RateWatchResults data={data} /> : null;
   }
 }

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchFilingRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchFilingRow.tsx
@@ -14,6 +14,11 @@ function changeColor(pct: number | null): BadgeColor {
 
 export interface RateWatchFilingRowProps {
   filing: InsuranceRateFiling;
+  /**
+   * Off inside a policy card, which has already named the carrier in its
+   * heading and again in its headline — a third printing is just repetition.
+   */
+  showCarrier?: boolean;
 }
 
 /**
@@ -23,15 +28,20 @@ export interface RateWatchFilingRowProps {
  * refused reads identically to one that got it unless the disposition is on
  * the row, and only one of those changes what the operator will pay.
  */
-export default function RateWatchFilingRow({ filing }: RateWatchFilingRowProps) {
+export default function RateWatchFilingRow({
+  filing,
+  showCarrier = true,
+}: RateWatchFilingRowProps) {
   return (
     <li
       className="flex flex-wrap items-baseline gap-x-3 gap-y-1 py-2 border-b border-border last:border-0"
       data-testid="rate-watch-filing-row"
     >
-      <span className="text-sm font-medium min-w-0 flex-1 truncate">
-        {filing.company_name}
-      </span>
+      {showCarrier ? (
+        // Never truncated. This list exists to be read to an agent, and half a
+        // carrier's name is not a name.
+        <span className="text-sm font-medium">{filing.company_name}</span>
+      ) : null}
 
       <Badge
         label={formatChangePct(filing.percent_change)}
@@ -43,7 +53,10 @@ export default function RateWatchFilingRow({ filing }: RateWatchFilingRowProps) 
         color={filing.is_in_force ? "gray" : "yellow"}
       />
 
-      <span className="text-xs text-muted-foreground w-full sm:w-auto">
+      {/* Always its own line. Left to wrap only when it does not fit, the
+          badges landed in a different place on every row and the list read as
+          ragged rather than as a column. */}
+      <span className="text-xs text-muted-foreground basis-full">
         {filing.product_name ?? "Unnamed program"} · renewals from{" "}
         {formatFilingDate(filing.effective_date_renewal)}
       </span>

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchMarketGroup.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchMarketGroup.tsx
@@ -1,0 +1,56 @@
+import RateWatchFilingRow from "@/app/features/insurance/RateWatchFilingRow";
+import { MARKET_GROUP_PREVIEW } from "@/shared/lib/rate-watch-constants";
+import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rate-filing";
+
+export interface RateWatchMarketGroupProps {
+  title: string;
+  blurb: string;
+  filings: InsuranceRateFiling[];
+  testId: string;
+}
+
+/**
+ * One half of the market: rising, or holding.
+ *
+ * Capped at a readable preview with the tail behind a native `<details>`. The
+ * first cut rendered every carrier at once, and twenty equal-weight rows read
+ * as a wall rather than as a shortlist — the length was doing the opposite of
+ * what more information is supposed to do.
+ */
+export default function RateWatchMarketGroup({
+  title,
+  blurb,
+  filings,
+  testId,
+}: RateWatchMarketGroupProps) {
+  if (filings.length === 0) return null;
+
+  const preview = filings.slice(0, MARKET_GROUP_PREVIEW);
+  const rest = filings.slice(MARKET_GROUP_PREVIEW);
+
+  return (
+    <div data-testid={testId}>
+      <h4 className="text-sm font-semibold">{title}</h4>
+      <p className="text-xs text-muted-foreground mt-0.5">{blurb}</p>
+
+      <ul className="mt-2">
+        {preview.map((filing) => (
+          <RateWatchFilingRow key={filing.serff_id} filing={filing} />
+        ))}
+      </ul>
+
+      {rest.length > 0 ? (
+        <details className="mt-1">
+          <summary className="text-xs text-muted-foreground cursor-pointer py-2">
+            Show {rest.length} more
+          </summary>
+          <ul>
+            {rest.map((filing) => (
+              <RateWatchFilingRow key={filing.serff_id} filing={filing} />
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchMarketList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchMarketList.tsx
@@ -1,37 +1,43 @@
-import RateWatchFilingRow from "@/app/features/insurance/RateWatchFilingRow";
+import RateWatchMarketGroup from "@/app/features/insurance/RateWatchMarketGroup";
 import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rate-filing";
 
 export interface RateWatchMarketListProps {
-  filings: InsuranceRateFiling[];
+  rising: InsuranceRateFiling[];
+  flat: InsuranceRateFiling[];
 }
 
 /**
- * The dwelling market: who last moved their landlord rates, and by how much.
+ * The dwelling market, as two answers rather than one table.
  *
- * This is the half the operator can act on. A dwelling policy is written
- * through an agent rather than bought online, so the useful thing to walk into
- * that conversation with is the list of carriers currently holding flat — and
- * the ones to avoid asking about.
+ * A dwelling policy is written through an agent rather than bought online, so
+ * what the operator needs from this is a short list of names to raise on a
+ * call — and a shorter list to skip. Pooling both into one percentage-ordered
+ * table made them do that sorting by eye.
  */
-export default function RateWatchMarketList({ filings }: RateWatchMarketListProps) {
-  if (filings.length === 0) return null;
+export default function RateWatchMarketList({
+  rising,
+  flat,
+}: RateWatchMarketListProps) {
+  if (rising.length === 0 && flat.length === 0) return null;
 
   return (
     <section
-      className="rounded-lg border border-border p-4"
+      className="rounded-lg border border-border p-4 space-y-4"
       data-testid="rate-watch-market-list"
     >
-      <h3 className="text-sm font-semibold">Recent landlord-policy filings</h3>
-      <p className="text-xs text-muted-foreground mt-0.5">
-        One row per carrier, most recent first. A carrier holding flat is worth
-        asking your agent about.
-      </p>
+      <RateWatchMarketGroup
+        title="Holding rates flat"
+        blurb="Worth asking your agent about — the last dwelling rate each of these filed was unchanged or lower."
+        filings={flat}
+        testId="rate-watch-market-flat"
+      />
 
-      <ul className="mt-3">
-        {filings.map((filing) => (
-          <RateWatchFilingRow key={filing.serff_id} filing={filing} />
-        ))}
-      </ul>
+      <RateWatchMarketGroup
+        title="Raising rates"
+        blurb="Filed an increase that has not reached renewals yet."
+        filings={rising}
+        testId="rate-watch-market-rising"
+      />
     </section>
   );
 }

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchOutOfScopeNote.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchOutOfScopeNote.tsx
@@ -1,0 +1,35 @@
+import type { InsurancePolicyRateOutlook } from "@/shared/types/insurance/insurance-policy-rate-outlook";
+
+export interface RateWatchOutOfScopeNoteProps {
+  outlooks: InsurancePolicyRateOutlook[];
+}
+
+/**
+ * The policies this feed was never going to cover.
+ *
+ * Named rather than hidden — a policy silently missing from the list would be
+ * worse than one explained — but as a footnote, not a card. The first cut gave
+ * a homeowners policy a full-size card reading "No dwelling-line filings found
+ * under this carrier's name", which both outweighed the card that had an answer
+ * and claimed a search that never ran.
+ */
+export default function RateWatchOutOfScopeNote({
+  outlooks,
+}: RateWatchOutOfScopeNoteProps) {
+  if (outlooks.length === 0) return null;
+
+  const names = outlooks
+    .map((outlook) => outlook.property_name ?? outlook.policy_label)
+    .join(", ");
+
+  return (
+    <p
+      className="text-xs text-muted-foreground"
+      data-testid="rate-watch-out-of-scope"
+    >
+      Not checked: {names}. Texas publishes rate filings for landlord
+      (dwelling-fire) policies only, so a homeowners policy has nothing to
+      compare against here.
+    </p>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchOutlookCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchOutlookCard.tsx
@@ -3,6 +3,7 @@ import {
   formatChangePct,
   formatFilingDate,
   formatOutlookHeadline,
+  formatPremiumDelta,
 } from "@/shared/lib/rate-filing-format";
 import { formatAnnualPremium } from "@/shared/lib/insurance-policy-format";
 import type { InsurancePolicyRateOutlook } from "@/shared/types/insurance/insurance-policy-rate-outlook";
@@ -14,6 +15,11 @@ export interface RateWatchOutlookCardProps {
 /**
  * One policy's renewal outlook.
  *
+ * A card with nothing to report is drawn quieter than one with an increase on
+ * it. Giving every policy identical weight is what made the first cut read as
+ * undifferentiated — the eye had nowhere to land, so the one card that mattered
+ * looked like the two that did not.
+ *
  * The projection is stated as an estimate every time it appears. A rate filing
  * is a statewide average across a carrier's whole book, and the operator's own
  * renewal also moves with their coverage amount and claims history — showing it
@@ -21,28 +27,38 @@ export interface RateWatchOutlookCardProps {
  */
 export default function RateWatchOutlookCard({ outlook }: RateWatchOutlookCardProps) {
   const { projected_change_pct: pct, unavailable_reason: reason } = outlook;
+  const hasMovement = reason === null && pct !== null && pct !== 0;
+  const delta = formatPremiumDelta(
+    outlook.current_premium_cents,
+    outlook.projected_premium_cents,
+  );
 
   return (
     <li
-      className="rounded-lg border border-border p-4"
+      className={`rounded-lg border p-4 ${
+        hasMovement ? "border-border" : "border-border/50"
+      }`}
       data-testid="rate-watch-outlook-card"
     >
       <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-        {/* Both names, always. A property can carry more than one policy — a
-            dwelling policy and a separate wind-only one is the common Texas
-            shape — and headed by property alone the two cards are
-            indistinguishable. */}
+        {/* The property leads; the form follows in a lighter weight. Both are
+            needed because a property can carry a dwelling policy and a separate
+            wind-only one, and headed by property alone those two cards are
+            indistinguishable. `policy_label` is the policy name with the
+            address already stripped — a declarations-page reader puts the whole
+            descriptor in the name, so rendering it raw printed the address
+            twice in one heading. */}
         <h3 className="text-sm font-semibold min-w-0">
           {outlook.property_name ? (
             <>
               {outlook.property_name}
               <span className="font-normal text-muted-foreground">
                 {" · "}
-                {outlook.policy_name}
+                {outlook.policy_label}
               </span>
             </>
           ) : (
-            outlook.policy_name
+            outlook.policy_label
           )}
         </h3>
         <span className="text-xs text-muted-foreground">
@@ -59,11 +75,14 @@ export default function RateWatchOutlookCard({ outlook }: RateWatchOutlookCardPr
         </p>
       ) : (
         <>
-          <p className="text-sm mt-2" data-testid="rate-watch-outlook-headline">
+          <p
+            className="text-sm text-muted-foreground mt-2"
+            data-testid="rate-watch-outlook-headline"
+          >
             {formatOutlookHeadline(pct, outlook.carrier)}
           </p>
 
-          {pct !== null && pct !== 0 ? (
+          {hasMovement ? (
             <p
               className="text-lg font-semibold mt-1"
               data-testid="rate-watch-outlook-projection"
@@ -73,7 +92,9 @@ export default function RateWatchOutlookCard({ outlook }: RateWatchOutlookCardPr
               {formatAnnualPremium(outlook.projected_premium_cents)}
               <span className="text-sm font-normal text-muted-foreground">
                 {" "}
-                ({formatChangePct(pct)}, estimated)
+                ({[delta, formatChangePct(pct), "estimated"]
+                  .filter(Boolean)
+                  .join(", ")})
               </span>
             </p>
           ) : null}
@@ -83,7 +104,11 @@ export default function RateWatchOutlookCard({ outlook }: RateWatchOutlookCardPr
       {outlook.filings.length > 0 ? (
         <ul className="mt-3">
           {outlook.filings.map((filing) => (
-            <RateWatchFilingRow key={filing.serff_id} filing={filing} />
+            <RateWatchFilingRow
+              key={filing.serff_id}
+              filing={filing}
+              showCarrier={false}
+            />
           ))}
         </ul>
       ) : null}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchResults.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchResults.tsx
@@ -1,0 +1,57 @@
+import AlertBox from "@/shared/components/ui/AlertBox";
+import RateWatchMarketList from "@/app/features/insurance/RateWatchMarketList";
+import RateWatchOutOfScopeNote from "@/app/features/insurance/RateWatchOutOfScopeNote";
+import RateWatchOutlookCard from "@/app/features/insurance/RateWatchOutlookCard";
+import RateWatchVerdict from "@/app/features/insurance/RateWatchVerdict";
+import { buildRateWatchVerdict } from "@/shared/lib/rate-watch-verdict";
+import type { InsuranceMarketWatch } from "@/shared/types/insurance/insurance-market-watch";
+
+export interface RateWatchResultsProps {
+  data: InsuranceMarketWatch;
+}
+
+/**
+ * The loaded section, in the order it should be read.
+ *
+ * Verdict, then the policies it came from, then the market, then the caveat.
+ * The first cut had no verdict and opened straight into cards — which is the
+ * whole reason the screen had to be read rather than glanced at.
+ */
+export default function RateWatchResults({ data }: RateWatchResultsProps) {
+  const verdict = buildRateWatchVerdict(data);
+  // Policies on a form this feed does not cover are collapsed to a footnote
+  // rather than given a card each. A full-size card saying "there is nothing to
+  // check here" competes for attention with the one that has an answer.
+  const checked = data.outlooks.filter((outlook) => outlook.is_checkable);
+  const outOfScope = data.outlooks.filter((outlook) => !outlook.is_checkable);
+
+  return (
+    <div className="space-y-4" data-testid="rate-watch-results">
+      {data.feed_unavailable_reason ? (
+        <AlertBox variant="warning">{data.feed_unavailable_reason}</AlertBox>
+      ) : null}
+
+      {verdict ? <RateWatchVerdict verdict={verdict} /> : null}
+
+      {checked.length > 0 ? (
+        <ul className="space-y-3">
+          {checked.map((outlook) => (
+            <RateWatchOutlookCard key={outlook.policy_id} outlook={outlook} />
+          ))}
+        </ul>
+      ) : null}
+
+      <RateWatchOutOfScopeNote outlooks={outOfScope} />
+
+      <RateWatchMarketList rising={data.market_rising} flat={data.market_flat} />
+
+      {/* Stated once, at the bottom. Every figure above is a carrier's
+          statewide average, not a quote on a specific house. */}
+      <p className="text-xs text-muted-foreground">
+        Filings come from the Texas Department of Insurance. A filed change is a
+        statewide average across the carrier's whole book — your own renewal also
+        moves with your coverage amount and claims history.
+      </p>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchSkeleton.tsx
@@ -1,10 +1,10 @@
 /**
  * Loading placeholder for the rate-watch check.
  *
- * Mirrors the loaded section: two bordered policy cards, each with a heading
- * row, a headline line, a projection line and two filing rows, then the market
- * list with its heading and five rows. Same shape means no layout shift when
- * the department answers.
+ * Mirrors the loaded section: the verdict banner, two bordered policy cards
+ * each with a heading row, a headline line, a projection line and two filing
+ * rows, then the market list with its heading and five rows. Same shape means
+ * no layout shift when the department answers.
  */
 export default function RateWatchSkeleton() {
   return (
@@ -13,6 +13,13 @@ export default function RateWatchSkeleton() {
       aria-busy="true"
       data-testid="rate-watch-loading"
     >
+      {/* The verdict lands first and is the tallest single element; without a
+          placeholder everything below it jumps on arrival. */}
+      <div className="rounded-lg border border-border p-4">
+        <div className="h-6 bg-muted rounded w-72" />
+        <div className="h-3 bg-muted rounded w-56 mt-2" />
+      </div>
+
       <ul className="space-y-3">
         {[1, 2].map((card) => (
           <li key={card} className="rounded-lg border border-border p-4">

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchVerdict.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/RateWatchVerdict.tsx
@@ -1,0 +1,37 @@
+import type { RateWatchVerdict as Verdict } from "@/shared/types/insurance/rate-watch-verdict";
+
+export interface RateWatchVerdictProps {
+  verdict: Verdict;
+}
+
+/**
+ * The answer, before the evidence.
+ *
+ * Deliberately the largest text in the section and the first thing under the
+ * button. Everything below it — the per-policy cards, the market lists — is
+ * support for this sentence, and is sized accordingly.
+ */
+export default function RateWatchVerdict({ verdict }: RateWatchVerdictProps) {
+  const alert = verdict.tone === "alert";
+
+  return (
+    <div
+      className={`rounded-lg border p-4 ${
+        alert
+          ? "border-orange-500/40 bg-orange-500/5"
+          : "border-green-600/40 bg-green-600/5"
+      }`}
+      data-testid="rate-watch-verdict"
+    >
+      <p className="text-lg font-semibold leading-snug">{verdict.headline}</p>
+      {verdict.detail ? (
+        <p
+          className="text-sm text-muted-foreground mt-1"
+          data-testid="rate-watch-verdict-detail"
+        >
+          {verdict.detail}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/rate-filing-format.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/rate-filing-format.ts
@@ -60,3 +60,21 @@ export function formatOutlookHeadline(
   if (pct < 0) return `${who} filed a decrease`;
   return `${who} filed an increase`;
 }
+
+/**
+ * The dollar movement, e.g. `"+$268/yr"`.
+ *
+ * The percentage is the insurer's unit; dollars per year is the operator's.
+ * Showing the two endpoints and leaving them to subtract is asking them to do
+ * arithmetic to reach the only number that changes their budget.
+ */
+export function formatPremiumDelta(
+  currentCents: number | null,
+  projectedCents: number | null,
+): string | null {
+  if (currentCents === null || projectedCents === null) return null;
+  const delta = projectedCents - currentCents;
+  if (delta === 0) return null;
+  const dollars = Math.round(Math.abs(delta) / 100);
+  return `${delta > 0 ? "+" : "−"}$${dollars.toLocaleString("en-US")}/yr`;
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/rate-watch-constants.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/rate-watch-constants.ts
@@ -1,0 +1,8 @@
+/**
+ * How many carriers each market group shows before the rest collapse.
+ *
+ * Mirrors ``MARKET_GROUP_PREVIEW`` in the backend's
+ * ``tdi_rate_filings_constants``. The backend caps what it sends; this caps
+ * what is shown at rest.
+ */
+export const MARKET_GROUP_PREVIEW = 5;

--- a/apps/mybookkeeper/frontend/src/shared/lib/rate-watch-verdict.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/rate-watch-verdict.ts
@@ -1,0 +1,76 @@
+import {
+  formatChangePct,
+  formatFilingDate,
+  formatPremiumDelta,
+} from "@/shared/lib/rate-filing-format";
+import type { InsuranceMarketWatch } from "@/shared/types/insurance/insurance-market-watch";
+import type { InsurancePolicyRateOutlook } from "@/shared/types/insurance/insurance-policy-rate-outlook";
+import type { RateWatchVerdict } from "@/shared/types/insurance/rate-watch-verdict";
+
+/**
+ * Reduce the whole rate-watch payload to the sentence it leads with.
+ *
+ * Returns null only when there is genuinely no verdict to give — the feed was
+ * unreachable, or nothing was checked. Both of those are stated elsewhere as
+ * what they are; neither may be dressed up as an all-clear here.
+ */
+export function buildRateWatchVerdict(
+  data: InsuranceMarketWatch,
+): RateWatchVerdict | null {
+  if (data.feed_unavailable_reason !== null) return null;
+  if (data.checked_policy_count === 0) return null;
+
+  if (!data.has_any_increase) {
+    const n = data.checked_policy_count;
+    return {
+      tone: "clear",
+      headline: `No rate increases filed against ${
+        n === 1 ? "your policy" : `your ${n} policies`
+      }.`,
+      detail: null,
+    };
+  }
+
+  const worst = worstOutlook(data.outlooks);
+  if (worst === null) return null;
+
+  const where = worst.property_name ?? worst.policy_label;
+  const delta = formatPremiumDelta(
+    worst.current_premium_cents,
+    worst.projected_premium_cents,
+  );
+
+  return {
+    tone: "alert",
+    headline: delta
+      ? `Your ${where} renewal is going up about ${delta}.`
+      : `A rate increase is filed against your ${where} policy.`,
+    detail: [
+      `${worst.carrier ?? "The carrier"} filed ${formatChangePct(
+        worst.projected_change_pct,
+      )}`,
+      worst.expiration_date
+        ? `takes effect before your ${formatFilingDate(
+            worst.expiration_date,
+          )} renewal`
+        : null,
+    ]
+      .filter(Boolean)
+      .join(", "),
+  };
+}
+
+/** The policy facing the largest filed increase — the one worth naming. */
+function worstOutlook(
+  outlooks: InsurancePolicyRateOutlook[],
+): InsurancePolicyRateOutlook | null {
+  let worst: InsurancePolicyRateOutlook | null = null;
+  for (const outlook of outlooks) {
+    const pct = outlook.projected_change_pct;
+    if (pct === null || pct <= 0) continue;
+    if (worst === null || pct > (worst.projected_change_pct ?? 0)) {
+      worst = outlook;
+    }
+  }
+  return worst;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-market-watch.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-market-watch.ts
@@ -4,9 +4,13 @@ import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rat
 /** Response for the dwelling-market rate watch. */
 export interface InsuranceMarketWatch {
   outlooks: InsurancePolicyRateOutlook[];
-  /** Recent filings across the whole market — the shortlist to call. */
-  market_filings: InsuranceRateFiling[];
+  /** Carriers whose next dwelling rate rises — who not to move to. */
+  market_rising: InsuranceRateFiling[];
+  /** Carriers holding flat or cutting — the shortlist worth an agent call. */
+  market_flat: InsuranceRateFiling[];
   has_any_increase: boolean;
+  /** Policies actually checked — excludes forms this feed does not cover. */
+  checked_policy_count: number;
   /** Set when the TDI feed could not be reached, so nothing was checked. */
   feed_unavailable_reason: string | null;
 }

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-rate-outlook.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-rate-outlook.ts
@@ -4,8 +4,15 @@ import type { InsuranceRateFiling } from "@/shared/types/insurance/insurance-rat
 export interface InsurancePolicyRateOutlook {
   policy_id: string;
   policy_name: string;
+  /** `policy_name` without the property address, for a heading that has it. */
+  policy_label: string;
   property_name: string | null;
   carrier: string | null;
+  /**
+   * False for a policy on a form the dwelling feed does not cover. "Searched
+   * and found nothing" and "never in scope" are different statements.
+   */
+  is_checkable: boolean;
   expiration_date: string | null;
   /** Annualised, so a monthly policy is comparable to the projection. */
   current_premium_cents: number | null;

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/rate-watch-verdict.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/rate-watch-verdict.ts
@@ -1,0 +1,15 @@
+/**
+ * The one sentence the rate-watch section leads with.
+ *
+ * The first cut of this screen had no verdict at all — it opened with three
+ * full-detail cards and a twenty-row table and left the operator to work out
+ * whether any of it mattered. It doesn't have to be read to be understood.
+ */
+export interface RateWatchVerdict {
+  /** `alert` when something is going up, `clear` when nothing is. */
+  tone: "alert" | "clear";
+  /** The sentence itself. */
+  headline: string;
+  /** Supporting line: which carrier, how much, by when. */
+  detail: string | null;
+}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -608,6 +608,8 @@
         "backend/app/api/insurance_market.py",
         "backend/app/core/tdi_rate_filings_constants.py",
         "frontend/src/shared/lib/rate-filing-format.ts",
+        "frontend/src/shared/lib/rate-watch-verdict.ts",
+        "frontend/src/shared/lib/rate-watch-constants.ts",
         "frontend/src/shared/store/insuranceMarketApi.ts",
         "backend/app/core/insurance_enums.py",
         "backend/app/core/insurance_benchmark_constants.py",
@@ -646,6 +648,7 @@
         "test_insurance_market_watch_service.py",
         "test_insurance_market_api.py",
         "test_insurance_carrier_filing_match.py",
+        "test_insurance_policy_form.py",
         "test_tdi_rate_filings_client.py",
         "test_document_draft_reader.py"
       ],
@@ -665,6 +668,7 @@
         "InsuranceBenchmarkSummary.test.tsx",
         "RateWatchSection.test.tsx",
         "rate-filing-format.test.ts",
+        "rate-watch-verdict.test.ts",
         "benchmark-format.test.ts",
         "Dashboard.test.tsx"
       ],


### PR DESCRIPTION
Loaded in production, the "Check for rate increases" section opened straight into three policy cards and a twenty-row filing list. Every number was correct and none of them answered the question the button asks. This is the design pass that should have run before the first cut shipped.

## What changed

**The screen answers first.** A verdict banner leads in dollars per year — `Your 6738 Peerless St renewal is going up about +$268/yr.` — with the carrier, percentage and renewal date as the supporting line beneath. It is suppressed entirely when the feed was unreachable or when nothing was in scope to check, because an all-clear in either case is a claim about a search that never ran.

**Cards name the policy, not the address twice.** A declarations-page reader fills `policy_name` with the whole descriptor off the PDF, and the card heading already names the property. `policy_label` strips the address back out, so a heading reads `6738 Peerless St · Dwelling Fire DP-3` instead of printing the street twice.

**A homeowners policy is no longer treated as a matching failure.** The TDI feed covers the dwelling-fire line only, so an HO-3 could never have matched under any carrier — saying "no filings found under this carrier's name" asserts a search that never happened. The form is read from the policy name (DP-1..3 / HO-1..8 codes, with a word fallback) and out-of-scope policies collapse to a footnote. An unrecognised name is **checked anyway**: a wrong "nothing to see here" hides a real increase, while a wrong check merely finds nothing. The durable fix is a `policy_type` column set at entry — that needs a migration, a backfill and a form field, so it is its own change.

**The market list became two answers instead of one table.** "Holding rates flat" is the shortlist to raise with an agent; "raising rates" is the warning. Residual-market pools and advisory bureaus (TWIA, TX FAIR Plan, ISO, AFI, AAIS) are dropped — nobody can sell an operator one of those. Each group previews five rows with a `Show N more` tail.

**Filing rows are uniform.** Name and badges on one line, program and date under it. Left to wrap, the badges landed in a different place on every row and the list read as ragged.

## What the live feed changed

The first cut of this PR filtered both market lists to filings whose rate has not taken effect yet. Run against the live TDI dataset that dropped **six of the seven carriers** off the flat list, leaving a shortlist of one. The rule was wrong for half the screen: an increase that already took effect is not a warning, but a carrier that filed *no change* said nothing that expires. The still-ahead rule now applies to increases only, and the flat list carries every carrier whose most recent filing was flat or lower, most recently confirmed first.

## Verification

Real path, not only mocks — local backend and frontend on offset ports against the dev DB and the **live** TDI feed, with three policies (a matched dwelling, an unmatched carrier, an HO-3) created through the real API, checked in the browser, then hard-deleted. Zero `insurance_policy` rows remain in the dev DB.

- backend: 96 passed (market watch, market API, new policy-form module, carrier match, feed client)
- frontend: 41 passed across 3 files (2 new)
- e2e: 4 passed (`insurance-rate-watch.spec.ts`, run against this worktree's dev server)
- `tsc --noEmit` and `eslint` clean

No migration, no new env var, no operational migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeNqUHKsZEa3imipsgb2AN
