### PR TITLE
fix(mybookkeeper): 500 when reclassifying a rental as a home you live in

### DIFF
--- a/apps/mybookkeeper/backend/app/models/properties/property.py
+++ b/apps/mybookkeeper/backend/app/models/properties/property.py
@@ -20,6 +20,29 @@ class PropertyType(str, enum.Enum):
     LONG_TERM = "long_term"
 
 
+def reconcile_type(
+    classification: PropertyClassification, type: PropertyType | None,
+) -> PropertyType | None:
+    """Return the rental ``type`` that ``classification`` allows.
+
+    Mirrors ``chk_prop_classification_type`` below: a rental type only means
+    something on an investment property, so the two columns have to move
+    together. Every write path goes through here, because the database rejects a
+    mismatched pair with an ``IntegrityError`` that surfaces as a 500 rather than
+    anything the caller can act on — and a PATCH that changes only
+    ``classification`` leaves the stored ``type`` behind unless something
+    reconciles it.
+    """
+    if classification is PropertyClassification.INVESTMENT:
+        return type or PropertyType.SHORT_TERM
+    if classification in (
+        PropertyClassification.PRIMARY_RESIDENCE,
+        PropertyClassification.SECOND_HOME,
+    ):
+        return None
+    return type
+
+
 class Property(Base):
     __tablename__ = "properties"
 

--- a/apps/mybookkeeper/backend/app/models/requests/property_create.py
+++ b/apps/mybookkeeper/backend/app/models/requests/property_create.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import BaseModel, model_validator
 
-from app.models.properties.property import PropertyType
+from app.models.properties.property import PropertyType, reconcile_type
 from app.models.properties.property_classification import PropertyClassification
 
 
@@ -14,8 +14,5 @@ class PropertyCreate(BaseModel):
 
     @model_validator(mode="after")
     def validate_classification_type(self) -> "PropertyCreate":
-        if self.classification == PropertyClassification.INVESTMENT and self.type is None:
-            self.type = PropertyType.SHORT_TERM
-        if self.classification in (PropertyClassification.PRIMARY_RESIDENCE, PropertyClassification.SECOND_HOME):
-            self.type = None
+        self.type = reconcile_type(self.classification, self.type)
         return self

--- a/apps/mybookkeeper/backend/app/services/properties/property_service.py
+++ b/apps/mybookkeeper/backend/app/services/properties/property_service.py
@@ -3,7 +3,7 @@ import uuid
 
 from app.core.context import RequestContext
 from app.db.session import AsyncSessionLocal, unit_of_work
-from app.models.properties.property import Property, PropertyType
+from app.models.properties.property import Property, PropertyType, reconcile_type
 from app.models.properties.property_classification import PropertyClassification
 from app.repositories import activity_repo, property_repo, tax_return_repo
 
