### PR TITLE
fix(security): close the three real CodeQL findings — log injection, ReDoS, HTML-strip

### DIFF
--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 
 from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
+from platform_shared.core.logging_safety import install_crlf_safe_logging
 from platform_shared.api.transparency_router import build_transparency_router
 from platform_shared.services.transparency.scheduler import (
     maybe_start_transparency_sync,
@@ -39,6 +40,10 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
     datefmt="%Y-%m-%dT%H:%M:%S",
 )
+# Escape CR/LF + ANSI in every interpolated log message, so a request-supplied
+# value can never forge a log record (log injection). Applied at the handler
+# boundary, so it covers every call site in the process without per-call work.
+install_crlf_safe_logging()
 logger = logging.getLogger("app")
 
 

--- a/apps/mybookkeeper/backend/app/services/inquiries/inquiry_spam_scorer.py
+++ b/apps/mybookkeeper/backend/app/services/inquiries/inquiry_spam_scorer.py
@@ -40,8 +40,23 @@ CLAUDE_TIMEOUT_S = 30.0
 # operator's audit trail in ``inquiry_spam_assessments.details_json`` doesn't
 # accumulate plaintext PII. Phone covers US 10-digit, US E.164, and most
 # international formats (8-15 digits with optional separators).
-_EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
-_PHONE_RE = re.compile(r"(?:\+?\d[\s().-]?){8,15}")
+#
+# Both patterns open with a negative lookbehind that pins a match to the START
+# of a run of candidate characters. Without it, a long run that never completes
+# a match (2 000 ``%`` with no ``@``) is retried from every offset in the run,
+# making redaction quadratic in the field length — a polynomial-ReDoS handle on
+# an unauthenticated public-inquiry form. The lookbehind makes every non-start
+# offset fail in constant time, which is linear overall (measured: 62 ms -> 0.1
+# ms on a 10 000-char adversarial input) and leaves the matched set unchanged.
+#
+# The e-mail domain is spelled ``(?:label\.)+tld`` rather than
+# ``[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`` so the dot belongs to exactly one place in
+# the grammar; the original let ``.`` match either inside the class or as the
+# literal separator, which is the same backtracking amplifier one level down.
+_EMAIL_RE = re.compile(
+    r"(?<![a-zA-Z0-9._%+-])[a-zA-Z0-9._%+-]+@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}"
+)
+_PHONE_RE = re.compile(r"(?<![\d+])(?:\+?\d[\s().-]?){8,15}")
 
 
 @dataclass

--- a/apps/mybookkeeper/backend/app/services/inquiries/inquiry_spam_scorer.py
+++ b/apps/mybookkeeper/backend/app/services/inquiries/inquiry_spam_scorer.py
@@ -53,8 +53,17 @@ CLAUDE_TIMEOUT_S = 30.0
 # ``[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`` so the dot belongs to exactly one place in
 # the grammar; the original let ``.`` match either inside the class or as the
 # literal separator, which is the same backtracking amplifier one level down.
+#
+# Every quantifier is bounded. The lookbehind is what makes the scan linear in
+# practice, but static analysis reasons about the pattern in isolation and
+# cannot see it, so the bounds carry the proof: worst-case work per start
+# position is a constant, not a function of input length. The limits sit far
+# above anything RFC 5321/1035 permits (64-char local part, 63-char labels), so
+# no address that the previous pattern redacted stops being redacted -- verified
+# against a parity set before the change.
 _EMAIL_RE = re.compile(
-    r"(?<![a-zA-Z0-9._%+-])[a-zA-Z0-9._%+-]+@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}"
+    r"(?<![a-zA-Z0-9._%+-])[a-zA-Z0-9._%+-]{1,256}"
+    r"@(?:[a-zA-Z0-9-]{1,63}\.){1,16}[a-zA-Z]{2,63}"
 )
 _PHONE_RE = re.compile(r"(?<![\d+])(?:\+?\d[\s().-]?){8,15}")
 

--- a/apps/mygamingassistant/backend/app/main.py
+++ b/apps/mygamingassistant/backend/app/main.py
@@ -23,6 +23,7 @@ from jwt.exceptions import PyJWTError as JWTError
 from platform_shared.api.admin_router import build_admin_router
 from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
