### PR TITLE
fix(shared): find the JSON in a model response instead of assuming it leads

### DIFF
--- a/packages/shared-backend/platform_shared/extraction/service.py
+++ b/packages/shared-backend/platform_shared/extraction/service.py
@@ -47,6 +47,9 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_TOKENS = 16384
 
+# Distinguishes "decoded the JSON value ``null``" from "decoded nothing".
+_NOTHING = object()
+
 
 @dataclass
 class ExtractionResponse:
@@ -154,29 +157,82 @@ class ExtractionService:
         return _parse_message(message)
 
 
+def _find_json(content: str) -> Any:
+    """The first JSON value in the response, wherever it starts.
+
+    A fenced block wins when there is one — the model was explicit about
+    which part of its answer is the payload. Failing that, the text is
+    scanned for a value rather than decoded from character zero.
+
+    That scan is the whole point. Asked to reconcile a declarations page
+    whose premiums did not add up, the model wrote out its arithmetic and
+    then answered, and the object it produced was discarded because prose
+    stood in front of it — a correct extraction, from a call that
+    succeeded and was paid for, thrown away over its position in the
+    string. ``raw_decode`` reads one value and stops, so trailing
+    commentary is tolerated for the same reason.
+
+    Candidates are tried left to right and the first that decodes wins. A
+    brace inside prose that starts no valid value simply fails and the scan
+    moves on. First rather than last, because every nested object inside
+    the payload is also a candidate: taking the last decodable value would
+    return an inner fragment of the very object being looked for.
+    """
+    stripped = content.strip()
+
+    fenced = _fenced_candidates(stripped)
+    for candidate in fenced:
+        value = _decode_prefix(candidate)
+        if value is not _NOTHING:
+            return value
+
+    for start in _value_starts(stripped):
+        value = _decode_prefix(stripped[start:])
+        if value is not _NOTHING:
+            return value
+
+    # Nothing decoded. Re-raise from the whole response so the error the
+    # caller logs points at what the model actually said.
+    return json.loads(stripped)
+
+
+def _fenced_candidates(content: str) -> list[str]:
+    """Bodies of any ``` fences, language tag removed."""
+    if "```" not in content:
+        return []
+    candidates = []
+    for part in content.split("```")[1::2]:  # odd-indexed parts are inside fences
+        inner = part.strip()
+        if inner.startswith("json"):
+            inner = inner[4:].strip()
+        candidates.append(inner)
+    return candidates
+
+
+def _value_starts(content: str) -> list[int]:
+    """Indexes where a JSON object or array could begin."""
+    return [i for i, ch in enumerate(content) if ch in "{["]
+
+
+def _decode_prefix(candidate: str) -> Any:
+    """One JSON value off the front of ``candidate``, or ``_NOTHING``."""
+    try:
+        value, _ = json.JSONDecoder().raw_decode(candidate.lstrip())
+    except json.JSONDecodeError:
+        return _NOTHING
+    return value
+
+
 def _parse_message(message: "Message") -> ExtractionResponse:
     """Pull JSON out of the model response. Domain-free.
 
-    Mirrors the pre-extraction parsing exactly: strip a fenced ```json
-    block if present, ``json.loads`` the result, attach token usage.
     Parse failure raises ExtractionParseError so the caller can apply a
     domain-specific fallback (the pre-extraction code returned a
     low-confidence placeholder dict here; that policy now lives in the
     MyBookkeeper wrapper).
     """
     try:
-        content = message.content[0].text.strip()
-        # Extract JSON from markdown code blocks anywhere in the response
-        if "```" in content:
-            parts = content.split("```")
-            for part in parts[1::2]:  # odd-indexed parts are inside code fences
-                inner = part.strip()
-                if inner.startswith("json"):
-                    inner = inner[4:].strip()
-                if inner.startswith("{"):
-                    content = inner
-                    break
-        parsed = json.loads(content)
+        parsed = _find_json(message.content[0].text)
     except (json.JSONDecodeError, IndexError, AttributeError) as e:
         raw_text = message.content[0].text[:500] if message.content else "EMPTY"
         logger.error("Failed to parse extraction response: %s — raw: %s", e, raw_text)