@@ -77,6 +77,13 @@ async def update_property(
             if field not in UPDATABLE_FIELDS:
                 raise ValueError(f"Cannot update field: {field}")
             setattr(prop, field, value)
+
+        # A PATCH that only moves classification leaves the old rental type in
+        # place, which the chk_prop_classification_type constraint rejects. The
+        # invariant belongs here rather than in the request model: only this
+        # layer sees the merged row, and callers cannot send a null type through
+        # a PATCH that drops nulls.
+        prop.type = reconcile_type(prop.classification, prop.type)
 
         # Cascade: when classification changes, update linked Activity and flag recompute
         new_classification = prop.classification

--- a/apps/mybookkeeper/backend/tests/test_property_classification_type.py
+++ b/apps/mybookkeeper/backend/tests/test_property_classification_type.py
@@ -1,0 +1,60 @@
+"""The classification/type invariant that ``chk_prop_classification_type`` enforces.
+
+Reclassifying a short-term rental as a primary residence used to return a 500
+from ``PATCH /properties/{id}``: the request carried a new classification but no
+``type``, the service wrote it straight through, and the database rejected the
+``(PRIMARY_RESIDENCE, SHORT_TERM)`` pair. These tests pin the reconciliation so
+the constraint stays unreachable from the API.
+"""
+
+import pytest
+
+from app.models.properties.property import PropertyType, reconcile_type
+from app.models.properties.property_classification import PropertyClassification
+from app.models.requests.property_create import PropertyCreate
+
+INVESTMENT = PropertyClassification.INVESTMENT
+PRIMARY = PropertyClassification.PRIMARY_RESIDENCE
+SECOND_HOME = PropertyClassification.SECOND_HOME
+UNCLASSIFIED = PropertyClassification.UNCLASSIFIED
+
+SHORT_TERM = PropertyType.SHORT_TERM
+LONG_TERM = PropertyType.LONG_TERM
+
+
+@pytest.mark.parametrize("stale_type", [SHORT_TERM, LONG_TERM, None])
+@pytest.mark.parametrize("personal", [PRIMARY, SECOND_HOME])
+def test_personal_classifications_clear_the_rental_type(personal, stale_type):
+    """A home you live in has no rental type, whatever was stored before."""
+    assert reconcile_type(personal, stale_type) is None
+
+
+def test_investment_keeps_an_explicit_rental_type():
+    assert reconcile_type(INVESTMENT, LONG_TERM) is LONG_TERM
+
+
+def test_investment_without_a_type_falls_back_to_short_term():
+    """The constraint requires a non-null type, so one has to be chosen."""
+    assert reconcile_type(INVESTMENT, None) is SHORT_TERM
+
+
+@pytest.mark.parametrize("any_type", [SHORT_TERM, LONG_TERM, None])
+def test_unclassified_is_left_alone(any_type):
+    """The constraint permits either, so an unclassified row keeps what it had."""
+    assert reconcile_type(UNCLASSIFIED, any_type) is any_type
+
+
+def test_create_request_still_reconciles():
+    """PropertyCreate delegates to the same rule rather than repeating it."""
+    created = PropertyCreate(
+        name="6734 Peerless", address="6734 Peerless St", classification=PRIMARY,
+        type=SHORT_TERM,
+    )
+    assert created.type is None
+
+
+def test_create_request_defaults_an_investment_type():
+    created = PropertyCreate(
+        name="6738 Peerless", address="6738 Peerless St", classification=INVESTMENT,
+    )
+    assert created.type is SHORT_TERM

--- a/apps/mybookkeeper/backend/tests/test_property_service_reclassify.py
+++ b/apps/mybookkeeper/backend/tests/test_property_service_reclassify.py
@@ -1,0 +1,167 @@
+"""``property_service.update_property`` against a real row and a real constraint.
+
+The 500 this covers only reproduces end-to-end: the helper unit tests in
+``test_property_classification_type.py`` pass a matched pair in by hand, whereas
+the bug was that the *stored* ``type`` survived a classification-only PATCH.
+Reclassifying a short-term rental as a primary residence therefore has to be
+exercised against a row the database actually rejects.
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.context import worker_context
+from app.models.properties.property import Property, PropertyType
+from app.models.properties.property_classification import PropertyClassification
+from app.services.properties import property_service
+
+
+def _make_fake_uow(session: AsyncSession):
+    @asynccontextmanager
+    async def _fake_uow():
+        yield session
+
+    return _fake_uow
+
+
+def _rental(org_id: uuid.UUID, user_id: uuid.UUID) -> Property:
+    """A short-term rental — the shape every Peerless property started as."""
+    return Property(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        name="6734 Peerless St, Houston, TX 77021",
+        address="6734 Peerless St, Houston, TX 77021",
+        classification=PropertyClassification.INVESTMENT,
+        type=PropertyType.SHORT_TERM,
+    )
+
+
+async def _reclassify(
+    db: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID, prop_id: uuid.UUID,
+    updates: dict,
+) -> Property | None:
+    ctx = worker_context(organization_id=org_id, user_id=user_id)
+    with patch(
+        "app.services.properties.property_service.unit_of_work",
+        _make_fake_uow(db),
+    ):
+        return await property_service.update_property(ctx, prop_id, updates)
+
+
+@pytest.mark.asyncio
+async def test_rental_to_primary_residence_clears_the_rental_type(db: AsyncSession):
+    """The regression: the PATCH carries no ``type``, so the stored one must go.
+
+    Without the reconciliation the flush raises IntegrityError against
+    ``chk_prop_classification_type`` and the endpoint returns a 500.
+    """
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = _rental(org_id, user_id)
+    db.add(prop)
+    await db.flush()
+
+    result = await _reclassify(
+        db, org_id, user_id, prop.id,
+        {"classification": PropertyClassification.PRIMARY_RESIDENCE},
+    )
+    assert result is not None
+    await db.flush()
+
+    stored = (
+        await db.execute(select(Property).where(Property.id == prop.id))
+    ).scalar_one()
+    assert stored.classification is PropertyClassification.PRIMARY_RESIDENCE
+    assert stored.type is None
+
+
+@pytest.mark.asyncio
+async def test_rental_to_second_home_clears_the_rental_type(db: AsyncSession):
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = _rental(org_id, user_id)
+    db.add(prop)
+    await db.flush()
+
+    await _reclassify(
+        db, org_id, user_id, prop.id,
+        {"classification": PropertyClassification.SECOND_HOME},
+    )
+    await db.flush()
+
+    stored = (
+        await db.execute(select(Property).where(Property.id == prop.id))
+    ).scalar_one()
+    assert stored.type is None
+
+
+@pytest.mark.asyncio
+async def test_primary_residence_back_to_investment_regains_a_type(db: AsyncSession):
+    """The constraint needs a non-null type going the other way, too."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = Property(
+        id=uuid.uuid4(), organization_id=org_id, user_id=user_id,
+        name="6734 Peerless", address="6734 Peerless St",
+        classification=PropertyClassification.PRIMARY_RESIDENCE, type=None,
+    )
+    db.add(prop)
+    await db.flush()
+
+    await _reclassify(
+        db, org_id, user_id, prop.id,
+        {"classification": PropertyClassification.INVESTMENT},
+    )
+    await db.flush()
+
+    stored = (
+        await db.execute(select(Property).where(Property.id == prop.id))
+    ).scalar_one()
+    assert stored.classification is PropertyClassification.INVESTMENT
+    assert stored.type is PropertyType.SHORT_TERM
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_rental_type_is_still_honoured(db: AsyncSession):
+    """Reconciling must not trample a type the caller actually sent."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = _rental(org_id, user_id)
+    db.add(prop)
+    await db.flush()
+
+    await _reclassify(
+        db, org_id, user_id, prop.id,
+        {
+            "classification": PropertyClassification.INVESTMENT,
+            "type": PropertyType.LONG_TERM,
+        },
+    )
+    await db.flush()
+
+    stored = (
+        await db.execute(select(Property).where(Property.id == prop.id))
+    ).scalar_one()
+    assert stored.type is PropertyType.LONG_TERM
+
+
+@pytest.mark.asyncio
+async def test_unrelated_edits_leave_the_rental_type_alone(db: AsyncSession):
+    """Renaming a rental must not quietly reshape its classification pair."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = _rental(org_id, user_id)
+    db.add(prop)
+    await db.flush()
+
+    await _reclassify(db, org_id, user_id, prop.id, {"name": "6734 Peerless (unit A)"})
+    await db.flush()
+
+    stored = (
+        await db.execute(select(Property).where(Property.id == prop.id))
+    ).scalar_one()
+    assert stored.name == "6734 Peerless (unit A)"
+    assert stored.classification is PropertyClassification.INVESTMENT
+    assert stored.type is PropertyType.SHORT_TERM

