### PR TITLE
feat(mbk): surface time-of-use electricity plans instead of dropping them

### DIFF
--- a/apps/mybookkeeper/backend/app/core/power_to_choose_constants.py
+++ b/apps/mybookkeeper/backend/app/core/power_to_choose_constants.py
@@ -72,3 +72,15 @@ UNRATED_SENTINELS: frozenset[int] = frozenset({-1, 0})
 # Cap on offers returned per property. The ranked list is long and repetitive
 # past the first handful — every REP fields near-identical 12-month products.
 MAX_OFFERS_PER_PROPERTY = 8
+
+# Cap on time-of-use offers returned per property. Shown in their own list with
+# no saving figure attached (see ``utility_offer_service``), so the operator is
+# reading each one's terms rather than scanning a ranking — a shorter list than
+# the priced one is the point.
+MAX_TIME_OF_USE_OFFERS_PER_PROPERTY = 4
+
+# Longest ``special_terms`` blurb to carry through, in characters. The field is
+# REP-authored free text: some state the free window in one sentence, others run
+# a few hundred characters of marketing. Truncating keeps a card readable, and
+# the Electricity Facts Label link beside it is the binding version regardless.
+MAX_SPECIAL_TERMS_CHARS = 260

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_offer.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_offer.py
@@ -33,8 +33,22 @@ class UtilityOffer(BaseModel):
     # and 2000 kWh. Ranked below honest plans and badged in the UI.
     is_teaser_priced: bool = False
     # Signed cents per year at the reference usage, against the plan currently
-    # held for this property. Negative means the offer is worse.
+    # held for this property. Negative means the offer is worse. Always None on
+    # a time-of-use offer: the reference usage says nothing about *when* power
+    # is drawn, so any figure computed from it would be a guess wearing a
+    # number's clothes.
     annual_saving_cents: int | None = None
+    # True when the plan prices power differently by hour or day — free nights,
+    # free weekends, off-peak discounts. The three disclosure prices below are
+    # then a blended average over an assumed usage shape, not a rate the
+    # operator will actually pay, so these offers are listed apart and never
+    # ranked against a flat plan.
+    is_time_of_use: bool = False
+    # The REP's own description of what the plan includes, verbatim from the
+    # feed and truncated. Carried only for time-of-use offers, where it is the
+    # one place the free window is stated in words; None when the REP published
+    # nothing, which is a real gap and not an empty string.
+    special_terms: str | None = None
     # The provider's Electricity Facts Label — the legally binding terms. Always
     # surfaced, because a ranking is a starting point and not a recommendation.
     fact_sheet_url: str | None = None

--- a/apps/mybookkeeper/backend/app/schemas/properties/utility_offer_group.py
+++ b/apps/mybookkeeper/backend/app/schemas/properties/utility_offer_group.py
@@ -26,6 +26,15 @@ class UtilityOfferGroup(BaseModel):
     # rating on file). Reported rather than silently dropped so the list never
     # reads as "this is everything" when it is not.
     withheld_low_rated_count: int = 0
+    # Plans that price by hour or day — free nights, free weekends, off-peak
+    # discounts. Kept apart from ``offers`` and carrying no saving figure,
+    # because whether one wins depends on *when* power is drawn and nothing in
+    # the data says that. Listed so the operator can judge them, never ranked.
+    time_of_use_offers: list[UtilityOffer] = []
+    # Time-of-use plans held back on the same rating bar. Counted separately
+    # from ``withheld_low_rated_count`` so neither number claims the other's
+    # meaning — one is about cheaper offers, this one is not about price at all.
+    withheld_low_rated_time_of_use_count: int = 0
     # Set when no ranking could be produced: no ZIP in the address, no current
     # electricity plan to compare against, or the feed was unreachable. The UI
     # shows this instead of an empty list, so a gap never reads as "no savings".

--- a/apps/mybookkeeper/backend/app/services/properties/_offer_ranking.py
+++ b/apps/mybookkeeper/backend/app/services/properties/_offer_ranking.py
@@ -1,7 +1,8 @@
-"""Pure scoring helpers for Power to Choose offers.
+"""Pure scoring and feed-text helpers for Power to Choose offers.
 
 No network, no DB — every function here is deterministic on its arguments so
-the ranking rules can be tested against the real shapes the feed emits.
+the ranking rules, and the free-text fields they read, can be tested against
+the real shapes the feed emits.
 """
 from __future__ import annotations
 
@@ -9,6 +10,7 @@ import re
 from decimal import Decimal
 
 from app.core.power_to_choose_constants import (
+    MAX_SPECIAL_TERMS_CHARS,
     MIN_PROVIDER_RATING,
     REFERENCE_ANNUAL_KWH,
     TEASER_PRICE_RATIO,
@@ -47,6 +49,34 @@ def parse_cancellation_fee_cents(pricing_details: str | None) -> tuple[int | Non
     dollars = Decimal(match.group(1).replace(",", ""))
     cents = int((dollars * 100).to_integral_value())
     return cents, _PER_MONTH_RE.search(pricing_details) is not None
+
+
+# Runs of whitespace, including the newlines some REPs paste into the field.
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def clean_special_terms(raw: object) -> str | None:
+    """Normalise a feed ``special_terms`` blurb, or None when there is none.
+
+    REP-authored free text: whitespace is collapsed so a pasted-in paragraph
+    does not render as a ragged block, and the result is capped at
+    ``MAX_SPECIAL_TERMS_CHARS``. Truncation cuts at a word boundary and marks
+    itself with an ellipsis — a sentence that stops mid-word reads as corrupted
+    data rather than as an excerpt, and the Electricity Facts Label link beside
+    it is the binding version either way.
+    """
+    if not isinstance(raw, str):
+        return None
+    text = _WHITESPACE_RE.sub(" ", raw).strip()
+    if not text:
+        return None
+    if len(text) <= MAX_SPECIAL_TERMS_CHARS:
+        return text
+    head = text[:MAX_SPECIAL_TERMS_CHARS].rstrip()
+    cut = head.rfind(" ")
+    if cut > 0:
+        head = head[:cut]
+    return f"{head.rstrip(' ,.;:-')}…"
 
 
 def is_teaser_priced(

--- a/apps/mybookkeeper/backend/app/services/properties/power_to_choose_client.py
+++ b/apps/mybookkeeper/backend/app/services/properties/power_to_choose_client.py
@@ -23,6 +23,7 @@ from app.core.power_to_choose_constants import (
 )
 from app.schemas.properties.utility_offer import UtilityOffer
 from app.services.properties._offer_ranking import (
+    clean_special_terms,
     is_teaser_priced,
     normalize_rating,
     parse_cancellation_fee_cents,
@@ -69,13 +70,23 @@ def _to_offer(row: dict[str, Any]) -> UtilityOffer | None:
 
     Only ``Fixed`` offers survive: a variable-rate offer is the holdover product
     a lapsed plan already fell into, so presenting it as an upgrade would be
-    incoherent. Prepaid and time-of-use products are dropped for the same
-    reason — their headline ¢/kWh is not comparable to a standard fixed rate.
+    incoherent. Prepaid is dropped too — it is a different product, bought under
+    a deposit-and-credit constraint rather than on price.
+
+    Time-of-use offers (free nights, free weekends, off-peak discounts) are
+    kept, flagged, and left for the caller to present separately. Their
+    disclosure prices are a blended average over an assumed usage shape, so they
+    cannot be ranked against a flat rate — but dropping them here made a whole
+    category of plan invisible, including well-rated ones, and an optimiser that
+    silently never considers a product is worse than one that shows it plainly
+    with no saving claimed.
     """
     if row.get("rate_type") != FEED_RATE_TYPE_FIXED:
         return None