--- a/packages/shared-backend/tests/test_extraction_service.py
+++ b/packages/shared-backend/tests/test_extraction_service.py
@@ -121,6 +121,97 @@ class TestExtractText:
         assert client.messages.create.await_args.kwargs["max_tokens"] == 2048
 
 
+class TestLocatingTheJson:
+    """Where in the response the payload is allowed to sit.
+
+    A production extraction was lost on 2026-08-17 because the model
+    reconciled a declarations page out loud — "I need to work through the
+    premium split carefully" and eight lines of arithmetic — before
+    answering. The call succeeded, the object was there, and it was thrown
+    away for starting at a character other than zero.
+    """
+
+    async def test_reads_json_that_follows_the_models_reasoning(self) -> None:
+        msg = _message(
+            "I need to work through the premium split carefully.\n\n"
+            "- Coverage A premium: $2,212\n"
+            "- Subtotal: $2,379\n"
+            "There is a $31 discrepancy, which I attribute to fees.\n\n"
+            '{"annual_premium": 2535, "confidence": "medium"}'
+        )
+        ctx, _ = _patched_client(msg)
+        with ctx:
+            resp = await _service().extract_text("s", "t")
+        assert resp.data == {"annual_premium": 2535, "confidence": "medium"}
+
+    async def test_reads_json_that_precedes_trailing_commentary(self) -> None:
+        msg = _message('{"vendor": "Acme"}\n\nLet me know if the fees look wrong.')
+        ctx, _ = _patched_client(msg)
+        with ctx:
+            resp = await _service().extract_text("s", "t")
+        assert resp.data == {"vendor": "Acme"}
+
+    async def test_returns_the_whole_object_not_a_nested_fragment(self) -> None:
+        # Every nested object is also a candidate start. Scanning left to
+        # right is what keeps the outer one winning.
+        msg = _message(
+            'Here is what I found:\n{"policy": {"carrier": "SafePoint"}, "premium": 2410}'
+        )
+        ctx, _ = _patched_client(msg)
+        with ctx:
+            resp = await _service().extract_text("s", "t")
+        assert resp.data == {"policy": {"carrier": "SafePoint"}, "premium": 2410}
+
+    async def test_a_brace_in_the_prose_does_not_derail_the_scan(self) -> None:
+        msg = _message('The template {name} was not filled in.\n{"ok": true}')
+        ctx, _ = _patched_client(msg)
+        with ctx:
+            resp = await _service().extract_text("s", "t")
+        assert resp.data == {"ok": True}
+
+    async def test_reads_a_top_level_array(self) -> None:
+        # Some prompts ask for a list of rows. The fence branch only ever
+        # accepted objects, so an array behind prose was unreachable.
+        msg = _message('Found two:\n[{"line": 1}, {"line": 2}]')
+        ctx, _ = _patched_client(msg)
+        with ctx:
+            resp = await _service().extract_text("s", "t")
+        assert resp.data == [{"line": 1}, {"line": 2}]
+
+    async def test_a_fenced_block_still_wins_over_stray_prose_braces(self) -> None:
+        msg = _message(
+            'Consider {a} and {b}.\n```json\n{"chosen": "fenced"}\n```\n{"later": true}'
+        )
+        ctx, _ = _patched_client(msg)
+        with ctx:
+            resp = await _service().extract_text("s", "t")
+        assert resp.data == {"chosen": "fenced"}
+
+    async def test_reads_a_fenced_array(self) -> None:
+        msg = _message('```json\n[1, 2, 3]\n```')
+        ctx, _ = _patched_client(msg)
+        with ctx:
+            resp = await _service().extract_text("s", "t")
+        assert resp.data == [1, 2, 3]
+
+    async def test_prose_with_no_json_at_all_still_raises(self) -> None:
+        # The fallback the caller depends on. A refusal or a clarifying
+        # question must not be dressed up as an extraction.
+        msg = _message("I could not read this document — the scan is blank.")
+        ctx, _ = _patched_client(msg)
+        with ctx:
+            with pytest.raises(ExtractionParseError):
+                await _service().extract_text("s", "t")
+
+    async def test_the_raised_error_quotes_the_whole_response(self) -> None:
+        msg = _message("No JSON here, only regrets.")
+        ctx, _ = _patched_client(msg)
+        with ctx:
+            with pytest.raises(ExtractionParseError) as exc:
+                await _service().extract_text("s", "t")
+        assert "line 1 column 1" in str(exc.value)
+
+
 class TestExtractDocument:
     async def test_pdf_uses_document_block(self) -> None:
         msg = _message("{}")


