### PR TITLE
fix(mybookkeeper): stop a photo upload wiping unsaved welcome-manual text

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualSectionCard.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualSectionCard.test.tsx
@@ -7,6 +7,10 @@
  *     changed field).
  *   - A freshly-seeded stub (body: null) shows the placeholder prompt, not a
  *     blank pre-filled field.
+ *   - Unsaved text survives a refetch that leaves the persisted title/body
+ *     untouched (e.g. uploading a photo into the section mid-edit).
+ *   - A genuine server-side change to the persisted body still re-baselines.
+ *   - A section still carrying the placeholder title is flagged as just-added.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -51,11 +55,21 @@ function makeSection(overrides: Partial<WelcomeManualSectionResponse>): WelcomeM
 }
 
 function renderCard(section: WelcomeManualSectionResponse) {
-  return render(
+  const utils = render(
     <DndContext>
       <WelcomeManualSectionCard manualId="m-1" section={section} />
     </DndContext>,
   );
+  return {
+    ...utils,
+    /** Simulate the manual refetching and handing this card a new section object. */
+    refetchWith: (next: WelcomeManualSectionResponse) =>
+      utils.rerender(
+        <DndContext>
+          <WelcomeManualSectionCard manualId="m-1" section={next} />
+        </DndContext>,
+      ),
+  };
 }
 
 describe("WelcomeManualSectionCard", () => {
@@ -96,6 +110,60 @@ describe("WelcomeManualSectionCard", () => {
     expect(body.placeholder).toBe("Add instructions for guests…");
     // No preview rendered when the body is empty.
     expect(screen.queryByTestId("welcome-manual-section-body-preview")).not.toBeInTheDocument();
+  });
+
+  it("keeps unsaved text when a photo upload refetches the manual", async () => {
+    // Uploading an image invalidates the whole manual tag, so this card is
+    // handed a brand-new section object whose title/body are unchanged. That
+    // must not discard what the host has typed but not yet saved.
+    const { refetchWith } = renderCard(makeSection({ body: null }));
+
+    const body = screen.getByTestId("welcome-manual-section-body") as HTMLTextAreaElement;
+    await userEvent.type(body, "Router is in the hall closet");
+
+    refetchWith(
+      makeSection({
+        body: null,
+        images: [
+          {
+            id: "img-1",
+            section_id: "sec-1",
+            storage_key: "welcome-manuals/m-1/sec-1/img-1.jpg",
+            caption: null,
+            display_order: 0,
+            presigned_url: "https://example.test/img-1.jpg",
+            is_available: true,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
+    );
+
+    expect(
+      (screen.getByTestId("welcome-manual-section-body") as HTMLTextAreaElement).value,
+    ).toBe("Router is in the hall closet");
+    expect(screen.getByTestId("welcome-manual-section-save")).not.toBeDisabled();
+  });
+
+  it("re-baselines when the persisted body actually changes", () => {
+    const { refetchWith } = renderCard(makeSection({ body: "Old text" }));
+    refetchWith(makeSection({ body: "Saved from another tab" }));
+
+    const body = screen.getByTestId("welcome-manual-section-body") as HTMLTextAreaElement;
+    expect(body.value).toBe("Saved from another tab");
+    expect(screen.getByTestId("welcome-manual-section-save")).toBeDisabled();
+  });
+
+  it("flags a section that still carries the placeholder title", () => {
+    renderCard(makeSection({ title: "New section", body: null }));
+    expect(screen.getByTestId("welcome-manual-section-unnamed-badge")).toBeInTheDocument();
+  });
+
+  it("drops the just-added flag once the section has a real title", () => {
+    renderCard(makeSection({ title: "Wi-Fi" }));
+    expect(
+      screen.queryByTestId("welcome-manual-section-unnamed-badge"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders the field manager with an Add-field button", () => {

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionCard.tsx
@@ -6,6 +6,7 @@ import { LoadingButton, ConfirmDialog } from "@platform/ui";
 import FormField from "@/shared/components/ui/FormField";
 import Markdown from "@/shared/components/ui/Markdown";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { NEW_SECTION_DEFAULT_TITLE } from "@/shared/lib/welcome-manual-constants";
 import { useDeleteSectionMutation } from "@/shared/store/welcomeManualsApi";
 import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
 import WelcomeManualSectionFieldManager from "./WelcomeManualSectionFieldManager";
@@ -27,6 +28,11 @@ const WelcomeManualSectionCard = forwardRef<HTMLElement, WelcomeManualSectionCar
     const [deleteSection] = useDeleteSectionMutation();
     const [confirmDelete, setConfirmDelete] = useState(false);
     const editor = useSectionEditor({ manualId, section });
+
+    // A section keeps the placeholder title until the host renames it, so this
+    // marks the one they just added without any transient client state — it
+    // survives a refetch or a page reload and clears itself on the first save.
+    const isUnnamed = section.title === NEW_SECTION_DEFAULT_TITLE;
 
     const style = {
       transform: CSS.Transform.toString(transform),
@@ -57,10 +63,23 @@ const WelcomeManualSectionCard = forwardRef<HTMLElement, WelcomeManualSectionCar
       <section
         ref={setRefs}
         style={style}
-        className="border rounded-lg p-4 space-y-3 bg-card"
+        className={`rounded-lg p-4 space-y-3 bg-card ${
+          isUnnamed
+            ? "border-2 border-amber-400 dark:border-amber-600"
+            : "border"
+        }`}
         data-testid="welcome-manual-section-card"
         data-section-id={section.id}
       >
+        {isUnnamed ? (
+          <p
+            className="inline-block rounded-full bg-amber-100 dark:bg-amber-900 px-2 py-0.5 text-xs font-medium text-amber-800 dark:text-amber-200"
+            data-testid="welcome-manual-section-unnamed-badge"
+          >
+            Just added — give it a name and instructions
+          </p>
+        ) : null}
+
         <div className="flex items-start gap-2">
           <button
             {...attributes}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/useSectionEditor.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/useSectionEditor.ts
@@ -6,10 +6,6 @@ import type { SectionEditorValues } from "@/shared/types/welcome-manual/section-
 import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
 import type { WelcomeManualSectionUpdateRequest } from "@/shared/types/welcome-manual/welcome-manual-section-update-request";
 
-function sectionToValues(section: WelcomeManualSectionResponse): SectionEditorValues {
-  return { title: section.title, body: section.body ?? "" };
-}
-
 function valuesToUpdateRequest(
   values: SectionEditorValues,
   dirty: Partial<Record<keyof SectionEditorValues, boolean>>,
@@ -46,7 +42,17 @@ export interface UseSectionEditorResult {
 export function useSectionEditor({ manualId, section }: UseSectionEditorArgs): UseSectionEditorResult {
   const [updateSection, { isLoading: isSaving }] = useUpdateSectionMutation();
 
-  const defaults = useMemo<SectionEditorValues>(() => sectionToValues(section), [section]);
+  // Depend on the persisted VALUES, not the section object. Every mutation on
+  // this manual (uploading a photo, adding a field, saving a caption, adding a
+  // place) invalidates the whole manual tag, so `section` is a brand-new object
+  // after each one even when its title and body are untouched.
+  const serverTitle = section.title;
+  const serverBody = section.body ?? "";
+
+  const defaults = useMemo<SectionEditorValues>(
+    () => ({ title: serverTitle, body: serverBody }),
+    [serverTitle, serverBody],
+  );
 
   const {
     register,
@@ -56,8 +62,10 @@ export function useSectionEditor({ manualId, section }: UseSectionEditorArgs): U
     formState: { errors, dirtyFields, isDirty },
   } = useForm<SectionEditorValues>({ defaultValues: defaults });
 
-  // Re-baseline when the server value changes (after a successful save/refetch
-  // or an external edit) so "dirty" reflects the latest persisted state.
+  // Re-baseline only when the persisted text actually changes — a successful
+  // save, or an edit from elsewhere. Keying this on object identity meant a
+  // photo upload mid-edit reset the form and discarded whatever the host had
+  // typed but not yet saved.
   useEffect(() => {
     reset(defaults);
   }, [defaults, reset]);

--- a/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
@@ -291,24 +291,35 @@ export default function WelcomeManualDetail() {
                     </div>
                   </SortableContext>
                 </DndContext>
-              ) : (
-                <p
-                  className="text-sm text-muted-foreground border rounded-lg p-6 text-center"
-                  data-testid="welcome-manual-sections-empty"
-                >
-                  No sections yet. Add one to start building this guide.
-                </p>
-              )}
+              ) : null}
 
-              <div className="flex justify-center">
+              {/* Deliberately a dashed tile, not another solid card — the host
+                  needs to tell "add a new section" apart from the sections
+                  themselves at a glance. Doubles as the empty state. */}
+              <div
+                className="border-2 border-dashed rounded-lg p-6 text-center space-y-3"
+                data-testid="welcome-manual-add-section"
+              >
+                {hasSections ? (
+                  <p className="text-sm text-muted-foreground">
+                    Sections are the parts of the guide — Wi-Fi, parking, trash day, check-out.
+                  </p>
+                ) : (
+                  <p
+                    className="text-sm text-muted-foreground"
+                    data-testid="welcome-manual-sections-empty"
+                  >
+                    No sections yet. Add one to start building this guide.
+                  </p>
+                )}
                 <LoadingButton
-                  variant="secondary"
+                  variant="primary"
                   onClick={() => void handleAddSection()}
                   isLoading={isAddingSection}
                   loadingText="Adding..."
                   data-testid="add-welcome-manual-section-button"
                 >
-                  <Plus className="h-4 w-4 mr-1" />
+                  <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
                   Add section
                 </LoadingButton>
               </div>


### PR DESCRIPTION
## The bug

> "I typed out a description in the new section then I uploaded a picture for the new section and my description was wiped."

Reproduced and fixed.

`useSectionEditor` re-baselined its react-hook-form state from a `useMemo` keyed on the **`section` object**:

```ts
const defaults = useMemo(() => sectionToValues(section), [section]);
useEffect(() => { reset(defaults); }, [defaults, reset]);
```

Every welcome-manual mutation invalidates the whole `{ type: "WelcomeManual", id }` tag, so `getWelcomeManualById` refetches and each card receives a brand-new `section` object — even when its title and body are byte-identical. That changed the memo's identity, fired `reset()`, and discarded whatever the host had typed but not yet saved.

Uploading a photo is the path the operator hit, but **adding a field, saving an image caption, reordering photos, and adding a place all did the same thing**, to every section card on the page at once.

The fix keys the baseline on the persisted title/body strings. The form still re-baselines after a real save or an edit from elsewhere; a refetch that changes nothing about the text now leaves the editor alone.

## Also: "it needs to be more visible which section is the new one"

The freshly-added card was styled identically to every other one.

- A section still carrying the placeholder title now gets an amber border and a **"Just added — give it a name and instructions"** badge. Derived from the persisted title rather than transient client state, so it survives a refetch or a reload and clears itself on the first save.
- The add-section affordance is now a dashed tile with a primary button, instead of a small secondary button floating between the cards. It also absorbs the empty state rather than sitting underneath a second placeholder.

## Verification

Run against the **real stack** — PostgreSQL 18 on :5433, MinIO on :9000, the API on :8001, Vite on :5174 — with a throwaway Playwright spec driving the operator's exact sequence: add a section → type a description → upload a real JPEG → assert the text survives.

- **Before the fix:** fails at the post-upload assertion (`toHaveValue` — the textarea is empty).
- **After the fix:** passes, and the text saves correctly afterwards.

Unit regression tests added to `WelcomeManualSectionCard.test.tsx`:
- unsaved text survives a refetch that only adds an image (**fails on the old code**: `expected '' to be 'Router is in the hall closet'`)
- a genuine server-side body change still re-baselines and clears dirty
- the just-added badge shows for a placeholder title and not for a real one

`tsc --noEmit` clean, ESLint clean (one pre-existing react-hook-form `watch` warning). MBK frontend unit suite: the 4 failing files (`hourly-rate`, `PromoteFromInquiryPanel`, `LeaseTemplateUploadDialog`, `PublicInquiryForm`) fail identically on untouched `main`. The 3 welcome-manual e2e failures are likewise identical on baseline — local dev-DB data pollution, not this change.

## Screenshots

Just-added section, and the dashed add tile — both from the running app.