### PR TITLE
chore(deps): add Dependabot coverage for mygamingassistant + mypizzatracker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -152,3 +152,79 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 3
     labels: ["dependencies", "docker", "myrecipes"]
+
+  # MyGamingAssistant
+  #
+  # No fastapi ignore here (unlike mybookkeeper / myjobhunter): the < 0.137 hold
+  # exists for those two apps' route-introspection tests, which mga does not
+  # have. myrecipes already runs fastapi 0.141.1 green, so the hold is
+  # app-specific, not cross-app. If a >= 0.137 bump ever reds mga's CI, add an
+  # ignore block then rather than pre-emptively freezing it here.
+  - package-ecosystem: "pip"
+    directory: "/apps/mygamingassistant/backend"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "python", "mygamingassistant"]
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "npm"
+    directory: "/apps/mygamingassistant/frontend"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "npm", "mygamingassistant"]
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      # @types/node must track the Node runtime, not leap ahead. Major bumps
+      # (e.g. 25 -> 26) desync the lock / break tsc against the version we
+      # actually run. Allow minor+patch; hold majors until the runtime moves.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "docker"
+    directory: "/apps/mygamingassistant"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    labels: ["dependencies", "docker", "mygamingassistant"]
+
+  # MyPizzaTracker
+  #
+  # No fastapi ignore — same reasoning as mygamingassistant above.
+  - package-ecosystem: "pip"
+    directory: "/apps/mypizzatracker/backend"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "python", "mypizzatracker"]
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "npm"
+    directory: "/apps/mypizzatracker/frontend"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "npm", "mypizzatracker"]
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      # @types/node must track the Node runtime, not leap ahead. Major bumps
+      # (e.g. 25 -> 26) desync the lock / break tsc against the version we
+      # actually run. Allow minor+patch; hold majors until the runtime moves.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "docker"
+    directory: "/apps/mypizzatracker"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    labels: ["dependencies", "docker", "mypizzatracker"]


### PR DESCRIPTION
## The gap

`mygamingassistant` and `mypizzatracker` had **zero Dependabot coverage** — no `pip`, no `npm`, no `docker` — despite having all three manifests since they were scaffolded.

Neither app has ever been offered a security update for its backend Python dependencies, its frontend npm dependencies, or its Docker base images.

## How it surfaced

The 2026-08-17/18 backlog sweep. The 12 held frontend-major PRs covered only **4 of 6** npm workspaces — Dependabot simply did not know mga and mpt existed. That also made them a standing source of root-lockfile desync: this monorepo has a single root `package-lock.json`, so every frontend bump that skipped them left the lock inconsistent.

## What this adds

Six entries, matching the existing per-app blocks exactly:

| ecosystem | directory |
|---|---|
| `pip` | `/apps/mygamingassistant/backend` |
| `npm` | `/apps/mygamingassistant/frontend` |
| `docker` | `/apps/mygamingassistant` |
| `pip` | `/apps/mypizzatracker/backend` |
| `npm` | `/apps/mypizzatracker/frontend` |
| `docker` | `/apps/mypizzatracker` |

Coverage is now complete — 5 apps × (pip, npm, docker) + shared-backend + shared-frontend + github-actions = **18 entries**.

## Two deliberate choices

**No `fastapi` ignore for either app.** The `< 0.137` hold exists for mybookkeeper and myjobhunter, whose route-introspection tests break on 0.137's `_IncludedRouter` refactor. mga and mpt don't have those tests — and **`myrecipes` already runs `fastapi==0.141.1` green with no ignore rule at all**, which is direct evidence the hold is app-specific rather than cross-app. Pre-emptively freezing two more apps a minor behind on an assumption isn't warranted; if a `>=0.137` bump ever reds their CI, add the ignore then.

**`@types/node` major ignore IS included**, matching all four existing npm blocks. Both apps pin `^25.6.0`, same as the others.

## Expect a burst

These two apps are catching up on everything at once, so the first Dependabot run will open more PRs than a normal cycle. `minor`/`patch` grouping plus the 5/5/3 per-ecosystem limits keep it bounded.

## Verification

`.github/dependabot.yml` parses clean and yields the 18 expected entries:

```
$ python -c "import yaml,io; d=yaml.safe_load(io.open('.github/dependabot.yml',encoding='utf-8')); ..."
YAML valid. updates entries: 18
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5U5LnLXRKNYmoD6wDTrrT