### PR TITLE
fix(mbk): serve /version without the /api prefix so VersionTag stops 404ing

### DIFF
--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -289,6 +289,10 @@ async def health():
         )
 
 
-@app.get("/api/version")
+# Declared WITHOUT the ``/api`` prefix on purpose. Both the docker Caddy
+# (``uri strip_prefix /api``) and the Vite dev proxy (``rewrite``) remove the
+# prefix before the request reaches FastAPI, so a route declared as
+# ``/api/version`` is unreachable from a browser in every environment.
+@app.get("/version")
 async def version():
     return {"commit": GIT_COMMIT, "timestamp": STARTUP_TIMESTAMP}

--- a/apps/mybookkeeper/backend/tests/test_version_endpoint.py
+++ b/apps/mybookkeeper/backend/tests/test_version_endpoint.py
@@ -55,13 +55,17 @@ def test_startup_timestamp_is_iso_format():
 
 @pytest.mark.asyncio
 async def test_version_endpoint_returns_commit_and_timestamp():
-    """GET /api/version returns commit and timestamp."""
+    """GET /version returns commit and timestamp.
+
+    Declared without the ``/api`` prefix: Caddy and the Vite dev proxy both
+    strip it, so the browser-facing ``/api/version`` lands here.
+    """
     from app.main import app, GIT_COMMIT, STARTUP_TIMESTAMP
     from httpx import ASGITransport, AsyncClient
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/api/version")
+        resp = await client.get("/version")
 
     assert resp.status_code == 200
     body = resp.json()
@@ -82,3 +86,27 @@ async def test_health_endpoint_includes_version():
     body = resp.json()
     assert "version" in body
     assert body["version"] == GIT_COMMIT
+
+
+def test_no_route_carries_the_api_prefix():
+    """No route may be declared under ``/api``.
+
+    Both the docker Caddy (``uri strip_prefix /api``) and the Vite dev proxy
+    (``rewrite``) remove the prefix before the request reaches FastAPI. A route
+    declared as ``/api/<x>`` is therefore unreachable from a browser in every
+    environment while still passing an ASGI-transport test, which is exactly
+    how ``/api/version`` shipped dead.
+    """
+    from app.main import app
+
+    offenders = [
+        route.path
+        for route in app.routes
+        if getattr(route, "path", "").startswith("/api/")
+        or getattr(route, "path", "") == "/api"
+    ]
+
+    assert offenders == [], (
+        "Routes declared under /api are unreachable behind the proxy: "
+        f"{offenders}. Drop the prefix — Caddy and Vite both strip it."
+    )


### PR DESCRIPTION
## What

`@app.get("/api/version")` is unreachable from a browser. Both the docker Caddy (`uri strip_prefix /api`) and the Vite dev proxy (`rewrite: p => p.replace(/^\/api/, "")`) strip the prefix before the request reaches FastAPI, so the browser's `/api/version` arrives as `/version` — which has no route.

Result: `useGetVersionQuery` rejects with 404 on every authenticated page load, and `VersionTag` has never rendered a commit hash.

## Verification

Read straight out of the live RTK Query cache on `mybookkeeper.myfreeapps.org` — `getVersion` was the only rejected query:

```
getVersion: { status: 404, data: { detail: "Not Found" } }
```

## The fix

- Route declared as `/version`, with a comment explaining why the prefix is absent.
- `tests/test_version_endpoint.py` retargeted. The old test hit the ASGI app directly, where nothing strips the prefix, so it passed against a dead route.
- New guard `test_no_route_carries_the_api_prefix` fails if any route is declared under `/api`. Confirmed it fires when a `/api/oops` route is registered.

9/9 tests pass.

## Operational migration

None. Additive route change; no env or config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjdCBvpKpsKRmYquYySxSA