### PR TITLE
fix(mybookkeeper): give a document reading a hierarchy instead of four blue boxes

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/AddUtilityPlanDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/AddUtilityPlanDialog.test.tsx
@@ -165,9 +165,12 @@ describe("AddUtilityPlanDialog — reading from a document", () => {
 
     await readTheDocument(user);
 
+    // Both live in the folded reference section now. Folded still renders —
+    // what the operator does to see it is open a disclosure, not re-read the
+    // document.
     await waitFor(() => {
       expect(
-        screen.getByText("Notes: Rate assumes autopay enrollment."),
+        screen.getByText("Rate assumes autopay enrollment."),
       ).toBeInTheDocument();
     });
     expect(

--- a/apps/mybookkeeper/frontend/src/__tests__/DocumentDraftNotices.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/DocumentDraftNotices.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * What a reading says beyond the fields it filled in, and how loudly.
+ *
+ * The panel used to render every one of these as the same blue box: the
+ * confidence line, a field that may be wrong, thirteen coverage limits, and a
+ * 1,900-character run of the reader's own prose folded into a single list item
+ * under the heading "this form has no field for them yet". Nothing was missing
+ * and nothing was legible.
+ *
+ * Two things are pinned here. Urgency: only the confidence line and the
+ * warnings — the content that decides whether the operator fixes a field before
+ * saving — stay in view, and "I wasn't very sure" no longer wears the same
+ * colour as "worth a look". And reach: folding the rest away is not dropping
+ * it, so the summary has to say how much is behind it and opening it has to
+ * produce all of it, verbatim.
+ */
+import { describe, expect, it } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import DocumentDraftNotices from "@/app/features/documents/DocumentDraftNotices";
+import type { DraftNoticeSource } from "@/app/features/documents/DocumentDraftNotices";
+
+/** Verbatim from the operator's 2026 Peerless renewal, trimmed to three paragraphs. */
+const REAL_NOTES = `Carrier is Certain Underwriters at Lloyd's of London; coverholder is Wilson Smith Group LLC. Mortgagee: Texas Dow Employees Credit Union, Loan# 240225216.
+
+Premium breakdown from dec page: Premium $2,591.00 (annual term). Fees and taxes itemised: Inspection Fee $65.00, Policy Fee $160.00, Agent Policy Fee $30.00, Surplus Lines Tax $138.03, Stamping Fee $1.14. Total fees and taxes = $394.17. Arithmetic check: $2,591.00 + $394.17 = $2,985.17 — confirmed.
+
+Co-insurance clause applies at 90%. Policy is surplus lines; 25% minimum earned premium applies.`;
+
+function source(overrides: Partial<DraftNoticeSource> = {}): DraftNoticeSource {
+  return { confidence: "high", warnings: [], unrepresented: [], ...overrides };
+}
+
+function renderNotices(
+  draft: DraftNoticeSource,
+  notes: string | null = null,
+) {
+  return render(
+    <DocumentDraftNotices draft={draft} notes={notes} testIdPrefix="policy" />,
+  );
+}
+
+function reference() {
+  return screen.getByTestId("policy-draft-reference");
+}
+
+describe("DocumentDraftNotices — how sure the reading was", () => {
+  it("congratulates a clean read", () => {
+    renderNotices(source({ confidence: "high" }));
+
+    expect(screen.getByText("I read these straight off the document.")).toBeVisible();
+  });
+
+  it("sounds a warning when it wasn't sure, not a note", () => {
+    // "Please check every field" and "worth a look" rendered in the same blue
+    // until now, which left the operator to work out which one was asking for
+    // something. Orange is the panel's word for "this needs you".
+    const { container } = renderNotices(source({ confidence: "low" }));
+
+    const box = screen.getByText(/Please check every field/);
+    expect(box).toBeVisible();
+    expect(container.querySelector(".bg-orange-50")).not.toBeNull();
+  });
+
+  it("keeps a partly-interpreted read below that", () => {
+    const { container } = renderNotices(source({ confidence: "medium" }));
+
+    expect(screen.getByText(/worth a look before you save/)).toBeVisible();
+    expect(container.querySelector(".bg-orange-50")).toBeNull();
+  });
+
+  it("treats an unrecognised confidence as the least sure", () => {
+    renderNotices(source({ confidence: "banana" }));
+
+    expect(screen.getByText(/Please check every field/)).toBeVisible();
+  });
+});
+
+describe("DocumentDraftNotices — what stays in view", () => {
+  it("shows every warning without folding it away", () => {
+    renderNotices(
+      source({
+        warnings: [
+          "I couldn't tell how often the premium is billed.",
+          "The fees didn't add up to the stated total.",
+        ],
+      }),
+    );
+
+    expect(screen.getByText(/how often the premium is billed/)).toBeVisible();
+    expect(screen.getByText(/didn't add up to the stated total/)).toBeVisible();
+    expect(screen.queryByTestId("policy-draft-reference")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing beyond the confidence line when the read was complete", () => {
+    renderNotices(source());
+
+    expect(screen.queryByTestId("policy-draft-reference")).not.toBeInTheDocument();
+  });
+});
+
+describe("DocumentDraftNotices — the folded reference section", () => {
+  it("counts the terms it is holding so folding them away isn't silence", () => {
+    renderNotices(source({ unrepresented: ["liability $300,000", "medical $5,000"] }));
+
+    expect(reference()).toHaveTextContent("I noticed 2 more terms on the document.");
+  });
+
+  it("says term, singular, when there is one", () => {
+    renderNotices(source({ unrepresented: ["liability $300,000"] }));
+
+    expect(reference()).toHaveTextContent("I noticed 1 more term on the document.");
+  });
+
+  it("mentions the notes alongside the count when both are there", () => {
+    renderNotices(source({ unrepresented: ["liability $300,000"] }), REAL_NOTES);
+
+    expect(reference()).toHaveTextContent(
+      "I noticed 1 more term on the document, plus some notes I jotted down.",
+    );
+  });
+
+  it("opens for notes alone, with no count to give", () => {
+    renderNotices(source(), REAL_NOTES);
+
+    expect(reference()).toHaveTextContent(
+      "I also jotted down some notes about this document.",
+    );
+  });
+
+  it("stays folded until the operator asks", () => {
+    // Folded, not truncated — the content below is rendered in full, and the
+    // browser reveals it on click. Nothing here is a summary of itself.
+    renderNotices(source({ unrepresented: ["liability $300,000"] }), REAL_NOTES);
+
+    expect(reference()).not.toHaveAttribute("open");
+  });
+
+  it("lists every term it counted", () => {
+    const terms = [
+      "Premises Liability (Coverage L) limit $300,000",
+      "Medical Payments (Coverage M) limit $5,000",
+      "Co-insurance clause at 90% of replacement cost value",
+    ];
+    renderNotices(source({ unrepresented: terms }));
+
+    const items = within(reference()).getAllByRole("listitem");
+    expect(items.map((item) => item.textContent)).toEqual(terms);
+  });
+});
+
+describe("DocumentDraftNotices — the reader's own notes", () => {
+  it("keeps the reader's paragraphs as paragraphs", () => {
+    // The whole point of the change. As one list item, the fee itemisation that
+    // proves the premium math sat mid-sentence in a 1,900-character block.
+    renderNotices(source(), REAL_NOTES);
+
+    const paragraphs = within(reference())
+      .getAllByText(/./, { selector: "p" })
+      .map((node) => node.textContent);
+
+    expect(paragraphs).toContain("My notes on this document:");
+    expect(paragraphs.some((text) => text?.startsWith("Carrier is Certain"))).toBe(true);
+    expect(paragraphs.some((text) => text?.startsWith("Premium breakdown"))).toBe(true);
+    expect(paragraphs.some((text) => text?.startsWith("Co-insurance clause"))).toBe(true);
+  });
+
+  it("keeps the arithmetic that reconciles premium against total", () => {
+    renderNotices(source(), REAL_NOTES);
+
+    expect(reference()).toHaveTextContent(
+      "Arithmetic check: $2,591.00 + $394.17 = $2,985.17 — confirmed.",
+    );
+  });
+
+  it("says nothing at all about notes that are only whitespace", () => {
+    renderNotices(source(), "   \n\n   ");
+
+    expect(screen.queryByTestId("policy-draft-reference")).not.toBeInTheDocument();
+  });
+
+  it("holds a single-paragraph note without splitting it", () => {
+    renderNotices(source(), "Rate assumes autopay enrollment.");
+
+    expect(reference()).toHaveTextContent("Rate assumes autopay enrollment.");
+  });
+});
+
+describe("DocumentDraftNotices — no longer apologising", () => {
+  it("does not promise a field that is never coming", () => {
+    // Notes is deliberately never auto-filled: the operator writes their own
+    // record there. "No field for them yet" promised the opposite.
+    renderNotices(source({ unrepresented: ["liability $300,000"] }), REAL_NOTES);
+
+    expect(screen.queryByText(/no field for them yet/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/don't fit anywhere/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/insurance-policy-draft.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/insurance-policy-draft.test.ts
@@ -11,10 +11,7 @@
  * field the operator knows to fill.
  */
 import { describe, it, expect } from "vitest";
-import {
-  applyDraftToForm,
-  draftFieldsTheFormCannotHold,
-} from "@/shared/lib/insurance-policy-draft";
+import { applyDraftToForm } from "@/shared/lib/insurance-policy-draft";
 import { EMPTY_POLICY_FORM } from "@/shared/lib/insurance-policy-form";
 import type { InsurancePolicyDraft } from "@/shared/types/insurance/insurance-policy-draft";
 import type { InsurancePolicyFormValues } from "@/shared/types/insurance/insurance-policy-form-values";
@@ -149,21 +146,5 @@ describe("applyDraftToForm — filling the form from a dec page", () => {
     const values = applyDraftToForm(form(), draft({ notes: "Wind/hail excluded" }));
 
     expect(values.notes).toBe("");
-  });
-});
-
-describe("draftFieldsTheFormCannotHold — what the read found but the form won't take", () => {
-  it("surfaces notes rather than dropping them on the floor", () => {
-    expect(draftFieldsTheFormCannotHold(draft({ notes: "Wind/hail excluded" }))).toEqual(
-      ["Notes: Wind/hail excluded"],
-    );
-  });
-
-  it("says nothing when the document had nothing left over", () => {
-    expect(draftFieldsTheFormCannotHold(draft({ carrier: "Texas Mutual" }))).toEqual([]);
-  });
-
-  it("treats whitespace-only notes as nothing left over", () => {
-    expect(draftFieldsTheFormCannotHold(draft({ notes: "   " }))).toEqual([]);
   });
 });

--- a/apps/mybookkeeper/frontend/src/__tests__/utility-plan-draft.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/utility-plan-draft.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  applyDraftToForm,
-  draftFieldsTheFormCannotHold,
-} from "@/shared/lib/utility-plan-draft";
+import { applyDraftToForm } from "@/shared/lib/utility-plan-draft";
 import { EMPTY_UTILITY_PLAN_FORM } from "@/shared/lib/utility-plan-form";
 import type { UtilityPlanDraft } from "@/shared/types/utility/utility-plan-draft";
 import type { UtilityPlanFormValues } from "@/shared/types/utility/utility-plan-form-values";
@@ -161,43 +158,5 @@ describe("applyDraftToForm", () => {
     expect(values.downloadMbps).toBe("1000");
     expect(values.uploadMbps).toBe("35");
     expect(values.dataCapGb).toBe("1200");
-  });
-});
-
-describe("draftFieldsTheFormCannotHold", () => {
-  it("lists what was read but has no input yet", () => {
-    expect(
-      draftFieldsTheFormCannotHold(draft({ notes: "Rate assumes autopay enrollment." })),
-    ).toEqual(["Notes: Rate assumes autopay enrollment."]);
-  });
-
-  it("says nothing when everything read fits the form", () => {
-    expect(draftFieldsTheFormCannotHold(draft({ provider_name: "Reliant" }))).toEqual([]);
-  });
-
-  /**
-   * These seven used to land here. Every one now has an input, so a document
-   * stating them fills the form instead of listing them as dropped — which is
-   * the whole point of the change, and the assertion that would catch a
-   * regression where an input is removed but the notice is not restored.
-   */
-  it("no longer reports the terms the form gained inputs for", () => {
-    expect(
-      draftFieldsTheFormCannotHold(
-        draft({
-          min_usage_fee_cents: 0,
-          min_usage_threshold_kwh: 1000,
-          post_promo_monthly_cents: 8999,
-          equipment_fee_monthly_cents: 1500,
-          download_mbps: 1000,
-          upload_mbps: 35,
-          data_cap_gb: 1200,
-        }),
-      ),
-    ).toEqual([]);
-  });
-
-  it("ignores whitespace-only notes", () => {
-    expect(draftFieldsTheFormCannotHold(draft({ notes: "   " }))).toEqual([]);
   });
 });

--- a/apps/mybookkeeper/frontend/src/app/features/documents/DocumentDraftNotices.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/DocumentDraftNotices.tsx
@@ -1,4 +1,5 @@
 import AlertBox from "@/shared/components/ui/AlertBox";
+import type { AlertVariant } from "@/shared/components/ui/AlertBox";
 
 /** The three things every draft reports beyond the fields it filled in. */
 export interface DraftNoticeSource {
@@ -9,10 +10,8 @@ export interface DraftNoticeSource {
 
 export interface DocumentDraftNoticesProps {
   draft: DraftNoticeSource;
-  /** Terms the database holds but this form does not edit yet. */
-  unheld: string[];
-  /** Names the record type, e.g. "a plan record" / "a policy record". */
-  unrepresentedLabel: string;
+  /** The reader's own written summary of the document. Never auto-filled. */
+  notes: string | null;
   /** Namespaces the test ids so each domain's specs address their own notices. */
   testIdPrefix: string;
 }
@@ -24,27 +23,66 @@ const CONFIDENCE_NOTE: Record<string, string> = {
 };
 
 /**
+ * "Check every field" is a warning, not a note.
+ *
+ * These three shared one blue box until the boxes below them stopped being blue
+ * too, and low read exactly like medium — the same tint saying "worth a look"
+ * and "I wasn't sure about any of this".
+ */
+const CONFIDENCE_VARIANT: Record<string, AlertVariant> = {
+  high: "success",
+  medium: "info",
+  low: "warning",
+};
+
+/** The document's own paragraphs, kept as paragraphs. */
+function notesParagraphs(notes: string): string[] {
+  return notes
+    .split(/\n\s*\n/)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph !== "");
+}
+
+/** What the folded section says about itself while it is still folded. */
+function referenceSummary(termCount: number, hasNotes: boolean): string {
+  const plural = termCount === 1 ? "" : "s";
+  const terms = `I noticed ${termCount} more term${plural} on the document`;
+  if (termCount > 0 && hasNotes) return `${terms}, plus some notes I jotted down.`;
+  if (termCount > 0) return `${terms}.`;
+  return "I also jotted down some notes about this document.";
+}
+
+/**
  * What the reading said beyond the fields it filled in.
  *
- * Three separate lists, because they mean different things and the operator
- * acts differently on each: ``warnings`` are fields that may be wrong,
- * ``unrepresented`` are real terms the database has no column for, and the
- * form-can't-hold list is terms the database holds but this form doesn't edit
- * yet. All three exist so nothing the document said gets dropped in silence.
+ * Split by when the operator needs it, which is the only division that changes
+ * what they do. Confidence and warnings answer "can I trust what got filled in,
+ * or must I fix something before saving" — they are the reason this panel is
+ * open, and they stay in view. Everything else is reference: real, worth
+ * keeping, but nothing above it changes because of it. The mortgagee's loan
+ * number matters the day there is a claim, not the moment before Save.
+ *
+ * So the reference half is folded away behind a count. Folded is not dropped —
+ * the summary says how much is there and one tap opens all of it, verbatim.
+ * What it stops doing is claiming the same urgency as a field that may be
+ * wrong. Every box on this panel used to be the same blue, which left the
+ * operator to work out on their own which of them was asking for something.
  */
 export default function DocumentDraftNotices({
   draft,
-  unheld,
-  unrepresentedLabel,
+  notes,
   testIdPrefix,
 }: DocumentDraftNoticesProps) {
   const note = CONFIDENCE_NOTE[draft.confidence] ?? CONFIDENCE_NOTE.low;
+  const variant = CONFIDENCE_VARIANT[draft.confidence] ?? CONFIDENCE_VARIANT.low;
+
+  const terms = draft.unrepresented;
+  const paragraphs = notes === null ? [] : notesParagraphs(notes);
+  const hasReference = terms.length > 0 || paragraphs.length > 0;
 
   return (
     <div className="space-y-2" data-testid={`${testIdPrefix}-draft-notices`}>
-      <AlertBox variant={draft.confidence === "high" ? "success" : "info"}>
-        {note}
-      </AlertBox>
+      <AlertBox variant={variant}>{note}</AlertBox>
 
       {draft.warnings.map((warning) => (
         <AlertBox key={warning} variant="warning">
@@ -52,30 +90,37 @@ export default function DocumentDraftNotices({
         </AlertBox>
       ))}
 
-      {unheld.length > 0 && (
-        <AlertBox variant="info">
-          <p className="font-medium">
-            The document also stated these, and this form has no field for them yet:
-          </p>
-          <ul className="mt-1 list-disc pl-5">
-            {unheld.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-        </AlertBox>
-      )}
+      {hasReference && (
+        <details
+          className="rounded-md border border-gray-200 bg-gray-50 p-3 text-sm dark:border-gray-800 dark:bg-gray-900/40"
+          data-testid={`${testIdPrefix}-draft-reference`}
+        >
+          <summary className="flex min-h-11 cursor-pointer items-center font-medium">
+            {referenceSummary(terms.length, paragraphs.length > 0)}
+          </summary>
 
-      {draft.unrepresented.length > 0 && (
-        <AlertBox variant="info">
-          <p className="font-medium">
-            And these terms don't fit anywhere in {unrepresentedLabel}:
-          </p>
-          <ul className="mt-1 list-disc pl-5">
-            {draft.unrepresented.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-        </AlertBox>
+          {terms.length > 0 && (
+            <div className="mt-2">
+              <p className="font-medium">Other terms from the document:</p>
+              <ul className="mt-1 list-disc pl-5">
+                {terms.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {paragraphs.length > 0 && (
+            <div className="mt-3">
+              <p className="font-medium">My notes on this document:</p>
+              <div className="mt-1 space-y-2">
+                {paragraphs.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
+            </div>
+          )}
+        </details>
       )}
     </div>
   );

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyDraftNotices.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyDraftNotices.tsx
@@ -1,5 +1,4 @@
 import DocumentDraftNotices from "@/app/features/documents/DocumentDraftNotices";
-import { draftFieldsTheFormCannotHold } from "@/shared/lib/insurance-policy-draft";
 import type { InsurancePolicyDraft } from "@/shared/types/insurance/insurance-policy-draft";
 
 export interface InsurancePolicyDraftNoticesProps {
@@ -13,8 +12,7 @@ export default function InsurancePolicyDraftNotices({
   return (
     <DocumentDraftNotices
       draft={draft}
-      unheld={draftFieldsTheFormCannotHold(draft)}
-      unrepresentedLabel="a policy record"
+      notes={draft.notes}
       testIdPrefix="insurance-policy"
     />
   );

--- a/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDraftNotices.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/UtilityPlanDraftNotices.tsx
@@ -1,5 +1,4 @@
 import DocumentDraftNotices from "@/app/features/documents/DocumentDraftNotices";
-import { draftFieldsTheFormCannotHold } from "@/shared/lib/utility-plan-draft";
 import type { UtilityPlanDraft } from "@/shared/types/utility/utility-plan-draft";
 
 export interface UtilityPlanDraftNoticesProps {
@@ -11,8 +10,7 @@ export default function UtilityPlanDraftNotices({ draft }: UtilityPlanDraftNotic
   return (
     <DocumentDraftNotices
       draft={draft}
-      unheld={draftFieldsTheFormCannotHold(draft)}
-      unrepresentedLabel="a plan record"
+      notes={draft.notes}
       testIdPrefix="utility-plan"
     />
   );

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/AlertBox.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/AlertBox.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-type AlertVariant = "info" | "warning" | "error" | "success";
+export type AlertVariant = "info" | "warning" | "error" | "success";
 
 interface AlertBoxProps {
   variant: AlertVariant;

--- a/apps/mybookkeeper/frontend/src/shared/lib/insurance-policy-draft.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/insurance-policy-draft.ts
@@ -72,22 +72,12 @@ export function applyDraftToForm(
   return { ...values, ...draftedFields(draft) };
 }
 
-/**
- * Terms the document stated that this form cannot currently hold.
+/*
+ * ``notes`` is deliberately absent from the fields above.
  *
- * Without this they would be read, returned, and silently dropped on the floor.
- * Rendered alongside the backend's own ``unrepresented`` list, which covers
- * coverages the *database* has no column for; this one covers terms the
- * database holds but this form does not yet fill.
- *
- * Down to ``notes`` alone. Every other field the reader can return has an
- * input, so the list is empty for most declarations pages — which is the point,
- * and the reason it stays: it is the seam that will catch the next column added
- * to the draft ahead of its input. Notes is deliberately last to be held: the
- * field is where the operator keeps their own record of the policy, and
- * overwriting it with a model's summary would cost them something they wrote.
+ * It is the one field the reader returns that the form must not fill: it is
+ * where the operator keeps their own record of the policy, and overwriting that
+ * with a model's summary would cost them something they wrote. It is not
+ * dropped either — ``DocumentDraftNotices`` renders it, unedited, as the
+ * reader's own account of the document.
  */
-export function draftFieldsTheFormCannotHold(draft: InsurancePolicyDraft): string[] {
-  if (draft.notes === null || draft.notes.trim() === "") return [];
-  return [`Notes: ${draft.notes.trim()}`];
-}

--- a/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-draft.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/utility-plan-draft.ts
@@ -103,22 +103,11 @@ export function applyDraftToForm(
   };
 }
 
-/**
- * Terms the document stated that this form cannot currently hold.
+/*
+ * ``notes`` is deliberately absent from the fields above.
  *
- * Without this they would be read, returned, and silently dropped on the floor.
- * Rendered alongside the backend's own ``unrepresented`` list, which covers
- * terms the *database* has no column for; this one covers terms the database
- * holds but this form does not yet edit.
- *
- * Down to ``notes`` alone. Every other field the reader can return now has an
- * input, so the list is empty for most documents — which is the point, and the
- * reason it stays: it is the seam that will catch the next column added to the
- * draft ahead of its input. Notes is deliberately last to be held. ``PATCH``
- * applies exactly the keys it is sent, and editing notes here would erase the
- * provenance line the seeded plans carry.
+ * ``PATCH`` applies exactly the keys it is sent, and filling notes here would
+ * erase the provenance line the seeded plans carry. It is not dropped either —
+ * ``DocumentDraftNotices`` renders it, unedited, as the reader's own account of
+ * the document.
  */
-export function draftFieldsTheFormCannotHold(draft: UtilityPlanDraft): string[] {
-  if (draft.notes === null || draft.notes.trim() === "") return [];
-  return [`Notes: ${draft.notes.trim()}`];
-}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -663,6 +663,7 @@
         "insurance-policy-form.test.ts",
         "insurance-policy-draft.test.ts",
         "AddInsurancePolicyDialog.test.tsx",
+        "DocumentDraftNotices.test.tsx",
         "InsurancePolicyDocumentReader.test.tsx",
         "usePageListModes.test.ts",
         "InsurancePremiumComparisonCard.test.tsx",
@@ -770,6 +771,7 @@
       "frontend_tests": [
         "UtilityPlans.test.tsx",
         "AddUtilityPlanDialog.test.tsx",
+        "DocumentDraftNotices.test.tsx",
         "UtilityPlanDocumentReader.test.tsx",
         "EditUtilityPlanDialog.test.tsx",
         "UtilityPlanRenewalAlertCard.test.tsx",


### PR DESCRIPTION
## What was wrong

Below a read declarations page, everything the reading found rendered in the same blue box: the confidence line, a field that might be wrong, thirteen coverage limits, and — as a single `<li>` — a 1,900-character run of the reader's own prose. The heading over that last one read **"The document also stated these, and this form has no field for them yet."**

Three separate problems:

1. **No urgency hierarchy.** The only content that changes what the operator does *before Save* is "can I trust what got filled in". It carried exactly as much visual weight as a mortgagee's loan number.
2. **No structure inside the prose.** On your 6732 Peerless renewal, the itemisation proving $2,591.00 premium + $394.17 fees = $2,985.17 total sat mid-paragraph inside an unbroken block.
3. **The heading apologised for a field that is never coming.** `notes` is the one thing the form deliberately must not fill — it's where you keep your own record of the policy, and a model's summary would overwrite something you wrote. "Yet" promised the opposite.

Plus: `medium` and `low` confidence both rendered blue, so *"I wasn't very sure — please check every field"* read exactly like *"worth a look"*.

## The design

Split by **when** the operator needs it, which is the only division that changes behaviour.

| | |
|---|---|
| Confidence line | stays in view — `high` green, `medium` blue, **`low` now orange** |
| Warnings | stay in view, unchanged (already deterministic, backend-computed) |
| Everything else | folds into **one** neutral disclosure |

The folded summary states a concrete count — *"I noticed 12 more terms on the document, plus some notes I jotted down."* — and opens to two labelled sections: **"Other terms from the document:"** and **"My notes on this document:"**. Notes keep whatever paragraphs the reader wrote them in.

Folding is not dropping. The count is concrete and one tap gives all of it, verbatim — that satisfies the panel's founding constraint that nothing the document stated disappears in silence. What it stops doing is claiming the same urgency as a field that may be wrong.

Reuses the shipped `<details>`/`<summary>` pattern from `OfferDisclosure.tsx`; no new primitive. Summary is `min-h-11` for touch.

## Departure from the design pass

The pass recommended keeping `draftFieldsTheFormCannotHold` as a seam for a future non-notes field. With `notes` moved to its own typed prop, that function returns `[]` for every possible input — a seam that provably never fires is dead code, not future-proofing, and the project's own rule is to remove it. Deleted, along with its three now-vacuous tests. The comment explaining *why* notes is not auto-filled stays in the module where the decision actually lives.

## Verification

Real path, not only jsdom: uploaded your `Renewal Policy - 2026 - 6732 Peerless St.pdf` through the actual dialog on a local dev server, let it do a live read, and expanded the disclosure.

Incidentally confirmed the address fix was needed — the dev backend is running `c480d409`, which predates #1095, and it reported the policy as **6734** Peerless. That's the original bug reproducing on the pre-fix prompt, not a regression.

Test document deleted afterward; no policy was saved.

54 frontend tests pass across the five affected specs. `npm run build` clean.

## Follow-ups this surfaced (not in this PR)

Both are prompt-side content fixes, one file, and neither blocks this:

- `unrepresented` carries reader *failures* alongside real terms — "Other Structures coverage limit not legible on the document" is a warning, not a policy term. The frontend can't classify that from the string without keyword-matching model phrasing, so it belongs in the prompt: redirect to `notes` + cap `confidence`, mirroring the instruction already there for arithmetic mismatches.
- `notes` and `unrepresented` duplicate each other (mortgagee, co-insurance, inflation guard, the AOP derivation all appear in both).

## Operational migration

None. Frontend only — no env vars, no schema, no config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeNqUHKsZEa3imipsgb2AN
