### PR TITLE
fix(ci): expand the myjobhunter test matrix when the suite is skipped

### DIFF
--- a/.github/workflows/ci-myjobhunter.yml
+++ b/.github/workflows/ci-myjobhunter.yml
@@ -118,7 +118,20 @@ jobs:
 
   backend-tests:
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.relevant != 'false' }}
+    # `!cancelled()` (not a `relevant` test) so the job still RUNS — and so still
+    # expands its matrix into the five required contexts — even if the `changes`
+    # gate job itself failed. The per-step conditions below then evaluate an empty
+    # `relevant`, which is != 'false', so the full suite runs. Fail-safe either way.
+    if: ${{ !cancelled() }}
+    # NOTE: unlike every other job here, the gate is applied per-STEP, not at
+    # the job level. A matrix job skipped by a job-level `if:` does not have its
+    # matrix expanded, so GitHub reports ONE check literally named
+    # "backend-tests / myjobhunter / ${{ matrix.shard.name }}" instead of the five
+    # shard contexts. All five are REQUIRED status checks on main, so the PR would
+    # stay blocked forever — the exact bug this gating was introduced to fix.
+    #
+    # Running the job and skipping its steps keeps the five real context names and
+    # costs only a few seconds of runner startup per shard.
     name: backend-tests / myjobhunter / ${{ matrix.shard.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -226,9 +239,11 @@ jobs:
 
     steps:
       - name: Checkout
+        if: ${{ needs.changes.outputs.relevant != 'false' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
+        if: ${{ needs.changes.outputs.relevant != 'false' }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
@@ -236,16 +251,19 @@ jobs:
           cache-dependency-path: apps/myjobhunter/backend/requirements.txt
 
       - name: Install backend dependencies
+        if: ${{ needs.changes.outputs.relevant != 'false' }}
         working-directory: apps/myjobhunter/backend
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Run alembic migrations
+        if: ${{ needs.changes.outputs.relevant != 'false' }}
         working-directory: apps/myjobhunter/backend
         run: PYTHONPATH=. alembic upgrade head
 
       - name: Run pytest (${{ matrix.shard.name }})
+        if: ${{ needs.changes.outputs.relevant != 'false' }}
         working-directory: apps/myjobhunter/backend
         # --timeout=60 (pytest-timeout) is a safety net so a future
         # teardown bug can't consume the whole shard timeout silently.


### PR DESCRIPTION
Follow-up to #1110, which didn't fully land.

## Observed on #1109

#1109 is an app-scoped PR (touches only `.github/dependabot.yml`). After #1110 merged, its required contexts reported like this:

```
pass       shared-backend-tests
skipping   backend-deps-resolve / mybookkeeper
skipping   backend-deps-resolve / myjobhunter
skipping   backend-tests / mybookkeeper
skipping   frontend-build / mybookkeeper
skipping   frontend-build / myjobhunter
skipping   backend-tests / myjobhunter / ${{ matrix.shard.name }}   <-- wrong
```

**A matrix job skipped by a job-level `if:` does not get its matrix expanded.** GitHub reports one check named after the literal, unevaluated expression instead of the five shard contexts.

All five — `fast`, `crud`, `login-heavy`, `totp`, `refinement` — are required status checks on `main`, so #1109 stayed `BLOCKED`. #1110 fixed 5 of the 10 non-reporting contexts and silently missed these 5.

## Fix: run the job, skip its steps

- job-level gate becomes just `!cancelled()`, so the job always runs and always expands its matrix into the five real context names
- the `relevant` test moves to all five steps

Cost is a few seconds of runner startup per shard when the suite isn't needed; the shards do no actual work.

## Still fail-safe

Same property as the rest of #1110. If the `changes` gate job *fails*, `!cancelled()` still runs this job, and the step conditions then see an empty `relevant` — which is `!= 'false'`, so the full suite runs rather than being silently skipped into a green check.

The naive fix here (dropping the job-level `if:` and relying on `needs:` alone) would have reintroduced exactly that hole: a failed gate job skips its dependents, and a skipped job reports success.

## Scope

`backend-tests / myjobhunter` is the only matrix job across both gated workflows — every other job already reported its correct context name, confirmed on #1109 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5U5LnLXRKNYmoD6wDTrrT