-    if row.get("prepaid") or row.get("timeofuse"):
+    if row.get("prepaid"):
         return None
+
+    is_time_of_use = bool(row.get("timeofuse"))
 
     price_500 = _decimal(row.get("price_kwh500"))
     price_1000 = _decimal(row.get("price_kwh1000"))
@@ -108,6 +119,13 @@ def _to_offer(row: dict[str, Any]) -> UtilityOffer | None:
         cancellation_fee_cents=fee_cents,
         cancellation_fee_is_per_remaining_month=fee_per_month,
         is_teaser_priced=is_teaser_priced(price_500, price_1000, price_2000),
+        is_time_of_use=is_time_of_use,
+        # Only carried for time-of-use plans: on a flat plan the field is
+        # marketing copy that adds nothing to a price comparison, whereas here
+        # it is the only place the free window is written down.
+        special_terms=(
+            clean_special_terms(row.get("special_terms")) if is_time_of_use else None
+        ),
         fact_sheet_url=str(row.get("fact_sheet") or "") or None,
         enroll_url=str(row.get("go_to_plan") or "") or None,
     )

--- a/apps/mybookkeeper/backend/app/services/properties/utility_offer_service.py
+++ b/apps/mybookkeeper/backend/app/services/properties/utility_offer_service.py
@@ -13,6 +13,13 @@ Ranking order is deliberate and quality-first:
    reputation is a false saving. Withheld offers are counted, never hidden.
 3. Sink teaser-priced offers below honest ones.
 4. Only then sort by price, breaking ties toward the better-rated provider.
+
+Time-of-use plans are handled apart from all of that. A free-weekends plan is
+worth what the household's weekend usage is worth, and the only consumption
+figure available here is an annual reference total — it carries no information
+about *when* power is drawn. So these are listed with their terms and no saving
+figure at all, rather than either silently dropped (which hid well-rated plans
+from the operator entirely) or ranked on a blended rate that nobody pays.
 """
 from __future__ import annotations
 
@@ -23,6 +30,7 @@ from decimal import Decimal
 from app.core.power_to_choose_constants import (
     DEFAULT_MIN_TERM_MONTHS,
     MAX_OFFERS_PER_PROPERTY,
+    MAX_TIME_OF_USE_OFFERS_PER_PROPERTY,
     MIN_MEANINGFUL_SAVING_CENTS,
     REFERENCE_ANNUAL_KWH,
 )
@@ -92,6 +100,8 @@ def _rank(
     kept: list[UtilityOffer] = []
 
     for offer in offers:
+        if offer.is_time_of_use:
+            continue
         if offer.term_months < min_term_months:
             continue
 
@@ -124,6 +134,44 @@ def _rank(
         ),
     )
     return kept[:MAX_OFFERS_PER_PROPERTY], withheld
+
+
+def _rank_time_of_use(
+    offers: list[UtilityOffer], *, min_term_months: int,
+) -> tuple[list[UtilityOffer], int]:
+    """Time-of-use offers worth reading, plus how many were withheld on rating.
+
+    No saving gate, because there is no honest saving to compute: the blended
+    disclosure price a time-of-use plan publishes assumes a usage shape, and
+    measuring it against a flat rate would reward or punish the plan for an
+    assumption the operator never made. Champion's 5-star free-weekends plan
+    prices at 12.8¢ blended against a 10.5¢ flat rate and would fail a saving
+    gate outright, while being the single best plan on the market for a
+    household that runs its load on Saturdays.
+
+    The rating bar still applies. A plan the operator cannot get a billing
+    dispute resolved on is not worth reading about, whatever it charges at 2am.
+    """
+    withheld = 0
+    kept: list[UtilityOffer] = []
+
+    for offer in offers:
+        if not offer.is_time_of_use:
+            continue
+        if offer.term_months < min_term_months:
+            continue
+        if not meets_rating_bar(offer.provider_rating):
+            withheld += 1
+            continue
+        kept.append(offer)
+
+    # Cheapest blended rate first is the least-bad available ordering: it is the
+    # rate paid outside the free window, which is the part of the bill that does
+    # not depend on the household's habits.
+    kept.sort(
+        key=lambda o: (o.price_cents_per_kwh_at_1000, -(o.provider_rating or 0)),
+    )
+    return kept[:MAX_TIME_OF_USE_OFFERS_PER_PROPERTY], withheld
 
 
 async def find_better_plans(
@@ -193,6 +241,15 @@ async def find_better_plans(
         )
         group.offers = ranked
         group.withheld_low_rated_count = withheld
+
+        time_of_use, withheld_tou = _rank_time_of_use(
+            available, min_term_months=min_term_months,
+        )
+        group.time_of_use_offers = time_of_use
+        group.withheld_low_rated_time_of_use_count = withheld_tou
+
+        # Still set when only time-of-use plans came back: the sentence is about
+        # what beats this plan on price, and none of these claim to.
         if not ranked:
             group.unavailable_reason = _NO_BETTER_REASON
         groups.append(group)

--- a/apps/mybookkeeper/backend/tests/test_offer_ranking.py
+++ b/apps/mybookkeeper/backend/tests/test_offer_ranking.py
@@ -12,10 +12,12 @@ from decimal import Decimal
 
 import pytest
 
+from app.core.power_to_choose_constants import MAX_SPECIAL_TERMS_CHARS
 from app.services.properties import power_to_choose_client
 from app.services.properties._address_zip import derive_zip_code
 from app.services.properties._offer_ranking import (
     annual_saving_cents,
+    clean_special_terms,
     is_teaser_priced,
     meets_rating_bar,
     normalize_rating,
@@ -138,6 +140,43 @@ class TestSavingsAndSwitchCost:
         assert switch_cost_cents(
             None, is_per_remaining_month=False, months_remaining=6,
         ) is None
+
+
+class TestCleanSpecialTerms:
+    """The one place a time-of-use plan states its free window in words."""
+
+    def test_champion_free_weekends_survives_intact(self) -> None:
+        """143 characters — under the cap, so nothing is touched."""
+        raw = (
+            "Free power from 12 midnight Friday night to 11:59 PM Sunday "
+            "night. No monthly fee or minimum usage requirement. Indexed "
+            "Solar Buyback Included."
+        )
+        assert clean_special_terms(raw) == raw
+
+    def test_pasted_whitespace_is_collapsed(self) -> None:
+        """Some REPs paste a formatted paragraph; a ragged block is not copy."""
+        assert clean_special_terms(
+            "FREE electricity from 9:00 AM\n  to 4:00 PM\tdaily.",
+        ) == "FREE electricity from 9:00 AM to 4:00 PM daily."
+
+    def test_a_long_blurb_is_cut_at_a_word_boundary(self) -> None:
+        """Chariot's 285-character marketing blurb is the real case."""
+        raw = "word " * 100
+        cleaned = clean_special_terms(raw)
+        assert cleaned is not None
+        assert cleaned.endswith("…")
+        assert len(cleaned) <= MAX_SPECIAL_TERMS_CHARS + 1
+        # No half-word before the ellipsis — a truncated token reads as
+        # corrupted data rather than as an excerpt.
+        assert cleaned[:-1].endswith("word")
+
+    def test_nothing_published_is_none_not_empty(self) -> None:
+        """The UI says so out loud, which it cannot do with an empty string."""
+        assert clean_special_terms("") is None
+        assert clean_special_terms("   ") is None
+        assert clean_special_terms(None) is None
+        assert clean_special_terms(42) is None
 
 
 class TestDeriveZipCode:

--- a/apps/mybookkeeper/backend/tests/test_time_of_use_offers.py
+++ b/apps/mybookkeeper/backend/tests/test_time_of_use_offers.py
@@ -1,0 +1,311 @@
+"""Tests for time-of-use plans: kept, flagged, and never priced against a flat rate.
+
+These plans — free nights, free weekends, off-peak discounts — used to be
+dropped at the feed boundary on the reasoning that a blended ¢/kWh is not
+comparable to a flat one. The reasoning holds; the conclusion did not. It made a
+whole product category invisible, including Champion's 5-star Free Weekends-24,
+which is the best plan on the Houston board for a household that runs its load
+at the weekend.
+
+The invariant these tests defend is narrow and load-bearing: a time-of-use offer
+reaches the operator, and it never carries a savings figure.
+
+Fixtures are the literal shapes the feed returned for ZIP 77002 on 2026-08-18,
+where 10 of 174 offers were time-of-use.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from app.core.power_to_choose_constants import MAX_TIME_OF_USE_OFFERS_PER_PROPERTY
+from app.schemas.properties.utility_offer import UtilityOffer
+from app.services.properties.power_to_choose_client import _to_offer
+from app.services.properties.utility_offer_service import _rank, _rank_time_of_use
+
+CURRENT_PRICE = Decimal("15.66")
+
+# Champion Energy's Free Weekends-24, verbatim from the feed.
+CHAMPION_ROW: dict[str, Any] = {
+    "plan_id": 24545,
+    "company_name": "CHAMPION ENERGY SERVICES LLC",
+    "plan_name": "Free Weekends-24",
+    "rate_type": "Fixed",
+    "term_value": 24,
+    "price_kwh500": 13.5,
+    "price_kwh1000": 12.8,
+    "price_kwh2000": 12.4,
+    "prepaid": False,
+    "timeofuse": True,
+    "special_terms": (
+        "Free power from 12 midnight Friday night to 11:59 PM Sunday night. "
+        "No monthly fee or minimum usage requirement. Indexed Solar Buyback "
+        "Included."
+    ),
+    "pricing_details": "Cancellation Fee: $150.00",
+    "rating_total": 5,
+    "jdp_rating": -1,
+    "renewable_energy_id": 22,
+    "fact_sheet": "https://example.test/efl.pdf",
+    "go_to_plan": "https://example.test/enroll",
+}
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    return {**CHAMPION_ROW, **overrides}
+
+
+def _offer(
+    *,
+    name: str,
+    price: str,
+    rating: int | None,
+    term: int = 12,
+    time_of_use: bool = False,
+    plan_id: int = 1,
+) -> UtilityOffer:
+    value = Decimal(price)
+    return UtilityOffer(
+        external_plan_id=plan_id,
+        provider_name=name,
+        plan_name=f"{name} {term}",
+        term_months=term,
+        price_cents_per_kwh_at_500=value,
+        price_cents_per_kwh_at_1000=value,
+        price_cents_per_kwh_at_2000=value,
+        provider_rating=rating,
+        is_time_of_use=time_of_use,
+    )
+
+
+class TestFeedMapping:
+    def test_a_time_of_use_row_is_kept_and_flagged(self) -> None:
+        """The regression this whole change exists for — it used to return None."""
+        offer = _to_offer(_row())
+
+        assert offer is not None
+        assert offer.is_time_of_use is True
+        assert offer.provider_name == "CHAMPION ENERGY SERVICES LLC"
+        assert offer.term_months == 24
+        assert offer.provider_rating == 5
+
+    def test_the_free_window_is_carried_through(self) -> None:
+        """Without this text the card says nothing the operator can act on."""
+        offer = _to_offer(_row())
+
+        assert offer is not None
+        assert offer.special_terms is not None
+        assert "12 midnight Friday night" in offer.special_terms
+
+    def test_a_flat_plan_carries_no_special_terms(self) -> None:
+        """On a flat plan the field is marketing copy, not a term that matters."""
+        offer = _to_offer(
+            _row(
+                timeofuse=False,
+                special_terms="Promo Code PTC. Best rates in Texas!",
+            ),
+        )
+
+        assert offer is not None
+        assert offer.is_time_of_use is False
+        assert offer.special_terms is None
+
+    def test_prepaid_is_still_dropped(self) -> None:
+        """A different product, bought under a deposit constraint, not on price."""
+        assert _to_offer(_row(prepaid=True)) is None
+
+    def test_a_variable_rate_plan_is_still_dropped(self) -> None:
+        """The holdover product a lapsed plan already fell into."""
+        assert _to_offer(_row(rate_type="Variable")) is None
+
+
+class TestPricedRankingExcludesTimeOfUse:
+    def test_a_time_of_use_offer_never_enters_the_priced_list(self) -> None:
+        """Even when its blended rate is dramatically cheaper than the current one.
+
+        This is the failure mode that keeping these offers introduces: a plan
+        advertising 8.0¢ blended would top the ranking and be labelled with an
+        annual saving the household has no reason to expect.
+        """
+        ranked, _ = _rank(
+            [
+                _offer(
+                    name="Chariot Energy",
+                    price="8.00",
+                    rating=5,
+                    time_of_use=True,
+                    plan_id=1,
+                ),
+                _offer(name="Veteran Energy", price="10.50", rating=3, plan_id=2),
+            ],
+            current_price=CURRENT_PRICE,
+            min_term_months=12,
+        )
+
+        assert [o.provider_name for o in ranked] == ["Veteran Energy"]
+
+    def test_a_time_of_use_offer_is_not_counted_as_withheld(self) -> None:
+        """It is not a hidden cheaper offer; it is listed elsewhere in full."""
+        _, withheld = _rank(
+            [_offer(name="Chariot Energy", price="8.00", rating=1, time_of_use=True)],
+            current_price=CURRENT_PRICE,
+            min_term_months=12,
+        )
+
+        assert withheld == 0
+
+
+class TestTimeOfUseRanking:
+    def test_only_time_of_use_offers_are_returned(self) -> None:
+        listed, _ = _rank_time_of_use(
+            [
+                _offer(name="Veteran Energy", price="10.50", rating=3, plan_id=1),
+                _offer(
+                    name="Champion Energy",
+                    price="12.80",
+                    rating=5,
+                    term=24,
+                    time_of_use=True,
+                    plan_id=2,
+                ),
+            ],
+            min_term_months=12,
+        )
+
+        assert [o.provider_name for o in listed] == ["Champion Energy"]
+
+    def test_a_dearer_blended_rate_is_still_listed(self) -> None:
+        """Champion's 12.80¢ blended loses to a 10.50¢ flat rate on paper.
+
+        A saving gate would drop it, and dropping it is the bug: the free
+        weekend is worth what the household's weekend usage is worth, and
+        nothing in the data says what that is.
+        """
+        listed, _ = _rank_time_of_use(
+            [
+                _offer(
+                    name="Champion Energy",
+                    price="12.80",
+                    rating=5,
+                    term=24,
+                    time_of_use=True,
+                ),
+            ],
+            min_term_months=12,
+        )
+
+        assert len(listed) == 1
+
+    def test_no_saving_figure_is_ever_attached(self) -> None:
+        """The load-bearing invariant. A number here would be a guess."""
+        listed, _ = _rank_time_of_use(
+            [
+                _offer(
+                    name="Champion Energy",
+                    price="12.80",
+                    rating=5,
+                    term=24,
+                    time_of_use=True,
+                ),
+            ],
+            min_term_months=12,
+        )
+
+        assert listed[0].annual_saving_cents is None
+
+    def test_poorly_rated_providers_are_withheld_and_counted(self) -> None:
+        """Chariot's five 1-star Bright Nights plans are the real case."""
+        listed, withheld = _rank_time_of_use(
+            [
+                _offer(
+                    name="Chariot Energy",
+                    price="10.10",
+                    rating=1,
+                    time_of_use=True,
+                    plan_id=1,
+                ),
+                _offer(
+                    name="Mystery REP",
+                    price="10.00",
+                    rating=None,
+                    time_of_use=True,
+                    plan_id=2,
+                ),
+                _offer(
+                    name="Octopus Energy",
+                    price="12.20",
+                    rating=3,
+                    time_of_use=True,
+                    plan_id=3,
+                ),
+            ],
+            min_term_months=12,
+        )
+
+        assert [o.provider_name for o in listed] == ["Octopus Energy"]
+        assert withheld == 2
+
+    def test_a_short_term_plan_is_dropped(self) -> None:
+        """Just Energy's 3-month bundle re-exposes the same renewal cliff."""
+        listed, withheld = _rank_time_of_use(
+            [
+                _offer(
+                    name="Just Energy",
+                    price="10.00",
+                    rating=4,
+                    term=3,
+                    time_of_use=True,
+                ),
+            ],
+            min_term_months=12,
+        )
+
+        assert listed == []
+        # Dropped on term, not on rating — the withheld counter says "hidden
+        # for being badly rated" and must not absorb a different reason.
+        assert withheld == 0
+
+    def test_cheapest_blended_rate_leads(self) -> None:
+        """The rate paid outside the free window is the habit-independent part."""
+        listed, _ = _rank_time_of_use(
+            [
+                _offer(
+                    name="Champion Energy",
+                    price="12.80",
+                    rating=5,
+                    term=24,
+                    time_of_use=True,
+                    plan_id=1,
+                ),
+                _offer(
+                    name="Octopus Energy",
+                    price="12.20",
+                    rating=3,
+                    time_of_use=True,
+                    plan_id=2,
+                ),
+            ],
+            min_term_months=12,
+        )
+
+        assert [o.provider_name for o in listed] == [
+            "Octopus Energy",
+            "Champion Energy",
+        ]
+
+    def test_the_list_is_capped(self) -> None:
+        listed, _ = _rank_time_of_use(
+            [
+                _offer(
+                    name=f"REP {index}",
+                    price=f"1{index}.00",
+                    rating=4,
+                    time_of_use=True,
+                    plan_id=index,
+                )
+                for index in range(MAX_TIME_OF_USE_OFFERS_PER_PROPERTY + 3)
+            ],
+            min_term_months=12,
+        )
+
+        assert len(listed) == MAX_TIME_OF_USE_OFFERS_PER_PROPERTY