### PR DESCRIPTION
## What happened

An insurance declarations page was extracted **correctly** and the result thrown away.

Sentry (`mybookkeeper-api`, issue `7676627235`, 2026-08-17T15:15:23Z):

```
Failed to parse extraction response: Expecting value: line 1 column 1 (char 0)
— raw: I need to work through the premium split carefully.

The dec page shows:
- Coverage A premium: $2,212
- Coverage C premium: $78
- Coverage L premium: $60
- Coverage M premium: $10
- Optional Coverages Premium: $19
- Subtotal of listed premiums: $2,379

Page 2 shows:
- Policy Fees and Assessments: $125 (MGA Fee $75 + Inspection Fee $50)
- Total Policy Premium: $2,535

So: $2,379 + $125 = $2,504, not $2,535. There is a …
```

The breadcrumb above it is `POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"`. The call succeeded and the tokens were paid for. The model noticed the premiums didn't add up, worked the arithmetic out loud, and *then* answered. `_parse_message` read character zero, found `I`, and discarded the whole response.

## The fix

Scan the response for a JSON value instead of decoding from the front.

- A **fenced block still wins** when there is one — the model was explicit about which part is the payload.
- Failing that, each `{` / `[` is tried in turn; the first that decodes is the payload.
- `raw_decode` reads one value and stops, so **trailing** commentary is tolerated on the same principle as leading prose.

**Left to right, not right to left.** Every nested object inside the payload is also a candidate start, so taking the *last* decodable value would return a fragment of the very object being looked for. A brace in prose that begins no valid value simply fails and the scan moves past it.

**Top-level arrays are read too.** The old fence branch accepted objects only (`inner.startswith("{")`), which left an array behind prose unreachable for no reason anyone chose.

## Blast radius

Strictly more permissive — every response that parsed before still parses. The domain fallbacks in `mybookkeeper/.../claude_service.py` (3 call sites) and `myrecipes/.../photo_extraction_service.py` only fire less often. A response with **no** JSON at all still raises `ExtractionParseError`; a refusal or a clarifying question must never be dressed up as an extraction.

## Verification

**Live Anthropic call, not mocks.** Given a declarations page whose premiums disagree by $31, the model replied:

```
response led with JSON? False
first 120 chars: 'Let me work through the arithmetic to verify the total.  Adding up the
                 components: - Coverage A: $2,212 - Coverage C: $7'

parsed: {'annual_premium_cents': 253500, 'carrier': 'SafePoint Insurance Company',
         'confidence': 0.6}
tokens: in=147 out=265 model=claude-sonnet-4-6
```

That is the exact response shape the old parser dropped, recovered end to end through the real SDK.

Unit tests: `test_extraction_service.py` 22 passed, 9 of them new — reasoning-then-JSON, JSON-then-commentary, whole-object-not-nested-fragment, stray brace in prose, top-level array, fenced block still winning over stray braces, fenced array, prose-with-no-JSON still raising, and the error still quoting the response.

Full shared suite: 851 passed. The 5 `test_sms_service.py` failures are pre-existing and environmental — `ModuleNotFoundError: No module named 'twilio'` in the local venv, which CI installs.

No schema change, no migration, no operational migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeNqUHKsZEa3imipsgb2AN