+from platform_shared.core.logging_safety import install_crlf_safe_logging
 from platform_shared.api.transparency_router import build_transparency_router
 
 from app.api import account, admin, games, health, lineups, lineup_packages, scheduler, sources, totp
@@ -57,6 +58,10 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
     datefmt="%Y-%m-%dT%H:%M:%S",
 )
+# Escape CR/LF + ANSI in every interpolated log message, so a request-supplied
+# value can never forge a log record (log injection). Applied at the handler
+# boundary, so it covers every call site in the process without per-call work.
+install_crlf_safe_logging()
 logger = logging.getLogger("app")
 
 

--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -10,6 +10,7 @@ from jwt.exceptions import PyJWTError as JWTError
 
 from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
+from platform_shared.core.logging_safety import install_crlf_safe_logging
 from platform_shared.api.transparency_router import build_transparency_router
 
 from app.api import account, admin, admin_invites, applications, companies, demo, discover, documents, health, integrations, job_analysis, profile, resume_refinement, resumes, totp
@@ -89,6 +90,10 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
     datefmt="%Y-%m-%dT%H:%M:%S",
 )
+# Escape CR/LF + ANSI in every interpolated log message, so a request-supplied
+# value can never forge a log record (log injection). Applied at the handler
+# boundary, so it covers every call site in the process without per-call work.
+install_crlf_safe_logging()
 logger = logging.getLogger("app")
 
 

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/dialogHelpers.test.ts
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/dialogHelpers.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { combineNotes, stripHtml } from "./dialogHelpers";
+import type { JdUrlExtractResponse } from "@/types/application/jd-url-extract-response";
+
+/**
+ * `stripHtml` turns an extracted job-description fragment into the plain-text
+ * notes scaffold. The fragment comes from a third-party page the user pointed
+ * us at, so it is untrusted input; the regex chain this replaced reconstructed
+ * markup from escaped input in two distinct ways, both pinned below.
+ */
+describe("stripHtml", () => {
+  it("removes tags and keeps the prose", () => {
+    expect(stripHtml("<p>Senior <strong>Engineer</strong></p>")).toBe("Senior Engineer");
+  });
+
+  it("turns <br> and block tags into line breaks", () => {
+    expect(stripHtml("one<br>two<br/>three")).toBe("one\ntwo\nthree");
+    expect(stripHtml("<p>alpha</p><p>beta</p>")).toBe("alpha\n\nbeta");
+    // Open AND close tags each become a break, so consecutive items read as
+    // separated paragraphs. Unchanged from the previous implementation.
+    expect(stripHtml("<li>a</li><li>b</li>")).toBe("a\n\nb");
+  });
+
+  it("collapses runs of three or more newlines", () => {
+    expect(stripHtml("a<br><br><br><br>b")).toBe("a\n\nb");
+  });
+
+  it("decodes entities", () => {
+    expect(stripHtml("Ben&nbsp;&amp; Jerry&#39;s &quot;best&quot;")).toBe(
+      'Ben & Jerry\'s "best"',
+    );
+  });
+
+  // An escaped tag is prose the page displayed literally, so it comes back as
+  // literal text — the contract is "HTML -> plain text", not "HTML -> safe
+  // HTML". What matters is that decoding happens exactly once, in one pass, so
+  // the output is a faithful transcript rather than a partially re-parsed one.
+  it("decodes an escaped tag to literal text, exactly once", () => {
+    expect(stripHtml("&lt;script&gt;alert(1)&lt;/script&gt;")).toBe(
+      "<script>alert(1)</script>",
+    );
+    expect(stripHtml("&amp;lt;script&amp;gt;")).toBe("&lt;script&gt;");
+  });
+
+  // Regression: `&amp;` -> `&` ran as its own replacement before `&lt;` -> `<`,
+  // so `&amp;lt;` was unescaped twice and yielded a bare `<`.
+  it("does not double-unescape", () => {
+    expect(stripHtml("&amp;lt;b&amp;gt;")).toBe("&lt;b&gt;");
+  });
+
+  it("drops script and style bodies rather than inlining them as prose", () => {
+    expect(stripHtml("<p>real</p><script>alert(1)</script>")).toBe("real");
+    expect(stripHtml("<style>.a{color:red}</style><p>real</p>")).toBe("real");
+  });
+
+  it("handles an unterminated tag without leaking it", () => {
+    expect(stripHtml("safe <script")).toBe("safe");
+  });
+
+  it("returns an empty string for empty or tag-only input", () => {
+    expect(stripHtml("")).toBe("");
+    expect(stripHtml("<div></div>")).toBe("");
+  });
+});
+
+describe("combineNotes", () => {
+  const base: JdUrlExtractResponse = {} as JdUrlExtractResponse;
+
+  it("returns null when every chunk is absent", () => {
+    expect(combineNotes({ ...base })).toBeNull();
+  });
+
+  it("joins summary, stripped description, and requirements with blank lines", () => {
+    const result = {
+      ...base,
+      summary: "Summary line",
+      description_html: "<p>Desc</p>",
+      requirements_text: "Reqs",
+    } as JdUrlExtractResponse;
+    expect(combineNotes(result)).toBe("Summary line\n\nDesc\n\nReqs");
+  });
+
+  it("omits a description that strips down to nothing", () => {
+    const result = {
+      ...base,
+      summary: "Summary line",
+      description_html: "<div>   </div>",
+    } as JdUrlExtractResponse;
+    expect(combineNotes(result)).toBe("Summary line");
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/dialogHelpers.ts
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/dialogHelpers.ts
@@ -53,17 +53,48 @@ export function combineNotes(result: JdUrlExtractResponse): string | null {
   return combined.length > NOTES_MAX_LEN ? combined.slice(0, NOTES_MAX_LEN) : combined;
 }
 
+/**
+ * Convert an HTML fragment to plain text.
+ *
+ * Parsing is delegated to the browser's own HTML parser via `DOMParser`
+ * rather than a chain of regex replacements. A regex chain gets this class of
+ * job wrong in two ways a real parser cannot:
+ *
+ * - **Order-dependent entity decoding.** Stripping tags before decoding
+ *   entities leaves `&lt;script&gt;` intact through the strip, then turns it
+ *   into `<script>` afterwards — the sanitiser hands back the exact markup it
+ *   was meant to remove.
+ * - **Double unescaping.** Running `&amp;` -> `&` as one replacement and
+ *   `&lt;` -> `<` as another means `&amp;lt;` decodes twice and yields `<`,
+ *   again reconstructing markup from an already-escaped input.
+ *
+ * `DOMParser.parseFromString(html, "text/html")` builds an inert document:
+ * scripts do not execute and no subresources are fetched. `textContent` then
+ * yields the text with every tag removed and every entity decoded exactly
+ * once, per the HTML spec.
+ *
+ * The result is used as plain text (the notes scaffold) and must never be fed
+ * to `dangerouslySetInnerHTML` — see NotesSection.
+ */
 export function stripHtml(html: string): string {
-  return html
+  // Preserve the line structure block-level markup implies, before the parser
+  // flattens everything to text.
+  const withBreaks = html
     .replace(/<\s*br\s*\/?\s*>/gi, "\n")
-    .replace(/<\s*\/?\s*(p|li|div|h[1-6])[^>]*>/gi, "\n")
-    .replace(/<[^>]+>/g, "")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
+    .replace(/<\s*\/?\s*(p|li|div|h[1-6])\b[^>]*>/gi, "\n");
+
+  const doc = new DOMParser().parseFromString(withBreaks, "text/html");
+  // Script/style bodies are markup internals, not prose — their text would
+  // otherwise survive into the notes.
+  doc.body
+    ?.querySelectorAll("script, style, noscript, template")
+    .forEach((el) => el.remove());
+
+  return (doc.body?.textContent ?? "")
+    // The parser decodes `&nbsp;` to U+00A0. Notes are plain text edited in a
+    // textarea, where a non-breaking space is an invisible foot-gun; fold it
+    // back to an ordinary space.
+    .replace(/\u00a0/g, " ")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }

--- a/apps/mypizzatracker/backend/app/main.py
+++ b/apps/mypizzatracker/backend/app/main.py
@@ -19,6 +19,7 @@ from jwt.exceptions import PyJWTError as JWTError
 
 from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
+from platform_shared.core.logging_safety import install_crlf_safe_logging
 from platform_shared.api.transparency_router import build_transparency_router
 
 from app.api import (
@@ -57,6 +58,10 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
     datefmt="%Y-%m-%dT%H:%M:%S",
 )
+# Escape CR/LF + ANSI in every interpolated log message, so a request-supplied
+# value can never forge a log record (log injection). Applied at the handler
+# boundary, so it covers every call site in the process without per-call work.
+install_crlf_safe_logging()
 logger = logging.getLogger("app")
 
 

--- a/apps/myrecipes/backend/app/main.py
+++ b/apps/myrecipes/backend/app/main.py
@@ -21,6 +21,7 @@ from jwt.exceptions import PyJWTError as JWTError
 
 from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
+from platform_shared.core.logging_safety import install_crlf_safe_logging
 from platform_shared.api.transparency_router import build_transparency_router
 from platform_shared.services.seed_admin_service import build_seed_admin_hook
 
@@ -48,6 +49,10 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
     datefmt="%Y-%m-%dT%H:%M:%S",
 )
+# Escape CR/LF + ANSI in every interpolated log message, so a request-supplied
+# value can never forge a log record (log injection). Applied at the handler
+# boundary, so it covers every call site in the process without per-call work.
+install_crlf_safe_logging()
 logger = logging.getLogger("app")
 
 

--- a/packages/shared-backend/platform_shared/core/logging_safety.py
+++ b/packages/shared-backend/platform_shared/core/logging_safety.py
@@ -1,0 +1,131 @@
+"""CRLF-safe logging — a Tier-1 shared primitive against log injection.
+
+Every app interpolates request-supplied values into log lines
+(``logger.info("... vendor=%s", body.vendor)``). If such a value contains a
+newline, the attacker controls where one log record visually ends and the
+next begins: they can forge an entire fake line ("... user=admin
+action=deleted") that an operator reading ``docker logs`` cannot distinguish
+from a genuine one. ANSI escape sequences are the same class of problem — a
+value carrying an ESC-bracket sequence can clear or repaint the reader's
+terminal.
+
+Rather than ask every call site to remember to sanitise (120+ call sites
+across five apps, and every new one a fresh chance to forget), this module
+neutralises the whole class **once**, at the handler boundary: the escaping
+happens after %-interpolation and before formatting, so it covers every
+logger in the process — app code, ``platform_shared``, and third-party
+libraries alike — without touching a single call site.
+
+What is escaped
+===============
+C0 control characters in the *interpolated message* — CR, LF, ESC, and the
+rest of the 0x00-0x1f range plus DEL — are rewritten to their printable
+backslash form. Horizontal tab is left alone: it is common in legitimate log
+payloads and cannot forge a record boundary.
+
+What is NOT escaped
+===================
+The formatter's own layout (timestamp, level, logger name) and the exception
+traceback appended by ``Formatter.format``. Tracebacks are multi-line by
+nature and are produced by the interpreter, not by user input. Only
+``record.getMessage()`` is rewritten.
+
+Usage
+=====
+Call once at boot, immediately after ``logging.basicConfig``::
+
+    logging.basicConfig(level=logging.INFO, format=...)
+    install_crlf_safe_logging()
+
+Idempotent — calling it twice neither double-escapes nor double-installs.
+"""
+from __future__ import annotations
+
+import logging
+
+__all__ = [
+    "CRLFSafeLogFilter",
+    "escape_log_controls",
+    "install_crlf_safe_logging",
+]
+
+# Spelled via chr() so no source-level escape sequence can be mis-read.
+_BACKSLASH = chr(92)
+
+# Control characters that get a mnemonic form; everything else in the C0
+# range falls back to a hex escape.
+_MNEMONICS = {
+    0x0A: "n",
+    0x0D: "r",
+    0x09: "t",  # listed for completeness; tab is exempted below
+}
+
+
+def _build_translation_table() -> dict[int, str]:
+    """Map every C0 control (bar tab) plus DEL to a printable escape."""
+    table: dict[int, str] = {}
+    for code in list(range(0x20)) + [0x7F]:
+        if code == 0x09:  # tab — legitimate in payloads, cannot break a record
+            continue
+        mnemonic = _MNEMONICS.get(code)
+        if mnemonic is not None:
+            table[code] = _BACKSLASH + mnemonic
+        else:
+            table[code] = _BACKSLASH + "x" + format(code, "02x")
+    return table
+
+
+_CONTROL_TRANSLATION = _build_translation_table()
+
+
+def escape_log_controls(message: str) -> str:
+    """Return ``message`` with record-breaking control characters escaped.
+
+    Pure and idempotent: the output contains no control characters, so
+    re-applying it is a no-op.
+    """
+    return message.translate(_CONTROL_TRANSLATION)
+
+
+class CRLFSafeLogFilter(logging.Filter):
+    """Rewrite a record's interpolated message so it cannot break a line.
+
+    Installed on handlers rather than loggers: a logger-level filter does not
+    see records that propagate up from child loggers, which is exactly where
+    app log calls originate.
+
+    The record is mutated in place (``msg`` replaced with the escaped,
+    fully-interpolated text and ``args`` cleared) so that *every* handler and
+    the Sentry logging integration observe the sanitised form, not just the
+    handler this filter happens to be attached to. Escaping is idempotent, so
+    several handlers each running the filter is harmless.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
+        try:
+            message = record.getMessage()
+        except Exception:  # pragma: no cover - malformed %-args
+            # A broken format string is the logging framework's problem to
+            # report; never let sanitisation swallow the record.
+            return True
+        safe = escape_log_controls(message)
+        if safe != message:
+            record.msg = safe
+            record.args = ()
+        return True
+
+
+def install_crlf_safe_logging(logger: logging.Logger | None = None) -> None:
+    """Attach :class:`CRLFSafeLogFilter` to every handler on ``logger``.
+
+    Defaults to the root logger, which is where ``logging.basicConfig``
+    installs the process-wide handler that app loggers propagate to.
+
+    Args:
+        logger: Logger whose handlers get the filter. Defaults to root.
+    """
+    target = logger if logger is not None else logging.getLogger()
+    for handler in target.handlers:
+        if any(isinstance(f, CRLFSafeLogFilter) for f in handler.filters):
+            continue
+        handler.addFilter(CRLFSafeLogFilter())

--- a/packages/shared-backend/tests/test_logging_safety.py
+++ b/packages/shared-backend/tests/test_logging_safety.py
@@ -1,0 +1,150 @@
+"""Tests for the CRLF-safe logging primitive.
+
+Log injection is the single largest class of CodeQL finding in this monorepo
+(120+ ``py/log-injection`` alerts across five apps): request-supplied values are
+interpolated into log lines, and a newline in one of them lets an attacker forge
+a whole extra record that an operator reading ``docker logs`` cannot tell from a
+real one. The defence lives at the handler boundary rather than at the call
+sites, so these tests pin the boundary behaviour.
+"""
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+from platform_shared.core.logging_safety import (
+    CRLFSafeLogFilter,
+    escape_log_controls,
+    install_crlf_safe_logging,
+)
+
+
+@pytest.fixture()
+def captured():
+    """A logger with one stream handler, isolated from the root config."""
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    logger = logging.getLogger("platform_shared.tests.logging_safety")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    try:
+        yield logger, stream, handler
+    finally:
+        logger.handlers = []
+
+
+class TestEscapeLogControls:
+    def test_newline_and_carriage_return_become_printable(self) -> None:
+        assert escape_log_controls("a\nb\rc") == "a\\nb\\rc"
+
+    def test_ansi_escape_is_neutralised(self) -> None:
+        # A raw ESC lets a value repaint or clear the reader's terminal.
+        assert escape_log_controls("\x1b[2Jwiped") == "\\x1b[2Jwiped"
+
+    def test_other_c0_controls_become_hex(self) -> None:
+        assert escape_log_controls("\x00\x07") == "\\x00\\x07"
+
+    def test_del_is_escaped(self) -> None:
+        assert escape_log_controls("\x7f") == "\\x7f"
+
+    def test_tab_is_preserved(self) -> None:
+        # Tab is common in legitimate payloads and cannot forge a record break.
+        assert escape_log_controls("a\tb") == "a\tb"
+
+    def test_ordinary_text_is_untouched(self) -> None:
+        assert escape_log_controls("vendor=ACME count=3") == "vendor=ACME count=3"
+
+    def test_idempotent(self) -> None:
+        once = escape_log_controls("a\nb")
+        assert escape_log_controls(once) == once
+
+
+class TestFilterAtHandlerBoundary:
+    def test_forged_record_is_flattened_to_one_line(self, captured) -> None:
+        logger, stream, _ = captured
+        install_crlf_safe_logging(logger)
+        # The classic attack: a field value that closes the real record and
+        # opens a convincing fake one.
+        logger.info("reassign vendor=%s", "ACME\nINFO app ADMIN_DB wiped_everything")
+        out = stream.getvalue()
+        assert out.count("\n") == 1, out  # only the handler's own terminator
+        assert "ACME\\nINFO app ADMIN_DB wiped_everything" in out
+
+    def test_escaping_happens_after_interpolation(self, captured) -> None:
+        # A literal ``%s`` in the format string is not itself the payload; the
+        # newline arrives via the argument, so escaping must run post-format.
+        logger, stream, _ = captured
+        install_crlf_safe_logging(logger)
+        logger.warning("a=%s b=%s", "x\ny", "z")
+        assert "a=x\\ny b=z" in stream.getvalue()
+
+    def test_clean_message_is_unchanged(self, captured) -> None:
+        logger, stream, _ = captured
+        install_crlf_safe_logging(logger)
+        logger.info("vendor=%s count=%d", "ACME", 3)
+        assert "INFO vendor=ACME count=3" in stream.getvalue()
+
+    def test_exception_traceback_keeps_its_newlines(self, captured) -> None:
+        # Tracebacks are interpreter-generated and multi-line by nature; only
+        # the interpolated message is sanitised.
+        logger, stream, _ = captured
+        install_crlf_safe_logging(logger)
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            logger.exception("failed for vendor=%s", "ACME\nfake")
+        out = stream.getvalue()
+        assert "vendor=ACME\\nfake" in out
+        assert "Traceback (most recent call last):" in out
+        assert out.count("\n") > 1
+
+    def test_install_is_idempotent(self, captured) -> None:
+        logger, stream, handler = captured
+        install_crlf_safe_logging(logger)
+        install_crlf_safe_logging(logger)
+        assert sum(isinstance(f, CRLFSafeLogFilter) for f in handler.filters) == 1
+        # And a second pass must not double-escape the backslash.
+        logger.info("v=%s", "a\nb")
+        assert "v=a\\nb" in stream.getvalue()
+
+    def test_two_handlers_do_not_double_escape(self, captured) -> None:
+        logger, stream, _ = captured
+        second = io.StringIO()
+        extra = logging.StreamHandler(second)
+        extra.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(extra)
+        install_crlf_safe_logging(logger)
+        logger.info("v=%s", "a\nb")
+        assert "v=a\\nb" in stream.getvalue()
+        assert second.getvalue().strip() == "v=a\\nb"
+
+    def test_malformed_format_string_still_emits(self, captured) -> None:
+        # A broken format string is the logging framework's error to report --
+        # sanitisation must never swallow the record.
+        logger, _stream, handler = captured
+        install_crlf_safe_logging(logger)
+        record = logging.LogRecord(
+            name="t", level=logging.INFO, pathname=__file__, lineno=1,
+            msg="%s %s", args=("only-one",), exc_info=None,
+        )
+        assert all(f.filter(record) for f in handler.filters)
+
+
+def test_root_install_covers_basic_config_handler() -> None:
+    """The boot-time shape: ``basicConfig`` then ``install_crlf_safe_logging``."""
+    root = logging.getLogger()
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    original = root.handlers
+    root.handlers = [handler]
+    try:
+        install_crlf_safe_logging()
+        logging.getLogger("app.some.child").warning("v=%s", "a\nb")
+        assert stream.getvalue().strip() == "v=a\\nb"
+    finally:
+        root.handlers = original


### PR DESCRIPTION
Triage of all **140 open code-scanning alerts**. Three are genuine defects and are fixed here; the remaining 137 are false positives or intentional, and are listed below for dismissal in the Security tab (no code change is the right answer for them).

## Fixed

### 1. `py/log-injection` — 120 alerts, all five apps + `platform_shared`

Request-supplied values are interpolated into log lines (`logger.info("... vendor=%s", body.vendor)`). A newline in one lets an attacker close the real record and forge a convincing extra one an operator reading `docker logs` cannot distinguish from genuine; an ANSI escape lets them repaint the reader's terminal.

Fixed **once at the handler boundary** rather than at 120 call sites: new Tier-1 shared primitive `platform_shared.core.logging_safety` escapes C0 controls (tab exempted) and DEL in the *interpolated* message. Exception tracebacks keep their newlines — interpreter-generated, not user input. All five apps call `install_crlf_safe_logging()` immediately after `logging.basicConfig`, so every current and future call site is covered without per-call discipline.

### 2. `py/polynomial-redos` — `inquiry_spam_scorer`, reachable from the unauthenticated public-inquiry form

`_EMAIL_RE` was retried from every offset of a long candidate run that never completes a match, making PII redaction quadratic in field length. A negative lookbehind pins each match to the start of a run; the domain is respelled `(?:label\.)+tld` so `.` belongs to one place in the grammar instead of two. **62 ms → 0.1 ms** on a 10 000-char adversarial input, matched set unchanged across a parity check. `_PHONE_RE` gets the same lookbehind.

### 3. `js/double-escaping` + `js/incomplete-multi-character-sanitization` — `stripHtml`

The regex chain stripped tags *before* decoding entities, so `&lt;script&gt;` survived the strip and was decoded back into markup afterwards; and `&amp;`→`&` running as its own replacement before `&lt;`→`<` unescaped `&amp;lt;` twice. Replaced with `DOMParser` + `textContent` — an inert parse (no script execution, no subresource loads) that removes every tag and decodes every entity exactly once, per spec.

Not currently exploitable: the output is a plain-text notes scaffold and MJH uses `dangerouslySetInnerHTML` nowhere. The function was still wrong on its own terms.

## Assessed as not-a-defect (dismiss, don't patch)

| Alert | Why |
|---|---|
| `py/full-ssrf` (critical) — `jd_url_fetcher.py:162` | Guarded. `assert_url_safe()` runs before **every** request including each manually-followed redirect hop; auto-follow is off precisely so the guard sees each one. CodeQL cannot see through the custom sanitiser. |
| `py/incomplete-url-substring-sanitization` ×5 — `tavily_service.py` | `_classify_source_type` is *classification*, not sanitisation — it picks a `source_type` label. No allow/deny decision rides on it; worst case is a mislabelled row. |
| `py/weak-sensitive-data-hashing` — `hibp_service.py:35` | SHA-1 is mandated by HIBP's k-anonymity range API. Only the first 5 hex chars leave the server; password *storage* is argon2 via pwdlib. (The existing inline `# codeql[...]` comment does nothing — code scanning does not honour suppression comments.) |
| `py/weak-sensitive-data-hashing` ×2 — `testing/factories.py` | Test-only fast hasher, monkeypatched into fastapi-users inside test processes only. |
| `py/jinja2/autoescape-false` — `infra/render.py:90` | Renders Caddyfile / compose / Dockerfile / workflow YAML, not HTML, from repo-local config. Turning autoescape on would corrupt the generated files. |
| `js/xss-through-dom` — `MinimapUploadDialog.tsx:92` | `previewUrl` is `URL.createObjectURL(file)` for a locally-selected image — a `blob:` URL, not attacker-supplied markup. |
| `js/missing-origin-check` ×5 — `chrome-extension/test-pages/*.html` | Local dev fixtures mimicking tax sites. Not in `manifest.json`, never shipped. |
| `py/clear-text-logging-sensitive-data` — `discovery_promote_service.py:92` | The logged value is a 3-character currency code, flagged because "salary" appears in the variable name. |

## Verification

- 15 new tests for the logging primitive — escaping, idempotency, post-interpolation ordering, traceback preservation, multi-handler safety, malformed-format-string passthrough.
- **Real-path check**: booted MBK's actual `app.main` and logged a forged-record payload through the real `app.api.db_admin` logger:
  ```
  2026-08-18T10:36:00 INFO app.api.db_admin ADMIN_DB reassign_property org=org-1 vendor=ACME\nINFO app ADMIN_DB soft_delete org=* count=99999 [FORGED]\x1b[31m pattern=*.pdf target=prop-1 count=3
  ```
  One line, escapes visible.
- 12 new tests for `stripHtml` / `combineNotes`, including regressions for both bugs.
- `shared-backend`: 866 passed (5 pre-existing `twilio` import failures in this venv, unrelated). MBK inquiry/spam: 142 passed. MJH `typecheck` + `eslint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5U5LnLXRKNYmoD6wDTrrT