--- a/apps/mybookkeeper/frontend/e2e/utility-better-plans.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/utility-better-plans.spec.ts
@@ -18,7 +18,11 @@
  *   - The current plan is on screen, and each offer reads as a movement from it.
  *   - The withheld-for-poor-rating count is stated, not silently applied.
  *   - A bill-credit teaser carries its caveat.
+ *   - Time-of-use plans are listed apart, with terms and no savings figure.
  *   - No horizontal scroll across mobile / tablet / desktop; 44px touch target.
+ *     The time-of-use fixture carries a full-length REP name on purpose —
+ *     "CHAMPION ENERGY SERVICES LLC" in an enrol label is what pushed 13px of
+ *     horizontal scroll onto the page before the label was allowed to wrap.
  *   - A 503 from the feed renders "nothing is wrong with your plans".
  */
 import { test, expect, type Page } from "@playwright/test";
@@ -124,6 +128,8 @@ const OFFERS_RESPONSE = {
           cancellation_fee_is_per_remaining_month: false,
           is_teaser_priced: false,
           annual_saving_cents: 61920,
+          is_time_of_use: false,
+          special_terms: null,
           fact_sheet_url: "https://example.test/efl.pdf",
           enroll_url: "https://example.test/enroll",
         },
@@ -142,11 +148,40 @@ const OFFERS_RESPONSE = {
           cancellation_fee_is_per_remaining_month: true,
           is_teaser_priced: true,
           annual_saving_cents: 113520,
+          is_time_of_use: false,
+          special_terms: null,
           fact_sheet_url: null,
           enroll_url: null,
         },
       ],
       withheld_low_rated_count: 33,
