### PR TITLE
feat(mbk): bill rent on calendar months with a prorated first period

### DIFF
--- a/apps/mybookkeeper/backend/app/core/rent_ledger_enums.py
+++ b/apps/mybookkeeper/backend/app/core/rent_ledger_enums.py
@@ -12,10 +12,11 @@ Mirrors ``app/core/applicant_enums.py`` for consistency.
 # deliberately independent of how often the tenant actually pays — a tenant on
 # a monthly schedule who pays weekly is the case this whole domain exists for.
 #
-# Periods tile forward from ``rent_schedules.start_date``; there is no separate
-# anchor day. A lease starting on the 15th bills the 15th→14th, which is how
-# leases actually read. Adding a cadence here means adding a branch to
-# ``rent_period_math.period_bounds`` and a case to its tests.
+# ``monthly`` bills calendar months: rent is due on the 1st, and a tenant who
+# moves in mid-month owes a prorated first period. ``weekly`` / ``biweekly``
+# tile from ``rent_schedules.start_date`` instead, since there is no calendar
+# boundary to align a weekly obligation to. Adding a cadence here means adding
+# a branch to ``rent_period_math.natural_bounds`` and a case to its tests.
 RENT_CADENCES: tuple[str, ...] = ("monthly", "weekly", "biweekly")
 
 # Number of days in a cadence's period, for the cadences that tile on a fixed

--- a/apps/mybookkeeper/backend/app/models/rent/rent_schedule.py
+++ b/apps/mybookkeeper/backend/app/models/rent/rent_schedule.py
@@ -77,7 +77,8 @@ class RentSchedule(Base):
 
     cadence: Mapped[str] = mapped_column(String(12), nullable=False)
 
-    # Periods tile forward from ``start_date``; see ``rent_period_math``.
+    # Monthly periods are calendar months, with the first one prorated from
+    # ``start_date``; weekly/biweekly tile from it. See ``rent_period_math``.
     start_date: Mapped[_dt.date] = mapped_column(Date, nullable=False)
     # NULL = open-ended. When set, the period containing it is prorated by
     # actual days and no later period is generated.

--- a/apps/mybookkeeper/backend/app/schemas/rent/rent_charge_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/rent/rent_charge_response.py
@@ -18,6 +18,11 @@ class RentChargeResponse(BaseModel):
     period_end: _dt.date
     due_date: _dt.date
     amount: Decimal
+    # The schedule's undivided amount, when this period was prorated for a
+    # part-month tenancy. ``None`` for a whole period or a one-off charge, so
+    # the client can say "$822.58 of $1,500.00, prorated" instead of leaving a
+    # short number looking like a mistake.
+    full_amount: Decimal | None = None
     description: str | None = None
     waived_at: _dt.datetime | None = None
     waived_reason: str | None = None

--- a/apps/mybookkeeper/backend/app/schemas/rent/rent_period_summary.py
+++ b/apps/mybookkeeper/backend/app/schemas/rent/rent_period_summary.py
@@ -14,6 +14,9 @@ class RentPeriodSummary(BaseModel):
     period_start: _dt.date
     period_end: _dt.date
     amount: Decimal
+    # Set only when ``amount`` is a prorated slice of a part-month tenancy;
+    # see ``RentChargeResponse.full_amount``.
+    full_amount: Decimal | None = None
     allocated: Decimal
     remaining: Decimal
     status: str

--- a/apps/mybookkeeper/backend/app/services/rent/rent_ledger_service.py
+++ b/apps/mybookkeeper/backend/app/services/rent/rent_ledger_service.py
@@ -248,6 +248,16 @@ async def get_ledger(
         for c in charges
     }
 
+    # A generated charge worth less than its schedule's amount was prorated —
+    # a part-month tenancy at one end or the other. Surfacing the undivided
+    # amount lets the UI explain the shortfall rather than just show it.
+    full_amount_by_charge = {
+        c.id: schedules_by_id[c.schedule_id].amount
+        for c in charges
+        if c.schedule_id in schedules_by_id
+        and c.amount != schedules_by_id[c.schedule_id].amount
+    }
+
     charge_responses: list[RentChargeResponse] = []
     for settlement in result.settlements:
         charge = charges_by_id[settlement.charge_id]