--- a/apps/mybookkeeper/frontend/src/__tests__/PropertyEditCard.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/PropertyEditCard.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { store } from "@/shared/store";
+import PropertyEditCard from "@/app/features/properties/PropertyEditCard";
+import type { Property } from "@/shared/types/property/property";
+
+const rental: Property = {
+  id: "prop-1",
+  name: "6734 Peerless St, Houston, TX 77021",
+  address: "6734 Peerless St, Houston, TX 77021",
+  classification: "investment",
+  type: "short_term",
+  is_active: true,
+  activity_periods: [],
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const updateProperty = vi.fn();
+const showError = vi.fn();
+const showSuccess = vi.fn();
+
+vi.mock("@/shared/store/propertiesApi", () => ({
+  useUpdatePropertyMutation: vi.fn(() => [updateProperty, { isLoading: false }]),
+}));
+
+vi.mock("@/shared/hooks/useToast", () => ({
+  useToast: vi.fn(() => ({ showError, showSuccess })),
+}));
+
+function renderCard(onDone = vi.fn()) {
+  return render(
+    <Provider store={store}>
+      <PropertyEditCard property={rental} onDone={onDone} />
+    </Provider>,
+  );
+}
+
+describe("PropertyEditCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateProperty.mockReturnValue({ unwrap: () => Promise.resolve(rental) });
+  });
+
+  it("drops the rental type when the property becomes a primary residence", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(screen.getByText("Primary Residence"));
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(updateProperty).toHaveBeenCalled());
+    const sent = updateProperty.mock.calls[0][0];
+    expect(sent.data.classification).toBe("primary_residence");
+    expect(sent.data).not.toHaveProperty("type");
+  });
+
+  it("hides the rental type picker once the home is not a rental", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    expect(screen.getByText("Rental type")).toBeInTheDocument();
+    await user.click(screen.getByText("Primary Residence"));
+    expect(screen.queryByText("Rental type")).not.toBeInTheDocument();
+  });
+
+  it("keeps the rental type when the property stays an investment", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(updateProperty).toHaveBeenCalled());
+    expect(updateProperty.mock.calls[0][0].data.type).toBe("short_term");
+  });
+
+  it("closes and confirms the save when the update succeeds", async () => {
+    const user = userEvent.setup();
+    const onDone = vi.fn();
+    renderCard(onDone);
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(onDone).toHaveBeenCalled());
+    expect(showSuccess).toHaveBeenCalledWith("Property updated");
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a failed save instead of leaving the card silently open", async () => {
+    // The reclassify 500 rejected here and nothing was rendered, so the card
+    // just sat there and the user had no idea the save had failed.
+    updateProperty.mockReturnValue({
+      unwrap: () => Promise.reject({ data: { detail: "Server error" } }),
+    });
+    const user = userEvent.setup();
+    const onDone = vi.fn();
+    renderCard(onDone);
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(showError).toHaveBeenCalled());
+    expect(showError.mock.calls[0][0]).toContain("Server error");
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/properties/PropertyEditCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/properties/PropertyEditCard.tsx
@@ -4,6 +4,8 @@ import type { Property } from "@/shared/types/property/property";
 import type { PropertyForm } from "@/shared/types/property/property-form";
 import type { PropertyClassification } from "@/shared/types/property/property-classification";
 import { CLASSIFICATION_OPTIONS } from "@/shared/lib/property-labels";