+      // Champion's Free Weekends-24, the shape this section exists for: a
+      // five-star plan whose blended rate loses to the flat offers above it,
+      // and which is worth reading anyway.
+      time_of_use_offers: [
+        {
+          external_plan_id: 601,
+          provider_name: "CHAMPION ENERGY SERVICES LLC",
+          plan_name: "Free Weekends-24",
+          term_months: 24,
+          price_cents_per_kwh_at_500: "13.5000",
+          price_cents_per_kwh_at_1000: "12.8000",
+          price_cents_per_kwh_at_2000: "12.4000",
+          renewable_pct: 22,
+          provider_rating: 5,
+          jd_power_rating: null,
+          cancellation_fee_cents: 15000,
+          cancellation_fee_is_per_remaining_month: false,
+          is_teaser_priced: false,
+          annual_saving_cents: null,
+          is_time_of_use: true,
+          special_terms:
+            "Free power from 12 midnight Friday night to 11:59 PM Sunday night.",
+          fact_sheet_url: "https://example.test/efl-tou.pdf",
+          enroll_url: "https://example.test/enroll-tou",
+        },
+      ],
+      withheld_low_rated_time_of_use_count: 5,
       unavailable_reason: null,
     },
   ],
@@ -224,6 +259,25 @@ test.describe("Find a better plan", () => {
 
     // A saving is arithmetic at a stated usage, not a bill promise.
     await expect(results).toContainText("12,000 kWh per year");
+
+    // Time-of-use plans sit in their own list, below the ranked ones.
+    const timeOfUse = page.getByTestId(`time-of-use-offers-${PROPERTY_ID}`);
+    await expect(timeOfUse).toContainText("Plans that price by time of day");
+    await expect(timeOfUse).toContainText("nothing here carries a savings figure");
+
+    const freeWeekends = page.getByTestId("time-of-use-plan-601");
+    await expect(freeWeekends).toContainText("CHAMPION ENERGY SERVICES LLC");
+    await expect(freeWeekends).toContainText("12 midnight Friday night");
+    await expect(freeWeekends).toContainText("12.80¢ average");
+    await expect(freeWeekends).toContainText("24 months");
+
+    // The invariant the whole section rests on: no money is promised here.
+    await expect(freeWeekends).not.toContainText("less per year than now");
+    await expect(freeWeekends).not.toContainText("Best value");
+
+    await expect(
+      page.getByTestId(`time-of-use-withheld-${PROPERTY_ID}`),
+    ).toContainText("5 more plans hidden");
   });
 
   test("the section fits every viewport and keeps a 44px touch target", async ({
@@ -255,12 +309,18 @@ test.describe("Find a better plan", () => {
 
       // The enrol link is the action the whole comparison exists to enable, so
       // it has to stay tappable at every width, not just the button above it.
-      const enroll = page.getByTestId("better-plan-enroll-501");
-      const enrollBox = await enroll.boundingBox();
-      expect(enrollBox, `enrol link has no box at ${size.width}px`).not.toBeNull();
-      expect(enrollBox!.height, `enrol link height at ${size.width}px`).toBeGreaterThanOrEqual(
-        44,
-      );
+      for (const testId of [
+        "better-plan-enroll-501",
+        "time-of-use-enroll-601",
+      ]) {
+        const enroll = page.getByTestId(testId);
+        const enrollBox = await enroll.boundingBox();
+        expect(enrollBox, `${testId} has no box at ${size.width}px`).not.toBeNull();
+        expect(
+          enrollBox!.height,
+          `${testId} height at ${size.width}px`,
+        ).toBeGreaterThanOrEqual(44);
+      }
     }
 
     await page.setViewportSize({ width: 375, height: 800 });

--- a/apps/mybookkeeper/frontend/src/__tests__/BetterPlansSection.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/BetterPlansSection.test.tsx
@@ -54,6 +54,8 @@ function offer(overrides: Partial<UtilityOffer> = {}): UtilityOffer {
     cancellation_fee_is_per_remaining_month: false,
     is_teaser_priced: false,
     annual_saving_cents: 61920,
+    is_time_of_use: false,
+    special_terms: null,
     fact_sheet_url: "https://example.test/efl.pdf",
     enroll_url: "https://example.test/enroll",
     ...overrides,
@@ -70,6 +72,8 @@ function group(overrides: Partial<UtilityOfferGroup> = {}): UtilityOfferGroup {
     switch_cost_cents: 15000,
     offers: [offer()],
     withheld_low_rated_count: 0,
+    time_of_use_offers: [],
+    withheld_low_rated_time_of_use_count: 0,
     unavailable_reason: null,
     ...overrides,
   };

--- a/apps/mybookkeeper/frontend/src/__tests__/TimeOfUseOffers.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/TimeOfUseOffers.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for the time-of-use plan list.
+ *
+ * The section exists because these plans were previously dropped before the
+ * operator ever saw them. Bringing them back introduces exactly one way to make
+ * things worse: presenting one as if it had been compared on price. Whether a
+ * free-weekends plan beats a flat rate depends on when power is drawn, and the
+ * app only knows how much — so the tests that matter here are the ones that pin
+ * the *absence* of a savings claim as hard as the presence of the terms.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TimeOfUseOffers from "@/app/features/utility/TimeOfUseOffers";
+import type { UtilityOffer } from "@/shared/types/utility/utility-offer";
+
+const PROPERTY_ID = "11111111-1111-1111-1111-111111111111";
+
+function offer(overrides: Partial<UtilityOffer> = {}): UtilityOffer {
+  return {
+    external_plan_id: 24545,
+    provider_name: "Champion Energy",
+    plan_name: "Free Weekends-24",
+    term_months: 24,
+    price_cents_per_kwh_at_500: "13.5",
+    price_cents_per_kwh_at_1000: "12.8",
+    price_cents_per_kwh_at_2000: "12.4",
+    renewable_pct: 22,
+    provider_rating: 5,
+    jd_power_rating: null,
+    cancellation_fee_cents: 15000,
+    cancellation_fee_is_per_remaining_month: false,
+    is_teaser_priced: false,
+    annual_saving_cents: null,
+    is_time_of_use: true,
+    special_terms:
+      "Free power from 12 midnight Friday night to 11:59 PM Sunday night. " +
+      "No monthly fee or minimum usage requirement.",
+    fact_sheet_url: "https://example.test/efl.pdf",
+    enroll_url: "https://example.test/enroll",
+    ...overrides,
+  };
+}
+
+function renderSection(
+  offers: UtilityOffer[],
+  withheldLowRatedCount = 0,
+): void {
+  render(
+    <TimeOfUseOffers
+      offers={offers}
+      withheldLowRatedCount={withheldLowRatedCount}
+      propertyId={PROPERTY_ID}
+    />,
+  );
+}
+
+describe("TimeOfUseOffers", () => {
+  it("renders nothing when the market has none and none were withheld", () => {
+    const { container } = render(
+      <TimeOfUseOffers
+        offers={[]}
+        withheldLowRatedCount={0}
+        propertyId={PROPERTY_ID}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("states why no savings figure is shown", () => {
+    renderSection([offer()]);
+    const section = screen.getByTestId(`time-of-use-offers-${PROPERTY_ID}`);
+    expect(section).toHaveTextContent(/depends on when you use power/i);
+    expect(section).toHaveTextContent(/nothing here carries a savings figure/i);
+  });
+
+  it("shows the provider's own description of the free window", () => {
+    renderSection([offer()]);
+    expect(screen.getByTestId("time-of-use-terms-24545")).toHaveTextContent(
+      "Free power from 12 midnight Friday night to 11:59 PM Sunday night.",
+    );
+  });
+
+  it("says so when the provider published no description", () => {
+    renderSection([offer({ special_terms: null })]);
+    const terms = screen.getByTestId("time-of-use-terms-24545");
+    expect(terms).toHaveTextContent(/didn't publish a description/i);
+    expect(terms).toHaveTextContent(/Electricity Facts Label/i);
+  });
+
+  it("labels the blended rate as an average, never as the rate", () => {
+    renderSection([offer()]);
+    expect(screen.getByTestId("time-of-use-plan-24545")).toHaveTextContent(
+      "12.80¢ average",
+    );
+  });
+
+  it("never renders a saving, even if one somehow arrives on the offer", () => {
+    // The API contract says this is always null. A regression that starts
+    // populating it must not silently turn into a dollar promise on screen.
+    renderSection([offer({ annual_saving_cents: 61920 })]);
+    const card = screen.getByTestId("time-of-use-plan-24545");
+    expect(card).not.toHaveTextContent(/\$619/);
+    expect(card).not.toHaveTextContent(/save/i);
+  });
+
+  it("carries no 'best value' marker", () => {
+    // These are not ranked against each other on money, so crowning one would
+    // claim a comparison that was never made.
+    renderSection([offer(), offer({ external_plan_id: 24638 })]);
+    expect(
+      screen.getByTestId(`time-of-use-offers-${PROPERTY_ID}`),
+    ).not.toHaveTextContent(/best value/i);
+  });
+
+  it("shows the term, exit fee and rating", () => {
+    renderSection([offer()]);
+    const card = screen.getByTestId("time-of-use-plan-24545");
+    expect(card).toHaveTextContent("24 months");
+    expect(card).toHaveTextContent("$150");
+    expect(card).toHaveTextContent("5/5");
+  });
+
+  it("renders an unrated provider as unrated, not as zero", () => {
+    renderSection([offer({ provider_rating: null })]);
+    expect(screen.getByTestId("time-of-use-plan-24545")).toHaveTextContent(
+      "Unrated",
+    );
+  });
+
+  it("opens the enrolment link safely in a new tab", () => {
+    renderSection([offer()]);
+    const link = screen.getByTestId("time-of-use-enroll-24545");
+    expect(link).toHaveAttribute("href", "https://example.test/enroll");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noreferrer noopener");
+  });
+
+  it("names how many plans were withheld for a poor rating", () => {
+    renderSection([offer()], 3);
+    expect(
+      screen.getByTestId(`time-of-use-withheld-${PROPERTY_ID}`),
+    ).toHaveTextContent("3 more plans hidden");
+  });
+
+  it("still explains itself when every plan was withheld", () => {
+    // Otherwise the count appears with no heading to give it a meaning.
+    renderSection([], 3);
+    expect(
+      screen.getByTestId(`time-of-use-offers-${PROPERTY_ID}`),
+    ).toHaveTextContent(/Plans that price by time of day/i);
+    expect(
+      screen.getByTestId(`time-of-use-withheld-${PROPERTY_ID}`),
+    ).toHaveTextContent("3 more plans hidden");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/offer-stats.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/offer-stats.test.ts
@@ -35,6 +35,8 @@ function offer(overrides: Partial<UtilityOffer> = {}): UtilityOffer {
     cancellation_fee_is_per_remaining_month: false,
     is_teaser_priced: false,
     annual_saving_cents: 61920,
+    is_time_of_use: false,
+    special_terms: null,
     fact_sheet_url: null,
     enroll_url: null,
     ...overrides,
@@ -51,6 +53,8 @@ function group(overrides: Partial<UtilityOfferGroup> = {}): UtilityOfferGroup {
     switch_cost_cents: 15000,
     offers: [],
     withheld_low_rated_count: 0,
+    time_of_use_offers: [],
+    withheld_low_rated_time_of_use_count: 0,
     unavailable_reason: null,
     ...overrides,
   };

--- a/apps/mybookkeeper/frontend/src/__tests__/offer-tiers.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/offer-tiers.test.ts
@@ -26,6 +26,8 @@ function offer(overrides: Partial<UtilityOffer> = {}): UtilityOffer {
     cancellation_fee_is_per_remaining_month: false,
     is_teaser_priced: false,
     annual_saving_cents: 61920,
+    is_time_of_use: false,
+    special_terms: null,
     fact_sheet_url: null,
     enroll_url: null,
     ...overrides,

--- a/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlansGroup.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/BetterPlansGroup.tsx
@@ -1,5 +1,6 @@
 import EquippedPlanCard from "@/app/features/utility/EquippedPlanCard";
 import OfferTierCard from "@/app/features/utility/OfferTierCard";
+import TimeOfUseOffers from "@/app/features/utility/TimeOfUseOffers";
 import { bestSavingCents } from "@/shared/lib/offer-stats";
 import { buildOfferTiers } from "@/shared/lib/offer-tiers";
 import type { UtilityOfferGroup } from "@/shared/types/utility/utility-offer-group";
@@ -74,6 +75,14 @@ export default function BetterPlansGroup({
               poorly rated or unrated providers.
             </p>
           ) : null}
+
+          {/* Below the ranked plans, and separated by a rule, because these are
+              not further down the same list — they are a different question. */}
+          <TimeOfUseOffers
+            offers={group.time_of_use_offers}
+            withheldLowRatedCount={group.withheld_low_rated_time_of_use_count}
+            propertyId={group.property_id}
+          />
         </div>
       </div>
     </section>

--- a/apps/mybookkeeper/frontend/src/app/features/utility/OfferEnrollLink.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/OfferEnrollLink.tsx
@@ -1,0 +1,41 @@
+import type { OfferEnrollTone } from "@/shared/types/utility/offer-enroll-tone";
+
+const TONE_CLASS: Record<OfferEnrollTone, string> = {
+  primary: "bg-primary text-primary-foreground hover:opacity-90",
+  secondary: "border border-border hover:bg-muted",
+};
+
+export interface OfferEnrollLinkProps {
+  href: string;
+  providerName: string;
+  tone: OfferEnrollTone;
+  testId: string;
+}
+
+/**
+ * The link that acts on an offer — the thing the whole comparison exists for.
+ *
+ * The label carries the provider name so it still says what it does when read
+ * on its own, and real names run long ("CHAMPION ENERGY SERVICES LLC"). It
+ * therefore has to wrap: pinning it to one line pushed 13px of horizontal
+ * scroll onto the whole page at 375px. Vertical padding rather than a fixed
+ * height keeps the 44px touch target intact once it wraps to two lines.
+ */
+export default function OfferEnrollLink({
+  href,
+  providerName,
+  tone,
+  testId,
+}: OfferEnrollLinkProps) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer noopener"
+      className={`inline-flex items-center justify-center text-center min-h-[44px] px-4 py-2 rounded-md text-sm font-medium ${TONE_CLASS[tone]}`}
+      data-testid={testId}
+    >
+      Sign up with {providerName}
+    </a>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/OfferTierCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/OfferTierCard.tsx
@@ -1,4 +1,5 @@
 import OfferDisclosure from "@/app/features/utility/OfferDisclosure";
+import OfferEnrollLink from "@/app/features/utility/OfferEnrollLink";
 import OfferStatGrid from "@/app/features/utility/OfferStatGrid";
 import OfferVerdictBadge from "@/app/features/utility/OfferVerdictBadge";
 import SavingHeadline from "@/app/features/utility/SavingHeadline";
@@ -33,11 +34,6 @@ export default function OfferTierCard({
   const offer = tier.lead;
   const stats = buildOfferStats(offer, group, referenceAnnualKwh);
   const verdict = offerVerdict(offer);
-  // One solid button per property. A column of identical primary buttons is a
-  // column of equally-weighted choices, which is the opposite of a ranking.
-  const enrollTone = isBest
-    ? "bg-primary text-primary-foreground hover:opacity-90"
-    : "border border-border hover:bg-muted";
 
   return (
     <li
@@ -83,15 +79,15 @@ export default function OfferTierCard({
 
       {offer.enroll_url ? (
         <p className="mt-3">
-          <a
+          {/* One solid button per property. A column of identical primary
+              buttons is a column of equally-weighted choices, which is the
+              opposite of a ranking. */}
+          <OfferEnrollLink
             href={offer.enroll_url}
-            target="_blank"
-            rel="noreferrer noopener"
-            className={`inline-flex items-center justify-center min-h-[44px] px-4 rounded-md text-sm font-medium whitespace-nowrap ${enrollTone}`}
-            data-testid={`better-plan-enroll-${offer.external_plan_id}`}
-          >
-            Sign up with {offer.provider_name}
-          </a>
+            providerName={offer.provider_name}
+            tone={isBest ? "primary" : "secondary"}
+            testId={`better-plan-enroll-${offer.external_plan_id}`}
+          />
         </p>
       ) : null}
 

--- a/apps/mybookkeeper/frontend/src/app/features/utility/TimeOfUseOfferRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/TimeOfUseOfferRow.tsx
@@ -1,0 +1,90 @@
+import OfferDisclosure from "@/app/features/utility/OfferDisclosure";
+import OfferEnrollLink from "@/app/features/utility/OfferEnrollLink";
+import {
+  formatCancellationFeeShort,
+  formatOfferRate,
+  formatProviderRating,
+  formatTerm,
+} from "@/shared/lib/utility-offer-format";
+import type { UtilityOffer } from "@/shared/types/utility/utility-offer";
+
+export interface TimeOfUseOfferRowProps {
+  offer: UtilityOffer;
+}
+
+/**
+ * One time-of-use plan, stated as terms to read rather than a saving to take.
+ *
+ * Deliberately not an `OfferTierCard`: no saving headline, no verdict badge, no
+ * "best value" marker. Every one of those would be a claim about money, and the
+ * comparison that would justify one needs to know when the household draws
+ * power. What the operator gets instead is the provider's own description of
+ * the free window, the rate outside it, and the label that binds both.
+ */
+export default function TimeOfUseOfferRow({ offer }: TimeOfUseOfferRowProps) {
+  return (
+    <li
+      className="rounded-lg border border-border p-4"
+      data-testid={`time-of-use-plan-${offer.external_plan_id}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm font-medium min-w-0 truncate">
+          {offer.provider_name}
+          <span className="text-muted-foreground font-normal">
+            {" · "}
+            {offer.plan_name}
+          </span>
+        </p>
+        <span className="text-xs text-muted-foreground whitespace-nowrap shrink-0">
+          {formatProviderRating(offer.provider_rating)}
+        </span>
+      </div>
+
+      {offer.special_terms ? (
+        <p
+          className="text-sm mt-2"
+          data-testid={`time-of-use-terms-${offer.external_plan_id}`}
+        >
+          {offer.special_terms}
+        </p>
+      ) : (
+        <p
+          className="text-sm mt-2 text-muted-foreground"
+          data-testid={`time-of-use-terms-${offer.external_plan_id}`}
+        >
+          This provider didn't publish a description of the free window — the
+          Electricity Facts Label below states it.
+        </p>
+      )}
+
+      {/* "Average" is doing load-bearing work: this is the blended disclosure
+          price, and printing it the way a flat plan's rate is printed would
+          invite exactly the comparison this section exists to avoid. */}
+      <p className="text-xs text-muted-foreground mt-2">
+        {formatTerm(offer.term_months)}
+        {" · "}
+        {formatOfferRate(offer.price_cents_per_kwh_at_1000)} average
+        {" · "}
+        {formatCancellationFeeShort(
+          offer.cancellation_fee_cents,
+          offer.cancellation_fee_is_per_remaining_month,
+        )}
+      </p>
+
+      {offer.enroll_url ? (
+        <p className="mt-3">
+          {/* Never `primary`: nothing in this list has been ranked against the
+              others on money, so none of them is the recommended one. */}
+          <OfferEnrollLink
+            href={offer.enroll_url}
+            providerName={offer.provider_name}
+            tone="secondary"
+            testId={`time-of-use-enroll-${offer.external_plan_id}`}
+          />
+        </p>
+      ) : null}
+
+      <OfferDisclosure offer={offer} />
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/utility/TimeOfUseOffers.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/utility/TimeOfUseOffers.tsx
@@ -1,0 +1,60 @@
+import TimeOfUseOfferRow from "@/app/features/utility/TimeOfUseOfferRow";
+import type { UtilityOffer } from "@/shared/types/utility/utility-offer";
+
+export interface TimeOfUseOffersProps {
+  offers: UtilityOffer[];
+  withheldLowRatedCount: number;
+  propertyId: string;
+}
+
+/**
+ * Plans priced by time of day, listed without a ranking.
+ *
+ * These used to be dropped before they reached the operator, on the reasoning
+ * that a blended rate is not comparable to a flat one. That reasoning is sound
+ * and the conclusion was not: it hid an entire product category, including
+ * five-star plans, behind a comparison the app was unable to make. So they are
+ * shown, in their own list, with the missing comparison stated rather than
+ * papered over with a number.
+ */
+export default function TimeOfUseOffers({
+  offers,
+  withheldLowRatedCount,
+  propertyId,
+}: TimeOfUseOffersProps) {
+  if (offers.length === 0 && withheldLowRatedCount === 0) return null;
+
+  return (
+    <section
+      className="mt-4 pt-4 border-t border-border"
+      data-testid={`time-of-use-offers-${propertyId}`}
+    >
+      <h4 className="text-sm font-semibold">Plans that price by time of day</h4>
+      <p className="text-xs text-muted-foreground mt-0.5">
+        Free nights, free weekends, off-peak discounts. Whether one of these
+        beats your current plan depends on <em>when</em> you use power, and your
+        bills only record how much — so nothing here carries a savings figure.
+        Read the terms against your own habits.
+      </p>
+
+      {offers.length > 0 ? (
+        <ul className="space-y-3 mt-3">
+          {offers.map((offer) => (
+            <TimeOfUseOfferRow key={offer.external_plan_id} offer={offer} />
+          ))}
+        </ul>
+      ) : null}
+
+      {withheldLowRatedCount > 0 ? (
+        <p
+          className="text-xs text-muted-foreground mt-3"
+          data-testid={`time-of-use-withheld-${propertyId}`}
+        >
+          {withheldLowRatedCount} more{" "}
+          {withheldLowRatedCount === 1 ? "plan" : "plans"} hidden — poorly rated
+          or unrated providers.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/offer-enroll-tone.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/offer-enroll-tone.ts
@@ -1,0 +1,8 @@
+/**
+ * How much visual weight an offer's enrolment link carries.
+ *
+ * `primary` is reserved for the single best-value plan on a property. A column
+ * of equally solid buttons is a column of equally weighted choices, which is
+ * the opposite of a ranking.
+ */
+export type OfferEnrollTone = "primary" | "secondary";

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-offer-group.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-offer-group.ts
@@ -16,6 +16,13 @@ export interface UtilityOfferGroup {
   offers: UtilityOffer[];
   /** Cheaper offers held back for failing the provider-rating bar. */
   withheld_low_rated_count: number;
+  /**
+   * Plans that price by hour or day. Carry no saving figure — whether one wins
+   * depends on when power is used, which nothing in the data records.
+   */
+  time_of_use_offers: UtilityOffer[];
+  /** Time-of-use plans held back on the same rating bar. */
+  withheld_low_rated_time_of_use_count: number;
   /** Why there is nothing to show. Rendered instead of an empty list. */
   unavailable_reason: string | null;
 }

--- a/apps/mybookkeeper/frontend/src/shared/types/utility/utility-offer.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/utility/utility-offer.ts
@@ -23,7 +23,24 @@ export interface UtilityOffer {
   cancellation_fee_cents: number | null;
   cancellation_fee_is_per_remaining_month: boolean;
   is_teaser_priced: boolean;
+  /**
+   * Always `null` on a time-of-use offer — the reference usage says nothing
+   * about when power is drawn, so there is no honest figure to put here.
+   */
   annual_saving_cents: number | null;
+  /**
+   * The plan prices power differently by hour or day — free nights, free
+   * weekends, off-peak discounts. The three disclosure prices are then a
+   * blended average, not a rate that will be paid, so these are listed apart
+   * from the ranked offers and never compared against a flat plan.
+   */
+  is_time_of_use: boolean;
+  /**
+   * The provider's own description of what the plan includes, verbatim and
+   * truncated. Only populated for time-of-use offers, where it is the one place
+   * the free window is stated in words.
+   */
+  special_terms: string | null;
   fact_sheet_url: string | null;
   enroll_url: string | null;
 }

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -836,6 +836,7 @@
         "test_market_rate_benchmarks_api.py",
         "test_offer_ranking.py",
         "test_utility_offer_ranking.py",
+        "test_time_of_use_offers.py",
         "test_document_draft_reader.py"
       ],
       "frontend_tests": [
@@ -854,7 +855,8 @@
         "MarketRateBenchmarkDialog.test.tsx",
         "BetterPlansSection.test.tsx",
         "offer-stats.test.ts",
-        "offer-tiers.test.ts"
+        "offer-tiers.test.ts",
+        "TimeOfUseOffers.test.tsx"
       ],
       "e2e_specs": [
         "utility-plans.spec.ts",


### PR DESCRIPTION
## What

Free-nights / free-weekends / off-peak plans were being discarded at the Power to Choose feed boundary, alongside prepaid plans, on the reasoning that a blended ¢/kWh cannot be ranked against a flat rate.

The reasoning holds. The conclusion did not — it made a whole product category invisible. On the live Houston board, **10 of 174 published plans are time-of-use**, including Champion Energy's 5-star **Free Weekends-24**, which is the best plan available to a household that runs its load at the weekend.

Whether one of these beats the current plan depends on **when** power is drawn, and MBK only has monthly kWh totals. So they are **listed, not ranked**: a separate section below the priced results showing the REP's own description of the free window, the blended rate labelled as an *average*, term, exit fee and rating — and **no savings figure, no verdict badge, no "best value" marker**.

## Backend

- `_to_offer` keeps time-of-use rows and flags them. The drop now keys off `rate_type != Fixed` and `prepaid`, both of which still apply. Time-of-use rows carry `rate_type: "Fixed"` **and** `timeofuse: true`, so filtering on rate type alone never caught them.
- `special_terms` is carried **only** for time-of-use plans, whitespace-normalised and cut at a word boundary. On a flat plan the same field is marketing copy that adds nothing to a price comparison; on a TOU plan it is the only place the free window is written down.
- `_rank` skips time-of-use offers outright, so one can never enter the priced list or be counted as a withheld cheaper offer.
- New `_rank_time_of_use` applies the same ≥3-star and minimum-term gates, sorts by blended rate, and reports its **own** withheld count so neither number claims the other's meaning.

## Frontend

- New `TimeOfUseOffers` / `TimeOfUseOfferRow`, rendered under a rule below the ranked plans, with copy that states out loud why no saving is shown.
- `OfferEnrollLink` extracted from `OfferTierCard`. The old inline link was `whitespace-nowrap`, which pushed **13px of horizontal scroll onto the whole page at 375px** once a real provider name (`CHAMPION ENERGY SERVICES LLC`) was rendered — a latent defect in the existing card, found only by running the live feed through the real UI. The e2e fixture now uses that long name so it stays fixed.

## Verification

Ran the real path against the **live** Power to Choose feed for the property's own ZIP 77021:

- 155 usable offers, 10 time-of-use
- Priced list: 6 (Energy Texas 6.1¢ / $528 per year … Amigo 8.5¢ / $240 per year), 2 withheld on rating
- Time-of-use list: Octopus Flex (12.2¢, 12 mo, 3★) and CHAMPION ENERGY SERVICES LLC Free Weekends-24 (12.8¢, 24 mo, 5★), 3 withheld on rating
- Runtime assertions confirmed no TOU offer leaked into the priced list and none carried a saving

That exact payload was then rendered through the real UI and inspected at desktop and 375px.

Both new invariants were confirmed to **bite**: removing the `is_time_of_use` guard from `_rank` failed exactly 2 tests; restoring `whitespace-nowrap` failed the viewport e2e with "horizontal overflow at 375px". Both restored.

Backend 62 passed · frontend 76 passed · 3 e2e passed · eslint and `tsc --noEmit` clean.

## Operational migration

None. No env vars, no schema change, no migration — the feed already carried these rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeNqUHKsZEa3imipsgb2AN