@@ -260,6 +270,7 @@ async def get_ledger(
                 period_end=charge.period_end,
                 due_date=charge.due_date,
                 amount=charge.amount,
+                full_amount=full_amount_by_charge.get(charge.id),
                 description=charge.description,
                 waived_at=charge.waived_at,
                 waived_reason=charge.waived_reason,
@@ -308,6 +319,7 @@ async def get_ledger(
         charges=charges,
         settlement_by_id=settlement_by_id,
         cadence_by_charge=cadence_by_charge,
+        full_amount_by_charge=full_amount_by_charge,
         as_of=today,
     )
 
@@ -326,7 +338,8 @@ async def get_ledger(
 
 
 def _current_period(
-    *, charges, settlement_by_id, cadence_by_charge, as_of: _dt.date,
+    *, charges, settlement_by_id, cadence_by_charge, full_amount_by_charge,
+    as_of: _dt.date,
 ) -> RentPeriodSummary | None:
     """The rent charge whose period contains ``as_of``.
 
@@ -353,6 +366,7 @@ def _current_period(
         period_start=charge.period_start,
         period_end=charge.period_end,
         amount=charge.amount,
+        full_amount=full_amount_by_charge.get(charge.id),
         allocated=settlement.allocated,
         remaining=settlement.remaining,
         status=settlement.status(as_of),

--- a/apps/mybookkeeper/backend/app/services/rent/rent_period_math.py
+++ b/apps/mybookkeeper/backend/app/services/rent/rent_period_math.py
@@ -1,16 +1,32 @@
 """Pure period arithmetic for rent schedules.
 
-A schedule's periods tile forward from ``start_date`` with no separate anchor
-day: period 0 begins on ``start_date``, and each subsequent period begins where
-the previous one ended. A lease starting on the 15th therefore bills 15th→14th,
-which is how leases actually read, and it removes any need to prorate a partial
-*first* period.
+Monthly schedules bill on **calendar months**: rent is due on the 1st, and a
+tenant who moves in mid-month owes a prorated first period covering only the
+days they were there. A schedule starting Aug 15 therefore produces
 
-The only period that can be short is the last one, when the schedule's
-``end_date`` falls inside it. That tail is prorated by actual elapsed days over
-the days the full period would have run — actual days, not the 30-day
-convention used by ``inquiry_rent_proration``, because here both boundaries of
-the period are known exactly and a real denominator is available.
+    Aug 15 – Aug 31   prorated (17 of August's 31 days)
+    Sep 1  – Sep 30   full
+    Oct 1  – Oct 31   full
+
+which is how rent is normally billed and collected. A schedule starting on the
+1st is the ordinary case of the same rule, with nothing to prorate.
+
+Weekly and biweekly schedules tile from ``start_date`` instead — a tenant who
+pays every Friday is billed Friday to Thursday, and there is no calendar
+boundary to align to.
+
+Either end of a period can be short:
+
+- the **first** period, when the schedule starts after the month begins;
+- the **last** period, when ``end_date`` falls inside it;
+- both at once, for a schedule that starts and ends inside one month.
+
+All three are the same computation — actual days over the days the whole
+period would have run. Actual days, not the 30-day convention used by
+``inquiry_rent_proration``, because here both boundaries of the period are
+known exactly and a real denominator is available. (That module prices
+hypothetical stays, where a fixed 30 keeps two equal-length stays priced
+equally; this one bills a real month someone actually lived in.)
 
 Everything in this module is a pure function of its arguments: no DB, no clock.
 """
@@ -25,43 +41,57 @@ from app.core.rent_ledger_enums import RENT_CADENCE_DAYS, RENT_CADENCES
 _CENTS = Decimal("0.01")
 
 
-def add_months(start: _dt.date, months: int) -> _dt.date:
-    """``start`` advanced by ``months``, clamping the day to the target month.
-
-    Clamping matters for month-end starts: a schedule beginning Jan 31 yields
-    Feb 28 (or 29), Mar 31, Apr 30 — the day never drifts permanently downward
-    because every step is computed from the original ``start``, not from the
-    previously clamped result.
-    """
+def month_first(start: _dt.date, months: int) -> _dt.date:
+    """The 1st of the month ``months`` after ``start``'s month."""
     total = start.month - 1 + months
     year = start.year + total // 12
     month = total % 12 + 1
-    day = min(start.day, calendar.monthrange(year, month)[1])
-    return _dt.date(year, month, day)
+    return _dt.date(year, month, 1)
 
 
-def period_start(schedule_start: _dt.date, cadence: str, index: int) -> _dt.date:
-    """First day of period ``index`` (0-based) for a schedule."""
+def month_last(day: _dt.date) -> _dt.date:
+    """The last day of ``day``'s month."""
+    return day.replace(day=calendar.monthrange(day.year, day.month)[1])
+
+
+def natural_bounds(
+    schedule_start: _dt.date, cadence: str, index: int,
+) -> tuple[_dt.date, _dt.date]:
+    """The whole period ``index`` occupies, ignoring where the schedule sits.
+
+    This is the denominator of proration: the period as it would run if the
+    tenant were there for all of it. For monthly that is the calendar month;
+    for the fixed-length cadences it is a full span from ``start_date``.
+    """
     if cadence not in RENT_CADENCES:
         raise ValueError(f"unknown cadence: {cadence!r}")
     if index < 0:
         raise ValueError("period index must be >= 0")
     if cadence == "monthly":
-        return add_months(schedule_start, index)
-    return schedule_start + _dt.timedelta(days=RENT_CADENCE_DAYS[cadence] * index)
+        begin = month_first(schedule_start, index)
+        return begin, month_last(begin)
+    span = RENT_CADENCE_DAYS[cadence]
+    begin = schedule_start + _dt.timedelta(days=span * index)
+    return begin, begin + _dt.timedelta(days=span - 1)
 
 
 def period_bounds(
     schedule_start: _dt.date, cadence: str, index: int,
 ) -> tuple[_dt.date, _dt.date]:
-    """``(period_start, period_end)`` for period ``index``, end **inclusive**.
+    """``(start, end)`` of period ``index`` as billed, end **inclusive**.
 
-    The end is the day before the next period begins, so consecutive periods
-    tile with no gap and no overlap.
+    Identical to :func:`natural_bounds` except that period 0 of a monthly
+    schedule is clipped to the day the schedule actually starts. Consecutive
+    periods tile with no gap and no overlap.
     """
-    begin = period_start(schedule_start, cadence, index)
-    nxt = period_start(schedule_start, cadence, index + 1)
-    return begin, nxt - _dt.timedelta(days=1)
+    begin, finish = natural_bounds(schedule_start, cadence, index)
+    # Only monthly period 0 can open before the schedule does.
+    return max(begin, schedule_start), finish
+
+
+def period_start(schedule_start: _dt.date, cadence: str, index: int) -> _dt.date:
+    """First billed day of period ``index`` (0-based)."""
+    return period_bounds(schedule_start, cadence, index)[0]
 
 
 def period_index_for(
@@ -69,25 +99,14 @@ def period_index_for(
 ) -> int | None:
     """Index of the period containing ``on``, or ``None`` if before the start.
 
-    Walks forward for monthly (calendar months vary in length, so there is no
-    closed form that clamping preserves) and divides for the fixed-length
-    cadences.
+    Monthly periods are calendar months, so the index is just the month
+    distance — no clamping correction, unlike anniversary-day tiling.
     """
     if on < schedule_start:
         return None
     if cadence != "monthly":
-        span = RENT_CADENCE_DAYS[cadence]
-        return (on - schedule_start).days // span
-
-    # Month-count estimate, then correct by at most one step in either
-    # direction — day-clamping can put the true period one off the estimate.
-    guess = (on.year - schedule_start.year) * 12 + (on.month - schedule_start.month)
-    guess = max(0, guess)
-    while guess > 0 and period_start(schedule_start, cadence, guess) > on:
-        guess -= 1
-    while period_start(schedule_start, cadence, guess + 1) <= on:
-        guess += 1
-    return guess
+        return (on - schedule_start).days // RENT_CADENCE_DAYS[cadence]
+    return (on.year - schedule_start.year) * 12 + (on.month - schedule_start.month)
 
 
 def periods_through(
@@ -128,18 +147,19 @@ def prorated_amount(
     cadence: str,
     index: int,
 ) -> Decimal:
-    """``full_amount`` scaled to a period truncated by the schedule's end date.
+    """``full_amount`` scaled to the days actually billed in this period.
 
-    Returns ``full_amount`` unchanged for whole periods. For a truncated tail,
-    scales by ``actual_days / full_days`` and rounds half-up to the cent.
+    Returns ``full_amount`` unchanged for a whole period. A period short at
+    either end — a mid-month move-in, a mid-month move-out, or both inside one
+    month — is scaled by ``billed_days / whole_days`` and rounded half-up to
+    the cent.
     """
-    _, natural_finish = period_bounds(schedule_start, cadence, index)
-    if period_finish >= natural_finish:
-        return full_amount.quantize(_CENTS, rounding=ROUND_HALF_UP)
-
-    full_days = (natural_finish - period_begin).days + 1
-    actual_days = (period_finish - period_begin).days + 1
-    if full_days <= 0 or actual_days <= 0:
+    natural_begin, natural_finish = natural_bounds(schedule_start, cadence, index)
+    whole_days = (natural_finish - natural_begin).days + 1
+    billed_days = (period_finish - period_begin).days + 1
+    if whole_days <= 0 or billed_days <= 0:
         return Decimal("0.00")
-    scaled = full_amount * Decimal(actual_days) / Decimal(full_days)
+    if billed_days >= whole_days:
+        return full_amount.quantize(_CENTS, rounding=ROUND_HALF_UP)
+    scaled = full_amount * Decimal(billed_days) / Decimal(whole_days)
     return scaled.quantize(_CENTS, rounding=ROUND_HALF_UP)

--- a/apps/mybookkeeper/backend/tests/test_rent_ledger_service.py
+++ b/apps/mybookkeeper/backend/tests/test_rent_ledger_service.py
@@ -201,6 +201,80 @@ class TestChargeGeneration:
 
 
     @pytest.mark.asyncio
+    async def test_mid_month_move_in_prorates_only_the_first_period(
+        self, db: AsyncSession,
+    ) -> None:
+        """A tenant who moves in Aug 15 owes 17 of August's 31 days, then full months."""
+        applicant_id = await _make_tenant(db)
+        await _create_monthly_schedule(
+            db, applicant_id, start=_dt.date(2026, 8, 15),
+        )
+
+        ledger_patch, _ = _patch_uow(db)
+        with ledger_patch:
+            await rent_ledger_service.ensure_charges_generated(
+                db, organization_id=ORG, applicant_id=applicant_id,
+                through=_dt.date(2026, 10, 5),
+            )
+
+        rows = (
+            await db.execute(
+                select(RentCharge)
+                .where(RentCharge.applicant_id == applicant_id)
+                .order_by(RentCharge.period_start),
+            )
+        ).scalars().all()
+
+        assert [(r.period_start, r.period_end, r.amount) for r in rows] == [
+            (_dt.date(2026, 8, 15), _dt.date(2026, 8, 31), Decimal("822.58")),
+            (_dt.date(2026, 9, 1), _dt.date(2026, 9, 30), Decimal("1500.00")),
+            (_dt.date(2026, 10, 1), _dt.date(2026, 10, 31), Decimal("1500.00")),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_mid_month_period_is_labelled_as_a_range_not_a_month(
+        self, db: AsyncSession,
+    ) -> None:
+        """"August 2026" against $822.58 would read as a shortfall, not a part-month."""
+        applicant_id = await _make_tenant(db)
+        await _create_monthly_schedule(
+            db, applicant_id, start=_dt.date(2026, 8, 15),
+        )
+
+        ledger_patch, _ = _patch_uow(db)
+        with ledger_patch:
+            ledger = await rent_ledger_service.get_ledger(
+                organization_id=ORG, user_id=USER,
+                applicant_id=applicant_id, as_of=_dt.date(2026, 8, 20),
+            )
+
+        assert ledger.current_period is not None
+        assert ledger.current_period.label == "Aug 15 – Aug 31, 2026"
+        assert ledger.current_period.amount == Decimal("822.58")
+        # The undivided amount rides along so the UI can explain the shortfall.
+        august = next(c for c in ledger.charges if c.amount == Decimal("822.58"))
+        assert august.full_amount == Decimal("1500.00")
+
+    @pytest.mark.asyncio
+    async def test_whole_periods_carry_no_full_amount(
+        self, db: AsyncSession,
+    ) -> None:
+        """Only a prorated charge needs explaining; a full month speaks for itself."""
+        applicant_id = await _make_tenant(db)
+        await _create_monthly_schedule(
+            db, applicant_id, start=_dt.date(2026, 8, 1),
+        )
+
+        ledger_patch, _ = _patch_uow(db)
+        with ledger_patch:
+            ledger = await rent_ledger_service.get_ledger(
+                organization_id=ORG, user_id=USER,
+                applicant_id=applicant_id, as_of=_dt.date(2026, 8, 20),
+            )
+
+        assert [c.full_amount for c in ledger.charges] == [None]
+
+    @pytest.mark.asyncio
     async def test_shortening_a_tenancy_retires_future_charges(
         self, db: AsyncSession,
     ) -> None:

--- a/apps/mybookkeeper/backend/tests/test_rent_period_math.py
+++ b/apps/mybookkeeper/backend/tests/test_rent_period_math.py
@@ -1,7 +1,8 @@
 """Unit tests for rent period arithmetic.
 
 Pure functions — no database, no clock. These cover the tiling rules the whole
-ledger rests on: month-end clamping, period lookup, and end-date proration.
+ledger rests on: calendar-month alignment, period lookup, and proration at
+either end of a schedule.
 """
 from __future__ import annotations
 
@@ -13,31 +14,25 @@ import pytest
 from app.services.rent import rent_period_math as m
 
 
-class TestAddMonths:
-    def test_advances_whole_months(self) -> None:
-        assert m.add_months(_dt.date(2026, 1, 15), 1) == _dt.date(2026, 2, 15)
-        assert m.add_months(_dt.date(2026, 1, 15), 12) == _dt.date(2027, 1, 15)
+class TestMonthHelpers:
+    def test_month_first_advances_whole_months(self) -> None:
+        assert m.month_first(_dt.date(2026, 1, 15), 0) == _dt.date(2026, 1, 1)
+        assert m.month_first(_dt.date(2026, 1, 15), 1) == _dt.date(2026, 2, 1)
+        assert m.month_first(_dt.date(2026, 1, 15), 12) == _dt.date(2027, 1, 1)
 
-    def test_clamps_to_short_month(self) -> None:
-        assert m.add_months(_dt.date(2026, 1, 31), 1) == _dt.date(2026, 2, 28)
+    def test_month_first_ignores_the_day_of_month(self) -> None:
+        """The 1st of next month is the 1st regardless of where you started.
 
-    def test_clamping_does_not_drift(self) -> None:
-        """A Jan-31 start must return to the 31st, not stay on the 28th.
-
-        Every step is computed from the original start, so the clamp applies
-        per-step rather than compounding.
+        This is what removes the day-clamping drift that anniversary-day
+        tiling needed: there is no day to clamp.
         """
-        start = _dt.date(2026, 1, 31)
-        assert [m.add_months(start, i) for i in range(5)] == [
-            _dt.date(2026, 1, 31),
-            _dt.date(2026, 2, 28),
-            _dt.date(2026, 3, 31),
-            _dt.date(2026, 4, 30),
-            _dt.date(2026, 5, 31),
-        ]
+        assert m.month_first(_dt.date(2026, 1, 31), 1) == _dt.date(2026, 2, 1)
+        assert m.month_first(_dt.date(2026, 1, 1), 1) == _dt.date(2026, 2, 1)
 
-    def test_leap_year_february(self) -> None:
-        assert m.add_months(_dt.date(2028, 1, 31), 1) == _dt.date(2028, 2, 29)
+    def test_month_last_handles_short_and_leap_months(self) -> None:
+        assert m.month_last(_dt.date(2026, 2, 10)) == _dt.date(2026, 2, 28)
+        assert m.month_last(_dt.date(2028, 2, 10)) == _dt.date(2028, 2, 29)
+        assert m.month_last(_dt.date(2026, 4, 1)) == _dt.date(2026, 4, 30)
 
 
 class TestPeriodBounds:
@@ -47,9 +42,29 @@ class TestPeriodBounds:
         next_begin, _ = m.period_bounds(_dt.date(2026, 1, 1), "monthly", 8)
         assert next_begin == end + _dt.timedelta(days=1)
 
-    def test_mid_month_start_bills_mid_month_to_mid_month(self) -> None:
-        begin, end = m.period_bounds(_dt.date(2026, 8, 15), "monthly", 0)
-        assert (begin, end) == (_dt.date(2026, 8, 15), _dt.date(2026, 9, 14))
+    def test_mid_month_start_bills_to_the_end_of_that_month(self) -> None:
+        """A mid-month move-in is a short first period, not a shifted one."""
+        assert m.period_bounds(_dt.date(2026, 8, 15), "monthly", 0) == (
+            _dt.date(2026, 8, 15), _dt.date(2026, 8, 31),
+        )
+
+    def test_period_after_a_mid_month_start_is_a_whole_calendar_month(self) -> None:
+        assert m.period_bounds(_dt.date(2026, 8, 15), "monthly", 1) == (
+            _dt.date(2026, 9, 1), _dt.date(2026, 9, 30),
+        )
+
+    def test_month_end_start_bills_a_single_day_then_whole_months(self) -> None:
+        start = _dt.date(2026, 1, 31)
+        assert m.period_bounds(start, "monthly", 0) == (start, _dt.date(2026, 1, 31))
+        assert m.period_bounds(start, "monthly", 1) == (
+            _dt.date(2026, 2, 1), _dt.date(2026, 2, 28),
+        )
+
+    def test_natural_bounds_is_the_whole_month_even_for_a_clipped_period(self) -> None:
+        """The proration denominator is the month, not the billed span."""
+        assert m.natural_bounds(_dt.date(2026, 8, 15), "monthly", 0) == (
+            _dt.date(2026, 8, 1), _dt.date(2026, 8, 31),
+        )
 
     def test_weekly_period_is_seven_days(self) -> None:
         begin, end = m.period_bounds(_dt.date(2026, 8, 3), "weekly", 2)
@@ -58,6 +73,12 @@ class TestPeriodBounds:
     def test_biweekly_period_is_fourteen_days(self) -> None:
         begin, end = m.period_bounds(_dt.date(2026, 8, 3), "biweekly", 1)
         assert (begin, end) == (_dt.date(2026, 8, 17), _dt.date(2026, 8, 30))
+
+    def test_weekly_ignores_calendar_months(self) -> None:
+        """A weekly obligation has no month boundary to align to."""
+        assert m.period_bounds(_dt.date(2026, 8, 26), "weekly", 0) == (
+            _dt.date(2026, 8, 26), _dt.date(2026, 9, 1),
+        )
 
     def test_rejects_unknown_cadence(self) -> None:
         with pytest.raises(ValueError, match="unknown cadence"):
@@ -78,12 +99,16 @@ class TestPeriodIndexFor:
     def test_finds_correct_month(self) -> None:
         assert m.period_index_for(_dt.date(2026, 1, 1), "monthly", _dt.date(2026, 8, 15)) == 7
 
-    def test_handles_clamped_month_boundaries(self) -> None:
-        """Jan-31 schedule: Feb 28 and Mar 30 both sit in period 1."""
+    def test_mid_month_start_keeps_the_rest_of_that_month_in_period_zero(self) -> None:
+        start = _dt.date(2026, 8, 15)
+        assert m.period_index_for(start, "monthly", _dt.date(2026, 8, 31)) == 0
+        assert m.period_index_for(start, "monthly", _dt.date(2026, 9, 1)) == 1
+
+    def test_month_end_start_rolls_over_on_the_first(self) -> None:
         start = _dt.date(2026, 1, 31)
+        assert m.period_index_for(start, "monthly", _dt.date(2026, 1, 31)) == 0
         assert m.period_index_for(start, "monthly", _dt.date(2026, 2, 28)) == 1
-        assert m.period_index_for(start, "monthly", _dt.date(2026, 3, 30)) == 1
-        assert m.period_index_for(start, "monthly", _dt.date(2026, 3, 31)) == 2
+        assert m.period_index_for(start, "monthly", _dt.date(2026, 3, 1)) == 2
 
     def test_weekly_divides(self) -> None:
         start = _dt.date(2026, 8, 3)
@@ -120,12 +145,44 @@ class TestPeriodsThrough:
         )
         assert [p[0] for p in periods] == [0, 1]
 
+    def test_mid_month_move_in_then_whole_months(self) -> None:
+        periods = m.periods_through(
+            _dt.date(2026, 8, 15), "monthly", _dt.date(2026, 10, 5),
+        )
+        assert [p[1:] for p in periods] == [
+            (_dt.date(2026, 8, 15), _dt.date(2026, 8, 31)),
+            (_dt.date(2026, 9, 1), _dt.date(2026, 9, 30)),
+            (_dt.date(2026, 10, 1), _dt.date(2026, 10, 31)),
+        ]
+
+    def test_move_in_and_out_inside_one_month_is_a_single_period(self) -> None:
+        periods = m.periods_through(
+            _dt.date(2026, 8, 15), "monthly", _dt.date(2026, 12, 31),
+            end_date=_dt.date(2026, 8, 20),
+        )
+        assert [p[1:] for p in periods] == [
+            (_dt.date(2026, 8, 15), _dt.date(2026, 8, 20)),
+        ]
+
 
 class TestProratedAmount:
     def test_whole_period_is_unchanged(self) -> None:
         assert m.prorated_amount(
             Decimal("1500.00"), _dt.date(2026, 8, 1), _dt.date(2026, 8, 31),
             _dt.date(2026, 6, 1), "monthly", 2,
+        ) == Decimal("1500.00")
+
+    def test_mid_month_move_in_is_scaled_by_days_lived(self) -> None:
+        """Aug 15 move-in: 17 of August's 31 days of a $1,500 month."""
+        assert m.prorated_amount(
+            Decimal("1500.00"), _dt.date(2026, 8, 15), _dt.date(2026, 8, 31),
+            _dt.date(2026, 8, 15), "monthly", 0,
+        ) == Decimal("822.58")
+
+    def test_the_month_after_a_prorated_move_in_is_full(self) -> None:
+        assert m.prorated_amount(
+            Decimal("1500.00"), _dt.date(2026, 9, 1), _dt.date(2026, 9, 30),
+            _dt.date(2026, 8, 15), "monthly", 1,
         ) == Decimal("1500.00")
 
     def test_truncated_tail_is_scaled_by_actual_days(self) -> None:
@@ -135,11 +192,37 @@ class TestProratedAmount:
             _dt.date(2026, 6, 1), "monthly", 2,
         ) == Decimal("725.81")
 
+    def test_short_at_both_ends_in_one_month(self) -> None:
+        """Moved in Aug 15 and out Aug 20: 6 days, billed once."""
+        assert m.prorated_amount(
+            Decimal("1500.00"), _dt.date(2026, 8, 15), _dt.date(2026, 8, 20),
+            _dt.date(2026, 8, 15), "monthly", 0,
+        ) == Decimal("290.32")
+
+    def test_denominator_is_the_month_not_a_fixed_thirty(self) -> None:
+        """February's shorter month makes each of its days worth more.
+
+        Deliberately unlike ``inquiry_rent_proration``'s 30-day convention:
+        that module prices a hypothetical stay, this one bills a real month.
+        """
+        february = m.prorated_amount(
+            Decimal("1400.00"), _dt.date(2026, 2, 15), _dt.date(2026, 2, 28),
+            _dt.date(2026, 2, 15), "monthly", 0,
+        )
+        assert february == Decimal("700.00")  # 14 of 28 days, exactly half
+
     def test_single_day_tail(self) -> None:
         assert m.prorated_amount(
             Decimal("1500.00"), _dt.date(2026, 8, 1), _dt.date(2026, 8, 1),
             _dt.date(2026, 6, 1), "monthly", 2,
         ) == Decimal("48.39")
+
+    def test_weekly_periods_are_never_prorated_by_the_calendar(self) -> None:
+        """A full week spanning a month boundary is still a full week."""
+        assert m.prorated_amount(
+            Decimal("375.00"), _dt.date(2026, 8, 26), _dt.date(2026, 9, 1),
+            _dt.date(2026, 8, 26), "weekly", 0,
+        ) == Decimal("375.00")
 
     def test_rounds_to_cents(self) -> None:
         result = m.prorated_amount(

--- a/apps/mybookkeeper/frontend/e2e/rent-ledger.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/rent-ledger.spec.ts
@@ -17,11 +17,19 @@ interface Ledger {
   charges: Array<{
     id: string;
     amount: string;
+    full_amount: string | null;
     allocated: string;
+    period_start: string;
+    period_end: string;
     status: string;
     waived_at: string | null;
   }>;
-  current_period: { allocated: string; amount: string; status: string } | null;
+  current_period: {
+    allocated: string;
+    amount: string;
+    full_amount: string | null;
+    status: string;
+  } | null;
   balance: string;
   total_paid: string;
 }
@@ -168,6 +176,53 @@ test.describe("Rent ledger", () => {
       const afterPeriod = await getLedger(api, applicantId, "2026-09-05");
       const august = afterPeriod.charges.find((c) => c.amount === "1500.00");
       expect(august?.status).toBe("overdue");
+    } finally {
+      await cleanUp(api, applicantId, transactionIds);
+    }
+  });
+
+  test("a mid-month move-in is prorated, then billed whole months", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    let applicantId = "";
+    let transactionIds: string[] = [];
+
+    try {
+      applicantId = await seedTenant(api, `E2E Rent Prorated ${runId}`);
+      transactionIds = await seedPayments(api, applicantId, ["2026-08-20"]);
+
+      await page.goto(`/applicants/${applicantId}`);
+      await expect(page.getByTestId("rent-ledger-section")).toBeVisible({
+        timeout: 15000,
+      });
+      await createSchedule(page, "2026-08-15");
+
+      // 17 of August's 31 days of $1,500 — and the page says why, so the
+      // short number cannot be mistaken for a shortfall.
+      await expect(page.getByTestId("rent-current-period")).toContainText(
+        "of $822.58",
+      );
+      await expect(page.getByTestId("rent-current-prorated")).toContainText(
+        "Prorated from $1,500.00",
+      );
+
+      const ledger = await getLedger(api, applicantId, "2026-09-20");
+      const [august, september] = ledger.charges;
+      expect([august.period_start, august.period_end]).toEqual([
+        "2026-08-15",
+        "2026-08-31",
+      ]);
+      expect(august.amount).toBe("822.58");
+      expect(august.full_amount).toBe("1500.00");
+      // The month after a prorated move-in is a whole calendar month.
+      expect([september.period_start, september.period_end]).toEqual([
+        "2026-09-01",
+        "2026-09-30",
+      ]);
+      expect(september.amount).toBe("1500.00");
+      expect(september.full_amount).toBeNull();
     } finally {
       await cleanUp(api, applicantId, transactionIds);
     }

--- a/apps/mybookkeeper/frontend/src/__tests__/RentChargeDialogs.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/RentChargeDialogs.test.tsx
@@ -29,6 +29,7 @@ const CHARGE: RentCharge = {
   period_end: "2026-08-31",
   due_date: "2026-08-01",
   amount: "1500.00",
+  full_amount: null,
   description: null,
   waived_at: null,
   waived_reason: null,

--- a/apps/mybookkeeper/frontend/src/__tests__/RentLedgerPanel.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/RentLedgerPanel.test.tsx
@@ -54,6 +54,7 @@ const SONU_LEDGER: RentLedgerResponse = {
       period_end: "2026-08-31",
       due_date: "2026-08-01",
       amount: "1500.00",
+      full_amount: null,
       description: null,
       waived_at: null,
       waived_reason: null,
@@ -78,6 +79,7 @@ const SONU_LEDGER: RentLedgerResponse = {
     period_start: "2026-08-01",
     period_end: "2026-08-31",
     amount: "1500.00",
+    full_amount: null,
     allocated: "1125.00",
     remaining: "375.00",
     status: "partial",
@@ -143,6 +145,66 @@ describe("RentLedgerPanel", () => {
     expect(screen.getByTestId("rent-current-remaining")).toHaveTextContent(
       "$375.00 still to come",
     );
+  });
+
+  it("explains a prorated first period instead of leaving it looking short", () => {
+    // A mid-month move-in owes 17 of August's 31 days. Without the note,
+    // $822.58 against a $1,500 schedule reads as a data error.
+    mockGetLedger.mockReturnValue({
+      data: {
+        ...SONU_LEDGER,
+        charges: [
+          { ...SONU_LEDGER.charges[0], amount: "822.58", full_amount: "1500.00" },
+        ],
+        current_period: {
+          ...SONU_LEDGER.current_period!,
+          amount: "822.58",
+          full_amount: "1500.00",
+        },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    });
+    renderPanel();
+    expect(screen.getByTestId("rent-current-prorated")).toHaveTextContent(
+      "Prorated from $1,500.00 for a partial month",
+    );
+  });
+
+  it("states a part-month's dates once, not twice", () => {
+    // The label for a part-month IS its date range, so appending the range
+    // again would read "Aug 15 – Aug 31, 2026 · Aug 15 – Aug 31".
+    mockGetLedger.mockReturnValue({
+      data: {
+        ...SONU_LEDGER,
+        current_period: {
+          ...SONU_LEDGER.current_period!,
+          label: "Aug 15 – Aug 31, 2026",
+          period_start: "2026-08-15",
+        },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    });
+    renderPanel();
+    const card = screen.getByTestId("rent-current-period");
+    expect(card).toHaveTextContent("Aug 15 – Aug 31, 2026");
+    expect(card.textContent).not.toContain("2026 · Aug 15");
+  });
+
+  it("adds the explicit dates to a whole month, where they say something new", () => {
+    renderPanel();
+    expect(screen.getByTestId("rent-current-period")).toHaveTextContent(
+      "August 2026 · Aug 1 – Aug 31",
+    );
+  });
+
+  it("leaves a whole period unannotated, since it needs no explaining", () => {
+    renderPanel();
+    expect(screen.queryByTestId("rent-current-prorated")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("rent-charge-prorated")).not.toBeInTheDocument();
   });
 
   it("reports a weekly payer mid-month as partly paid, not overdue", () => {

--- a/apps/mybookkeeper/frontend/src/__tests__/RentScheduleForm.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/RentScheduleForm.test.tsx
@@ -85,6 +85,23 @@ describe("RentScheduleForm", () => {
     expect(onSaved).toHaveBeenCalledOnce();
   });
 
+  it("warns that a mid-month monthly start will be prorated", () => {
+    renderForm(null);
+    expect(screen.getByTestId("rent-schedule-start-hint")).toHaveTextContent(
+      "Rent falls due on the 1st. Starting mid-month bills a prorated first period",
+    );
+  });
+
+  it("describes weekly periods as tiling from the start day, not the calendar", () => {
+    renderForm(null);
+    fireEvent.change(screen.getByTestId("rent-schedule-cadence"), {
+      target: { value: "weekly" },
+    });
+    expect(screen.getByTestId("rent-schedule-start-hint")).toHaveTextContent(
+      "Weeks are counted from this day",
+    );
+  });
+
   it("blocks submission until an amount and start date are entered", () => {
     renderForm(null);
     expect(screen.getByTestId("rent-schedule-save-button")).toBeDisabled();

--- a/apps/mybookkeeper/frontend/src/app/features/rent/RentBalanceLine.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/rent/RentBalanceLine.tsx
@@ -1,22 +1,10 @@
 import { formatCurrency } from "@/shared/utils/currency";
+import RentTotalsLine from "./RentTotalsLine";
 
 export interface RentBalanceLineProps {
   balance: string;
   totalCharged: string;
   totalPaid: string;
-}
-
-interface TotalsProps {
-  totalCharged: string;
-  totalPaid: string;
-}
-
-function Totals({ totalCharged, totalPaid }: TotalsProps) {
-  return (
-    <span className="text-xs text-muted-foreground tabular-nums">
-      {formatCurrency(totalPaid)} paid of {formatCurrency(totalCharged)} charged
-    </span>
-  );
 }
 
 /**
@@ -32,7 +20,9 @@ export default function RentBalanceLine({
   totalPaid,
 }: RentBalanceLineProps) {
   const owed = parseFloat(balance);
-  const totals = <Totals totalCharged={totalCharged} totalPaid={totalPaid} />;
+  const totals = (
+    <RentTotalsLine totalCharged={totalCharged} totalPaid={totalPaid} />
+  );
 
   if (Math.abs(owed) < 0.005) {
     return (

--- a/apps/mybookkeeper/frontend/src/app/features/rent/RentChargeRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/rent/RentChargeRow.tsx
@@ -6,6 +6,7 @@ import RentChargeStatusBadge from "./RentChargeStatusBadge";
 import RentChargeApplications from "./RentChargeApplications";
 import RentChargeRowActions from "./RentChargeRowActions";
 import { RENT_CHARGE_TYPE_LABEL } from "./rent-labels";
+import { proratedNote } from "./rent-prorated-note";
 import type { RentCharge } from "@/shared/types/rent/rent-charge";
 
 export interface RentChargeRowProps {
@@ -33,6 +34,7 @@ export default function RentChargeRow({
 }: RentChargeRowProps) {
   const [expanded, setExpanded] = useState(false);
   const Chevron = expanded ? ChevronDown : ChevronRight;
+  const prorated = proratedNote(charge.full_amount);
 
   return (
     <li className="py-2" data-testid="rent-charge-row">
@@ -65,6 +67,15 @@ export default function RentChargeRow({
           />
         ) : null}
       </div>
+
+      {prorated ? (
+        <p
+          className="text-xs text-muted-foreground pl-7 pt-1"
+          data-testid="rent-charge-prorated"
+        >
+          {prorated}
+        </p>
+      ) : null}
 
       {charge.waived_at && charge.waived_reason ? (
         <p className="text-xs text-muted-foreground italic pl-7 pt-1">

--- a/apps/mybookkeeper/frontend/src/app/features/rent/RentCurrentPeriodCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/rent/RentCurrentPeriodCard.tsx
@@ -1,7 +1,8 @@
 import { ProgressBar } from "@platform/ui";
 import { formatCurrency } from "@/shared/utils/currency";
-import { formatShortDate } from "@/shared/lib/inquiry-date-format";
 import RentChargeStatusBadge from "./RentChargeStatusBadge";
+import { proratedNote } from "./rent-prorated-note";
+import { periodDateRange } from "./rent-period-dates";
 import type { RentPeriodSummary } from "@/shared/types/rent/rent-period-summary";
 import type { ProgressTone } from "@platform/ui";
 
@@ -31,6 +32,8 @@ export default function RentCurrentPeriodCard({
   const allocated = parseFloat(period.allocated);
   const remaining = parseFloat(period.remaining);
   const percent = amount > 0 ? (allocated / amount) * 100 : 100;
+  const prorated = proratedNote(period.full_amount);
+  const dates = periodDateRange(period);
 
   return (
     <div
@@ -40,8 +43,8 @@ export default function RentCurrentPeriodCard({
       <div className="flex items-start justify-between gap-3 flex-wrap">
         <div>
           <p className="text-xs text-muted-foreground">
-            {period.label} · {formatShortDate(period.period_start)} –{" "}
-            {formatShortDate(period.period_end)}
+            {period.label}
+            {dates ? ` · ${dates}` : ""}
           </p>
           <p className="text-xl font-semibold tabular-nums mt-0.5">
             <span data-testid="rent-current-allocated">
@@ -64,6 +67,15 @@ export default function RentCurrentPeriodCard({
         tone={toneFor(period.status)}
         label={`${formatCurrency(allocated)} of ${formatCurrency(amount)} paid for ${period.label}`}
       />
+
+      {prorated ? (
+        <p
+          className="text-xs text-muted-foreground"
+          data-testid="rent-current-prorated"
+        >
+          {prorated}
+        </p>
+      ) : null}
 
       <p className="text-xs text-muted-foreground" data-testid="rent-current-remaining">
         {remaining > 0

--- a/apps/mybookkeeper/frontend/src/app/features/rent/RentScheduleForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/rent/RentScheduleForm.tsx
@@ -1,7 +1,7 @@
 import { Button, LoadingButton } from "@platform/ui";
 import Select from "@/shared/components/ui/Select";
 import { RENT_INPUT_CLASS } from "./rent-input-class";
-import { RENT_CADENCE_LABEL } from "./rent-labels";
+import { RENT_CADENCE_LABEL, RENT_START_HINT } from "./rent-labels";
 import RentScheduleFixedTerms from "./RentScheduleFixedTerms";
 import { useRentScheduleForm } from "./useRentScheduleForm";
 import type { RentCadence } from "@/shared/types/rent/rent-cadence";
@@ -108,9 +108,11 @@ export default function RentScheduleForm({
               data-testid="rent-schedule-start"
               required
             />
-            <p className="text-xs text-muted-foreground mt-1">
-              Periods are counted from this day, so a tenancy starting the 15th
-              is billed the 15th to the 14th.
+            <p
+              className="text-xs text-muted-foreground mt-1"
+              data-testid="rent-schedule-start-hint"
+            >
+              {RENT_START_HINT[form.cadence]}
             </p>
           </div>
         )}

--- a/apps/mybookkeeper/frontend/src/app/features/rent/RentTotalsLine.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/rent/RentTotalsLine.tsx
@@ -1,0 +1,23 @@
+import { formatCurrency } from "@/shared/utils/currency";
+
+export interface RentTotalsLineProps {
+  totalCharged: string;
+  totalPaid: string;
+}
+
+/**
+ * The two lifetime totals the balance is the difference of.
+ *
+ * Shown beside the balance so "owes $422.58" can be checked against the
+ * numbers it came from rather than taken on faith.
+ */
+export default function RentTotalsLine({
+  totalCharged,
+  totalPaid,
+}: RentTotalsLineProps) {
+  return (
+    <span className="text-xs text-muted-foreground tabular-nums">
+      {formatCurrency(totalPaid)} paid of {formatCurrency(totalCharged)} charged
+    </span>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/rent/rent-labels.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/rent/rent-labels.ts
@@ -24,3 +24,16 @@ export const RENT_MANUAL_CHARGE_TYPES: readonly RentChargeType[] = [
   "deposit",
   "other",
 ];
+
+/** What choosing a start date means for the first period, per cadence.
+ *
+ *  Monthly rent is billed on calendar months, so the start date only decides
+ *  how much of the first month is owed. The other cadences tile from the start
+ *  date itself, where there is no calendar boundary to align to. */
+export const RENT_START_HINT: Record<RentCadence, string> = {
+  monthly:
+    "Rent falls due on the 1st. Starting mid-month bills a prorated first period covering only those days.",
+  weekly: "Weeks are counted from this day — a Friday start bills Friday to Thursday.",
+  biweekly:
+    "Fortnights are counted from this day — a Friday start bills Friday to the Thursday two weeks on.",
+};

--- a/apps/mybookkeeper/frontend/src/app/features/rent/rent-period-dates.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/rent/rent-period-dates.ts
@@ -1,0 +1,17 @@
+import { formatShortDate } from "@/shared/lib/inquiry-date-format";
+import type { RentPeriodSummary } from "@/shared/types/rent/rent-period-summary";
+
+/**
+ * The period's explicit dates, or null when the label already states them.
+ *
+ * A whole calendar month is labelled "August 2026", and appending "Aug 1 – Aug
+ * 31" tells the host something. A part-month is labelled with its range
+ * already, so appending it again reads as "Aug 15 – Aug 31, 2026 · Aug 15 –
+ * Aug 31" — the same dates twice. The label leads with the start date exactly
+ * when it is a range, which is what distinguishes the two.
+ */
+export function periodDateRange(period: RentPeriodSummary): string | null {
+  const start = formatShortDate(period.period_start);
+  if (period.label.startsWith(start)) return null;
+  return `${start} – ${formatShortDate(period.period_end)}`;
+}

--- a/apps/mybookkeeper/frontend/src/app/features/rent/rent-prorated-note.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/rent/rent-prorated-note.ts
@@ -1,0 +1,14 @@
+import { formatCurrency } from "@/shared/utils/currency";
+
+/**
+ * Why this period costs less than the schedule says.
+ *
+ * A tenant who moves in on the 15th owes half a month, and the charge shows
+ * $822.58 against a $1,500 schedule. Without saying so, that reads as a bug or
+ * a shortfall; the backend sends the undivided amount precisely so the number
+ * can explain itself. Returns null for a whole period, which needs no note.
+ */
+export function proratedNote(fullAmount: string | null): string | null {
+  if (!fullAmount) return null;
+  return `Prorated from ${formatCurrency(fullAmount)} for a partial month`;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/rent/rent-charge.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/rent/rent-charge.ts
@@ -11,6 +11,9 @@ export interface RentCharge {
   period_end: string;
   due_date: string;
   amount: string;
+  /** The schedule's undivided amount when this period was prorated for a
+   *  part-month tenancy; null for a whole period or a one-off charge. */
+  full_amount: string | null;
   description: string | null;
   waived_at: string | null;
   waived_reason: string | null;

--- a/apps/mybookkeeper/frontend/src/shared/types/rent/rent-period-summary.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/rent/rent-period-summary.ts
@@ -7,6 +7,8 @@ export interface RentPeriodSummary {
   period_start: string;
   period_end: string;
   amount: string;
+  /** Set only when `amount` is a prorated slice of a part-month tenancy. */
+  full_amount: string | null;
   allocated: string;
   remaining: string;
   status: RentChargeStatus;


### PR DESCRIPTION
## Why

Monthly rent schedules tiled from the schedule's **start day**, so a tenant who moved in on Aug 15 was billed `Aug 15 – Sep 14` for a full $1,500. That is not how rent is collected — rent falls due on the 1st, and a mid-month move-in owes only the days lived. Anniversary-day tiling also needed day-clamping to survive short months and drifted for a schedule starting on the 31st.

Follows #1141 (the rent ledger itself), which prorated the **move-out** end correctly but designed the move-in case away.

## What changed

Monthly periods are now **calendar months**:

- `natural_bounds(...)` — the whole month a period occupies (the proration denominator)
- `period_bounds(...)` — the same, with period 0 clipped to the schedule's start date

Proration is `billed_days / whole_days`, so a period short at the front (move-in), at the back (`end_date`), or at **both** ends inside one month is a single computation rather than three branches:

| Period | Amount |
|---|---|
| Aug 15 – Aug 31 | **$822.58** (17 of August's 31 days) |
| Sep 1 – Sep 30 | $1,500.00 |
| Oct 1 – Oct 31 | $1,500.00 |

Actual days, not the fixed 30 `inquiry_rent_proration` uses — that module prices a *hypothetical* stay, where a fixed denominator keeps two equal-length stays priced equally; this one bills a real month someone lived in. A dedicated test pins the divergence so a future reader doesn't "unify" them.

**Weekly and biweekly are untouched** — they tile from `start_date` and have no calendar boundary to align to. A schedule starting on the 1st produces exactly the periods and amounts it did before.

## Surfacing it

A prorated charge would otherwise read as a shortfall, so the API sends `full_amount` — the undivided schedule amount — on any charge that was scaled, and `null` when it wasn't. The rule stays server-side; the UI only renders it:

- "Prorated from $1,500.00 for a partial month" on the current-period card and the charge row
- The schedule form warns before you save a mid-month start
- `periodDateRange` suppresses the duplicate range that made the header read `Aug 15 – Aug 31, 2026 · Aug 15 – Aug 31` (a part-month label already *is* the range)

## Also here

`Totals` was a second component living inside `RentBalanceLine.tsx` — split out to `RentTotalsLine.tsx`, no behaviour change.

## Verification

Run against **real** Postgres, MinIO and FastAPI, not mocks:

- **7/7 E2E green**, including a new "a mid-month move-in is prorated, then billed whole months" test asserting both the rendered amounts and the stored charge rows (`amount = 822.58`, `full_amount = 1500.00`, then `1500.00` / `null`)
- 66 backend + 42 frontend unit tests pass; `tsc -b` and eslint clean
- Eyeballed the rendered panel — which is what caught the duplicated-date-range defect above

No migration: `full_amount` is derived on read from the schedule, not stored.