### PR TITLE
fix(ci): report required contexts on PRs that don't touch mybookkeeper/myjobhunter

### DIFF
--- a/.github/workflows/ci-mybookkeeper.yml
+++ b/.github/workflows/ci-mybookkeeper.yml
@@ -3,12 +3,6 @@ name: MyBookkeeper CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'apps/mybookkeeper/**'
-      - 'packages/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/ci-mybookkeeper.yml'
   push:
     branches: [main]
     paths:
@@ -26,7 +20,82 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Path filtering lives HERE, at the job level — NOT in `on.pull_request.paths`.
+  #
+  # Several of this workflow's checks are REQUIRED status checks on main. A
+  # `pull_request` workflow skipped by a top-level `paths:` filter never reports
+  # its check contexts at all, so every PR that did not touch mybookkeeper hung forever
+  # on "Expected — Waiting for status to be reported" and could only be landed
+  # with `gh pr merge --admin`. (Same failure mode documented at length in
+  # ci-shared-backend.yml, which solves it by always running its ~5s suite. This
+  # workflow is far too heavy for that, so it skips at the job level instead.)
+  #
+  # A job skipped by an `if:` condition reports SUCCESS to required status
+  # checks, whereas a workflow skipped by a path filter reports nothing at all.
+  # That difference is the entire fix. The `paths:` filter is deliberately KEPT
+  # on `push` — main builds do not need to report contexts.
+  #
+  # DO NOT re-add `paths:` under `on.pull_request`.
+  #
+  # The gate below is `!cancelled() && ... != 'false'`, NOT `== 'true'`.
+  # A plain `needs: changes` would skip every dependent job if the gate job
+  # itself failed — and a skipped job reports SUCCESS, which would let a PR
+  # merge with no tests run at all. This form inverts that: work is skipped
+  # only on an explicit `false`, so any failure of the gate runs everything.
+  changes:
+    name: changes / mybookkeeper
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes relevant to mybookkeeper
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -uo pipefail
+          # Non-PR events (push to main) still carry the `paths:` filter below,
+          # so if we are running at all the change is relevant by definition.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Three-dot semantics: only what THIS PR changed, ignoring commits
+          # that landed on main after it branched.
+          MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")" || MERGE_BASE=""
+          if [ -z "$MERGE_BASE" ]; then
+            echo "::warning::Could not compute merge base; running the full suite."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! FILES="$(git diff --name-only "$MERGE_BASE" "$HEAD_SHA")"; then
+            echo "::warning::Could not diff; running the full suite."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::group::changed files"
+          echo "$FILES"
+          echo "::endgroup::"
+          # Mirrors the `paths:` filter still applied to `push` below. Every
+          # failure path above falls back to relevant=true — this gate may only
+          # ever skip work it is certain is unrelated.
+          if echo "$FILES" | grep -qE '^(apps/mybookkeeper/|packages/|package\.json$|package-lock\.json$|\.github/workflows/ci-mybookkeeper\.yml$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   backend-deps-resolve:
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.relevant != 'false' }}
     name: backend-deps-resolve / mybookkeeper
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -54,6 +123,8 @@ jobs:
         run: uv sync --frozen
 
   backend-tests:
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.relevant != 'false' }}
     name: backend-tests / mybookkeeper
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -103,6 +174,8 @@ jobs:
         run: uv run pytest -q -m "not integration" -n auto
 
   frontend-build:
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.relevant != 'false' }}
     name: frontend-build / mybookkeeper
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -141,6 +214,8 @@ jobs:
   # already validates the workspace lockfile resolves cleanly.
 
   frontend-layout-e2e:
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.relevant != 'false' }}
     name: frontend-layout-e2e / mybookkeeper
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci-myjobhunter.yml
+++ b/.github/workflows/ci-myjobhunter.yml
@@ -3,12 +3,6 @@ name: MyJobHunter CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'apps/myjobhunter/**'
-      - 'packages/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/ci-myjobhunter.yml'
   push:
     branches: [main]
     paths:
@@ -26,7 +20,82 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Path filtering lives HERE, at the job level — NOT in `on.pull_request.paths`.
+  #
+  # Several of this workflow's checks are REQUIRED status checks on main. A
+  # `pull_request` workflow skipped by a top-level `paths:` filter never reports
+  # its check contexts at all, so every PR that did not touch myjobhunter hung forever
+  # on "Expected — Waiting for status to be reported" and could only be landed
+  # with `gh pr merge --admin`. (Same failure mode documented at length in
+  # ci-shared-backend.yml, which solves it by always running its ~5s suite. This
+  # workflow is far too heavy for that, so it skips at the job level instead.)
+  #
+  # A job skipped by an `if:` condition reports SUCCESS to required status
+  # checks, whereas a workflow skipped by a path filter reports nothing at all.
+  # That difference is the entire fix. The `paths:` filter is deliberately KEPT
+  # on `push` — main builds do not need to report contexts.
+  #
+  # DO NOT re-add `paths:` under `on.pull_request`.
+  #
+  # The gate below is `!cancelled() && ... != 'false'`, NOT `== 'true'`.
+  # A plain `needs: changes` would skip every dependent job if the gate job
+  # itself failed — and a skipped job reports SUCCESS, which would let a PR
+  # merge with no tests run at all. This form inverts that: work is skipped
+  # only on an explicit `false`, so any failure of the gate runs everything.
+  changes:
+    name: changes / myjobhunter
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes relevant to myjobhunter
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -uo pipefail
+          # Non-PR events (push to main) still carry the `paths:` filter below,
+          # so if we are running at all the change is relevant by definition.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Three-dot semantics: only what THIS PR changed, ignoring commits
+          # that landed on main after it branched.
+          MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")" || MERGE_BASE=""
+          if [ -z "$MERGE_BASE" ]; then
+            echo "::warning::Could not compute merge base; running the full suite."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! FILES="$(git diff --name-only "$MERGE_BASE" "$HEAD_SHA")"; then
+            echo "::warning::Could not diff; running the full suite."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::group::changed files"
+          echo "$FILES"
+          echo "::endgroup::"
+          # Mirrors the `paths:` filter still applied to `push` below. Every
+          # failure path above falls back to relevant=true — this gate may only
+          # ever skip work it is certain is unrelated.
+          if echo "$FILES" | grep -qE '^(apps/myjobhunter/|packages/|package\.json$|package-lock\.json$|\.github/workflows/ci-myjobhunter\.yml$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   backend-deps-resolve:
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.relevant != 'false' }}
     name: backend-deps-resolve / myjobhunter
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -48,6 +117,8 @@ jobs:
           pip install -r requirements.txt
 
   backend-tests:
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.relevant != 'false' }}
     name: backend-tests / myjobhunter / ${{ matrix.shard.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -181,6 +252,8 @@ jobs:
         run: python -m pytest -q --timeout=60 ${{ matrix.shard.paths }}
 
   frontend-build:
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.relevant != 'false' }}
     name: frontend-build / myjobhunter
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -203,6 +276,8 @@ jobs:
         run: npm run build --workspace=myjobhunter-frontend
 
   caddy-image:
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.relevant != 'false' }}
     name: caddy-image / myjobhunter
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## The bug

Ten of the eleven required status checks on `main` live in `ci-mybookkeeper.yml` and `ci-myjobhunter.yml`, and both workflows were filtered by `on.pull_request.paths`.

**A `pull_request` workflow skipped by a path filter never reports its check contexts at all.** So every PR that didn't touch mybookkeeper or myjobhunter sat permanently `BLOCKED` on *"Expected — Waiting for status to be reported"*, no matter how green it actually was.

That's why `gh pr merge --admin` became the habitual — and only — way to land anything scoped to mygamingassistant, mypizzatracker, or myrecipes. Admin merge bypasses required checks, which also masked the problem for months.

## Reproduced

PR #1109 touches only `.github/dependabot.yml`, which is in no app's filter:

```
mergeState: BLOCKED   review: REVIEW_REQUIRED
required contexts reporting: 1 of 11   (only shared-backend-tests)
```

## The fix

`ci-shared-backend.yml` already documents this exact failure mode in a 15-line header and solves it by never filtering — it runs a ~5s suite on every PR. These two workflows are far heavier (myjobhunter alone is 5 test shards plus a 10-minute e2e), so they move the filter to the **job** level instead.

> A job skipped by an `if:` condition reports **SUCCESS** to required status checks. A workflow skipped by a path filter reports **nothing**.

That difference is the entire fix.

- `paths:` removed from `on.pull_request` — **kept** on `push`, since main builds don't need to report contexts
- new `changes` job diffs the PR against its merge base and mirrors the old filter exactly
- all 8 real jobs gated on its output

## The gate is deliberately not `== 'true'`

```yaml
if: ${{ !cancelled() && needs.changes.outputs.relevant != 'false' }}
```

With a plain `needs: changes`, a **failure** of the gate job would skip every dependent job — and a skipped job reports SUCCESS. That would let a PR merge having run no tests whatsoever, which is a strictly worse bug than the one being fixed.

Inverting the condition means work is skipped only on an explicit `false`, so any failure of the gate itself runs the full suite. Every error path inside the gate (no merge base, diff failure) also falls back to `relevant=true`.

## Verification

Filter pattern tested against 12 representative paths, 12/12 correct:

| path | expected | got |
|---|---|---|
| `apps/mybookkeeper/backend/app/main.py` | run | run |
| `apps/mybookkeeper/frontend/src/App.tsx` | run | run |
| `packages/shared-backend/pyproject.toml` | run | run |
| `packages/shared-frontend/package.json` | run | run |
| `package.json` | run | run |
| `package-lock.json` | run | run |
| `.github/workflows/ci-mybookkeeper.yml` | run | run |
| `apps/mygamingassistant/frontend/src/x.tsx` | skip | skip |
| `apps/mypizzatracker/backend/app/y.py` | skip | skip |
| `.github/dependabot.yml` | skip | skip |
| `.github/workflows/ci-myrecipes.yml` | skip | skip |
| `README.md` | skip | skip |

Both YAML files parse clean, `pull_request` retains only `branches`, `push` retains `branches` + `paths`, and all 8 jobs carry `needs: changes` plus the gate.

**This PR edits both workflow files**, so both suites run on it in full — that exercises the `relevant=true` path. The skip path gets exercised by #1109 once this lands: it should go from 1-of-11 reporting to 11-of-11, with the mbk/mjh contexts reporting as skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5U5LnLXRKNYmoD6wDTrrT