+import { useToast } from "@/shared/hooks/useToast";
+import { extractErrorMessage } from "@/shared/utils/errorMessage";
 import { Button, LoadingButton } from "@platform/ui";
 import Select from "@/shared/components/ui/Select";
 import TilePicker from "@/shared/components/ui/TilePicker";
@@ -19,6 +21,7 @@ export interface PropertyEditCardProps {
 export default function PropertyEditCard({ property, onDone }: PropertyEditCardProps) {
   const [form, setForm] = useState<PropertyForm>(() => fromProperty(property));
   const [updateProperty, { isLoading }] = useUpdatePropertyMutation();
+  const { showSuccess, showError } = useToast();
 
   function setField(field: keyof PropertyForm, value: string | null) {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -45,7 +48,11 @@ export default function PropertyEditCard({ property, onDone }: PropertyEditCardP
       },
     })
       .unwrap()
-      .then(onDone);
+      .then(() => {
+        showSuccess("Property updated");
+        onDone();
+      })
+      .catch((err) => showError(extractErrorMessage(err)));
   }
 
   return (

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -305,22 +305,27 @@
     "properties": {
       "source_paths": [
         "backend/app/models/properties/",
+        "backend/app/models/requests/property_create.py",
+        "backend/app/models/requests/property_update.py",
         "backend/app/repositories/properties/",
         "backend/app/services/properties/",
         "backend/app/schemas/properties/",
         "backend/app/api/properties.py",
         "backend/alembic/versions/utillink260624_add_utility_account_links.py",
-        "frontend/src/pages/Properties.tsx",
-        "frontend/src/features/properties/"
+        "frontend/src/app/pages/Properties.tsx",
+        "frontend/src/app/features/properties/"
       ],
       "backend_tests": [
         "test_property_duplicate.py",
+        "test_property_classification_type.py",
+        "test_property_service_reclassify.py",
         "test_utility_account_link_repo.py",
         "test_utility_account_service.py",
         "test_property_matcher_account_link.py"
       ],
       "frontend_tests": [
-        "Properties.test.tsx"
+        "Properties.test.tsx",
+        "PropertyEditCard.test.tsx"
       ],
       "e2e_specs": [
         "properties.spec.ts"


### PR DESCRIPTION
## What broke

Marking a property as **Primary Residence** when it was recorded as an Investment returned a **500** from `PATCH /properties/{id}`. The edit card gave no sign anything had gone wrong — it stayed open, so the change read as ignored rather than broken. Hit while recording real mortgages against the new `/mortgages` page: the rate comparison prices a loan differently depending on whether you live in the property, so this is on the path to a correct answer, not a cosmetic setting.

## Why

Three things lined up:

1. `PropertyEditCard` omits `type` entirely once the property stops being a rental — it literally cannot ask the backend to clear it.
2. The route does `model_dump(exclude_none=True)`, so a null `type` would be dropped anyway.
3. `update_property` wrote the new classification straight onto the row.

The stored `short_term` survived, and Postgres rejected the resulting `(PRIMARY_RESIDENCE, SHORT_TERM)` pair against `chk_prop_classification_type`. The `IntegrityError` surfaced as an unhandled 500.

`PropertyCreate` already carried this exact rule as a `model_validator` — the create path was protected and the update path never was.

## The fix

`reconcile_type` now sits beside the constraint it mirrors in `property.py`, and **both** write paths go through it:

- `PropertyCreate` delegates instead of repeating the rule inline.
- `update_property` applies it after merging the patch — the only layer that sees the finished row, and the only one that can correct a classification-only edit.

The constraint is no longer reachable from the API, for any caller — including the occupancy fixer on the mortgages page and any future client.

`PropertyEditCard` also gained the `.catch()` that every other mutation on the Properties page already had, so a failed save surfaces instead of failing silently.

## Tests

- `test_property_service_reclassify.py` — 5 tests against a **real row and a real constraint**. Removing the reconciliation reproduces the exact production error: `CHECK constraint failed: chk_prop_classification_type`. Verified by temporarily reverting the fix.
- `test_property_classification_type.py` — 13 tests pinning the invariant in both directions, including that `unclassified` is left alone and that an explicitly-sent type is never trampled.
- `PropertyEditCard.test.tsx` — 5 tests, including the silent-failure case.

`test-map.json`'s properties entry pointed at `frontend/src/pages/` and `frontend/src/features/`, but these files live under `src/app/`. None of this would have been picked up by the targeted runner; corrected alongside.

## Verification

- 89 backend property tests pass
- 35 frontend property tests pass
- `tsc -b` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)