### PR TITLE
fix(mybookkeeper): read the insured location off a dec page, not the mailing address

### DIFF
--- a/apps/mybookkeeper/backend/app/services/extraction/prompts/insurance_policy_prompt.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/prompts/insurance_policy_prompt.py
@@ -30,6 +30,16 @@ contract:
 And the rule that outranks both: **a missing value is null, never an inference.**
 A plausible invented limit is worse than a blank, because a blank is visibly
 unknown and a number is not.
+
+The same rule is why the address gets a section of its own. The 2026 Peerless
+renewal names the insured location as 6732 and the insured's mailing address as
+6734 — the house next door, because that is where the landlord lives. Read off
+the text layer, where the labels sit in one block and the values in another and
+the agent's ZIP runs straight into the next street number
+("Houston, TX 770366734 Peerless St"), the policy came back named for 6734 at
+confidence "high". Every other field on it was right. A policy filed against the
+neighbouring building does not look like a failed read, which is exactly what
+makes it worth spelling out.
 """
 
 INSURANCE_POLICY_PROMPT = """You read property insurance documents and report the policy terms they state.
@@ -146,11 +156,44 @@ the coverage — on a Texas surplus lines policy by around 15%.
   rental value, personal property, ordinance or law, water backup — has no field
   here. Put each in `unrepresented`.
 
+# Which address
+
+A declarations page carries several addresses and only one of them is the
+property. Getting this wrong does not look like an error — it produces a
+confident, well-formed policy filed against the wrong building.
+
+- Use the INSURED LOCATION: the address labelled "Insured Location", "Location
+  of Risk", "Described Location", "Covered Property", "Property Address", or
+  appearing under a combined "Insured(s) & Insured Location" heading.
+- Never use the INSURED MAILING ADDRESS. A landlord's mail goes to where they
+  live, which is a different building from the one insured — and on a portfolio
+  of nearby rentals it is often the house next door, so the wrong answer looks
+  entirely plausible.
+- Never use the agent's, agency's, producer's, coverholder's, carrier's,
+  mortgagee's, or loss payee's address.
+
+Two things about how these pages extract make the wrong one easy to grab:
+
+- Labels and values are frequently in separate blocks, so every label appears
+  first and every value after, in the same order. Match them by position: the
+  third address in the value block belongs to the third address label.
+- Adjacent values can run together with no separator. A line reading
+  "Houston, TX 770366734 Peerless St" is the END of one address ("Houston, TX
+  77036") immediately followed by the START of the next ("6734 Peerless St").
+  Do not read the digits as a single ZIP or a single street number.
+
+If more than one address appears and you cannot tell with certainty which is
+the insured location, use none of them, say what you saw in `notes`, and set
+`confidence` no higher than "medium". An address that might be the property is
+worth less than no address, because the operator cannot see that it was a
+guess.
+
 # Naming the policy
 
 - `policy_name` is how the operator would recognise this policy in a list. Use
   the product name the document gives it ("Landlord Protection", "Dwelling Fire
-  DP-3") and, if the document names the insured property, the street address.
+  DP-3") and, if the document names the insured property, the street address of
+  the INSURED LOCATION — see "Which address" above.
 - `carrier` is the insurance company, not the agency or the broker. "Written
   through Smith Insurance Agency" is the agency; the carrier is whose paper the
   policy is on. If both appear, report the carrier and mention the agency in

--- a/apps/mybookkeeper/backend/tests/test_insurance_policy_prompt_address.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_policy_prompt_address.py
@@ -1,0 +1,104 @@
+"""The declarations-page prompt must say which of several addresses is the property.
+
+A dec page names the insured location, the insured's mailing address, the
+agent, the coverholder, and often a mortgagee. Only the first is the building.
+
+The 2026 renewal for 6732 Peerless St names 6732 as the insured location and
+6734 — the house next door, where the landlord lives — as the mailing address.
+Read off the PDF text layer, where labels sit in one block and values in
+another and the agent's ZIP runs straight into the next street number
+("Houston, TX 770366734 Peerless St"), the model reported the policy as
+6734 at confidence "high". Every other field was correct.
+
+That is the failure worth guarding: not a blank field or a 422, but a
+confident, well-formed policy filed against the wrong building. These tests
+pin the instruction rather than the model — if a later edit drops the rule,
+nothing else in the suite would notice, because the prompt is a string and the
+behaviour it buys only shows up against a live document.
+"""
+from __future__ import annotations
+
+import re
+
+from app.services.extraction.prompts.insurance_policy_prompt import (
+    INSURANCE_POLICY_PROMPT,
+)
+
+ADDRESS_SECTION_HEADING = "# Which address"
+
+
+def _section(heading: str) -> str:
+    """The prompt text under ``heading``, up to the next heading.
+
+    Whitespace is collapsed: the prompt is hand-wrapped prose, so a phrase like
+    "Location of Risk" can straddle a line break. Asserting on the wrapping
+    would fail the next time a sentence is reworded, which is not the thing
+    worth protecting.
+    """
+    start = INSURANCE_POLICY_PROMPT.index(heading)
+    rest = INSURANCE_POLICY_PROMPT[start + len(heading):]
+    end = rest.find("\n# ")
+    return re.sub(r"\s+", " ", rest if end == -1 else rest[:end])
+
+
+class TestTheAddressSectionExists:
+    def test_the_prompt_has_a_section_about_which_address_to_use(self) -> None:
+        assert ADDRESS_SECTION_HEADING in INSURANCE_POLICY_PROMPT
+
+    def test_naming_the_policy_points_at_that_section(self) -> None:
+        # The address reaches the operator through policy_name, so the rule has
+        # to be reachable from the instruction that writes it.
+        naming = _section("# Naming the policy")
+        assert "insured location" in naming.lower()
+
+
+class TestWhichAddressToUse:
+    def test_names_the_insured_location_as_the_one_to_use(self) -> None:
+        section = _section(ADDRESS_SECTION_HEADING).lower()
+        assert "insured location" in section
+
+    def test_lists_the_labels_a_dec_page_actually_prints(self) -> None:
+        section = _section(ADDRESS_SECTION_HEADING).lower()
+        for label in ("location of risk", "described location", "covered property"):
+            assert label in section, label
+
+
+class TestWhichAddressesAreForbidden:
+    def test_forbids_the_insured_mailing_address(self) -> None:
+        # The one that actually fired. A landlord's mail goes to where they
+        # live, which on a portfolio of nearby rentals is often the house next
+        # door — so the wrong answer looks entirely plausible.
+        section = _section(ADDRESS_SECTION_HEADING).lower()
+        assert re.search(r"never use the insured mailing address", section)
+
+    def test_forbids_the_intermediaries_addresses(self) -> None:
+        section = _section(ADDRESS_SECTION_HEADING).lower()
+        for party in ("agent", "mortgagee", "loss payee"):
+            assert party in section, party
+
+
+class TestReadingTheTextLayer:
+    def test_warns_that_labels_and_values_arrive_in_separate_blocks(self) -> None:
+        section = _section(ADDRESS_SECTION_HEADING).lower()
+        assert "separate blocks" in section
+        assert "position" in section
+
+    def test_quotes_the_run_together_line_from_the_real_document(self) -> None:
+        # Verbatim from the 2026 Peerless renewal's text layer. A worked
+        # example of the trap beats a description of it.
+        section = _section(ADDRESS_SECTION_HEADING)
+        assert "Houston, TX 770366734 Peerless St" in section
+
+
+class TestRefusingToGuess:
+    def test_an_ambiguous_address_caps_confidence_below_high(self) -> None:
+        section = _section(ADDRESS_SECTION_HEADING).lower()
+        assert "medium" in section
+        assert "confidence" in section
+
+    def test_prefers_no_address_to_a_guessed_one(self) -> None:
+        # Consistent with the prompt's governing rule: a missing value is null,
+        # never an inference. An address that might be the property is worth
+        # less than none, because nothing downstream shows it was a guess.
+        section = _section(ADDRESS_SECTION_HEADING).lower()
+        assert "use none of them" in section

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -628,6 +628,7 @@
         "frontend/src/shared/store/insurancePoliciesApi.ts",
         "frontend/src/shared/store/insuranceBenchmarksApi.ts",
         "backend/app/services/extraction/document_draft_reader.py",
+        "backend/app/services/extraction/prompts/insurance_policy_prompt.py",
         "backend/app/services/documents/document_ownership.py",
         "frontend/src/app/features/documents/",
         "frontend/src/shared/lib/document-read-errors.ts",
@@ -649,6 +650,7 @@
         "test_insurance_market_api.py",
         "test_insurance_carrier_filing_match.py",
         "test_insurance_policy_form.py",
+        "test_insurance_policy_prompt_address.py",
         "test_tdi_rate_filings_client.py",
         "test_document_draft_reader.py"
       ],


### PR DESCRIPTION
## What was wrong

The 2026 Peerless renewal names **6732** as the insured location and **6734** — the house next door, where the landlord lives — as the insured's mailing address. It extracted as 6734 at `confidence: "high"`, with every other field on the policy correct.

That is the failure worth guarding. Not a blank field or a 422, but a confident, well-formed policy filed against the wrong building — nothing downstream can tell it was wrong.

## Why it happens

Two things about how these pages come off the PDF text layer:

- **Labels and values arrive in separate blocks.** Every label first, every value after, in the same order. They have to be matched by position, not adjacency.
- **Adjacent values run together with no separator.** The real document contains the line `Houston, TX 770366734 Peerless St` — the end of the agent's address immediately followed by the start of the mailing one. Read as a single ZIP or a single street number, it yields exactly the address that shipped.

## The fix

A `# Which address` section in `insurance_policy_prompt.py` that names the insured location and the labels a dec page actually prints for it, forbids the mailing address and every intermediary's (agent, coverholder, mortgagee, loss payee), and describes both extraction traps above with the real line as a worked example.

It also refuses the guess: when more than one address appears and the insured location cannot be told with certainty, report none of them and cap `confidence` at `"medium"`. Consistent with the prompt's governing rule that a missing value is null, never an inference — an address that *might* be the property is worth less than no address.

## Verification

Against the operator's own document, through the real pipeline (pypdf text layer → live model call under `INSURANCE_POLICY_PROMPT`):

| | `policy_name` |
|---|---|
| before | `Dwelling Fire TDP-3, 6734 Peerless St, Houston, TX 77021` ❌ |
| after | `Dwelling Fire TDP-3 — 6732 Peerless St, Houston, TX 77021` ✅ |

Swept the other dec pages for over-correction — none. The three Swyfft HO-3 documents still report 6734, which is genuinely their insured location.

66 tests pass across the insurance extraction suite.

## Tests

`test_insurance_policy_prompt_address.py` pins the instruction rather than the behaviour. The prompt is a string and what it buys only shows up against a live document, so a later edit that dropped the rule would otherwise pass the entire suite unnoticed.

## Operational migration

None. Prompt text only — no env vars, no schema, no config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeNqUHKsZEa3imipsgb2AN
